### PR TITLE
[feat] reactive modifiers

### DIFF
--- a/plugins/flags.ts
+++ b/plugins/flags.ts
@@ -3,6 +3,7 @@ export type Flags = {
   RUN_EVENT_DESTRUCTORS_FOR_SCOPED_NODES: boolean;
   TRY_CATCH_ERROR_HANDLING: boolean;
   SUPPORT_SHADOW_DOM: boolean;
+  REACTIVE_MODIFIERS: boolean;
 };
 
 export function defaultFlags() {
@@ -11,5 +12,6 @@ export function defaultFlags() {
     RUN_EVENT_DESTRUCTORS_FOR_SCOPED_NODES: false,
     TRY_CATCH_ERROR_HANDLING: true,
     SUPPORT_SHADOW_DOM: true,
+    REACTIVE_MODIFIERS: true,
   } as Flags;
 }

--- a/src/tests/integration/modifier-test.gts
+++ b/src/tests/integration/modifier-test.gts
@@ -4,6 +4,27 @@ import { cell } from '@lifeart/gxt';
 import { rerender } from '@lifeart/gxt/test-utils';
 
 module('Integration | Internal | modifier', function () {
+  test('modifiers may be reactive', async function (assert) {
+    assert.expect(5);
+    const value = cell(3);
+    let removeCount = 0;
+    const modifier = (element: HTMLDivElement, v: number) => {
+      assert.equal(v, value.value, 'modifier rendered with correct value');
+      return () => {
+        removeCount++;
+        assert.ok(removeCount, 'modifier destructor is running');
+      };
+    };
+    await render(
+      <template>
+        <div {{modifier value.value}}></div>
+      </template>,
+    );
+    value.update(value.value - 1);
+    await allSettled();
+    value.update(value.value - 1);
+    await allSettled();
+  });
   test('modifiers executed during component creation, before it appears in DOM', async function (assert) {
     assert.expect(1);
     const modifier = (element: HTMLDivElement) => {

--- a/src/tests/integration/modifier-test.gts
+++ b/src/tests/integration/modifier-test.gts
@@ -4,27 +4,30 @@ import { cell } from '@lifeart/gxt';
 import { rerender } from '@lifeart/gxt/test-utils';
 
 module('Integration | Internal | modifier', function () {
-  test('modifiers may be reactive', async function (assert) {
-    assert.expect(5);
-    const value = cell(3);
-    let removeCount = 0;
-    const modifier = (element: HTMLDivElement, v: number) => {
-      assert.equal(v, value.value, 'modifier rendered with correct value');
-      return () => {
-        removeCount++;
-        assert.ok(removeCount, 'modifier destructor is running');
+  if (REACTIVE_MODIFIERS) {
+    test('modifiers may be reactive', async function (assert) {
+      assert.expect(5);
+      const value = cell(3);
+      let removeCount = 0;
+      const modifier = (element: HTMLDivElement, v: number) => {
+        assert.equal(v, value.value, 'modifier rendered with correct value');
+        return () => {
+          removeCount++;
+          assert.ok(removeCount, 'modifier destructor is running');
+        };
       };
-    };
-    await render(
-      <template>
-        <div {{modifier value.value}}></div>
-      </template>,
-    );
-    value.update(value.value - 1);
-    await allSettled();
-    value.update(value.value - 1);
-    await allSettled();
-  });
+      await render(
+        <template>
+          <div {{modifier value.value}}></div>
+        </template>,
+      );
+      value.update(value.value - 1);
+      await rerender();
+      value.update(value.value - 1);
+      await rerender();
+    });
+  }
+
   test('modifiers executed during component creation, before it appears in DOM', async function (assert) {
     assert.expect(1);
     const modifier = (element: HTMLDivElement) => {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -248,32 +248,39 @@ function $ev(
     }
     // modifier case
   } else if (eventName === EVENT_TYPE.ON_CREATED) {
-    let destructor = () => void 0;
-    const updatingCell = formula(() => {
-      destructor();
-      return (fn as ModifierFn)(element);
-    }, `${element.tagName}.modifier`);
-    const opcodeDestructor = opcodeFor(updatingCell, (dest: any) => {
-      if (isFn(dest)) {
-        destructor = dest as any;
-      }
-    });
-    if (updatingCell.isConst) {
-      updatingCell.destroy();
-      opcodeDestructor();
-      destructors.push(() => {
-        return destructor();
+    if (REACTIVE_MODIFIERS) {
+      let destructor = () => void 0;
+      const updatingCell = formula(() => {
+        destructor();
+        return (fn as ModifierFn)(element);
+      }, `${element.tagName}.modifier`);
+      const opcodeDestructor = opcodeFor(updatingCell, (dest: any) => {
+        if (isFn(dest)) {
+          destructor = dest as any;
+        }
       });
-    } else {
-      destructors.push(
-        opcodeDestructor,
-        () => {
-          updatingCell.destroy();
-        },
-        () => {
+      if (updatingCell.isConst) {
+        updatingCell.destroy();
+        opcodeDestructor();
+        destructors.push(() => {
           return destructor();
-        },
-      );
+        });
+      } else {
+        destructors.push(
+          opcodeDestructor,
+          () => {
+            updatingCell.destroy();
+          },
+          () => {
+            return destructor();
+          },
+        );
+      }
+    } else {
+      const destructor = (fn as ModifierFn)(element);
+      if (isFn(destructor)) {
+        destructors.push(destructor);
+      }
     }
   } else {
     // event case (on modifier)

--- a/src/utils/list.ts
+++ b/src/utils/list.ts
@@ -268,7 +268,7 @@ class BasicListComponent<T extends { id: number }> {
       const trueParent = bottomMarker.parentNode!;
       // parent may not exist in rehydration
       if (!import.meta.env.SSR) {
-        parent && parent.removeChild(targetNode)
+        parent && parent.removeChild(targetNode);
       }
       if (trueParent !== parent) {
         api.insert(trueParent, parent, bottomMarker);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ declare global {
   const RUN_EVENT_DESTRUCTORS_FOR_SCOPED_NODES: boolean;
   const TRY_CATCH_ERROR_HANDLING: boolean;
   const SUPPORT_SHADOW_DOM: boolean;
+  const REACTIVE_MODIFIERS: boolean;
 }
 
 declare module 'glint-environment-gxt/globals' {


### PR DESCRIPTION
In scope of this PR we adding auto-update functionality to modifiers if some of it's inputs are reactive

### 1
<img width="792" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/fbe8eb9e-c3ba-4323-8153-2940a4d7c878">


### 2
<img width="803" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/b401e964-0908-48ab-a8ae-19f62f6495bb">
