### PR TITLE
[perf experiment] - skip related tags removal

### DIFF
--- a/src/utils/reactive.ts
+++ b/src/utils/reactive.ts
@@ -164,7 +164,6 @@ export class MergedCell {
     return this.value;
   }
   _debugName?: string | undefined;
-  relatedCells: Set<Cell> | null = null;
   [isTag] = true;
   constructor(fn: Fn | Function, debugName?: string) {
     this.fn = fn;
@@ -176,12 +175,6 @@ export class MergedCell {
   destroy() {
     this.isDestroyed = true;
     opsForTag.delete(this);
-    if (this.relatedCells !== null) {
-      this.relatedCells.forEach((cell) => {
-        relatedTags.get(cell)?.delete(this);
-      });
-      this.relatedCells.clear();
-    }
     if (IS_DEV_MODE) {
       DEBUG_MERGED_CELLS.delete(this);
     }
@@ -201,7 +194,6 @@ export class MergedCell {
     } finally {
       bindAllCellsToTag(currentTracker!, this);
       this.isConst = currentTracker!.size === 0;
-      this.relatedCells = currentTracker;
       currentTracker = null;
     }
   }


### PR DESCRIPTION
Here we trading memory size to destructors performance.
Related cell will be cleaned-up in next render anyway.
But, likely we need to schedule extra run to do single cleanup instead per-subtag.

<img width="797" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/d07252a6-4371-4ec7-b93d-86f03c36cbc3">

Looks like on large numbers we slower because of GC