### PR TITLE
[feature] render-error-overlays

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -531,6 +531,9 @@ function component(
   try {
     return _component(comp, args, fw, ctx);
   } catch (e) {
+    if (import.meta.env.SSR) {
+      throw e;
+    }
     if (IS_DEV_MODE) {
       let ErrorOverlayClass = customElements.get('vite-error-overlay');
       let errorOverlay!: Element;
@@ -551,6 +554,7 @@ function component(
       } else {
         errorOverlay = new ErrorOverlayClass(e, true);
       }
+      console.error(label, e);
 
       return {
         ctx: null,

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -521,8 +521,56 @@ if (!import.meta.env.SSR) {
     };
   }
 }
-// hello, basic component manager
 function component(
+  comp: ComponentReturnType | Component,
+  args: Record<string, unknown>,
+  fw: FwType,
+  ctx: Component<any>,
+  // slots: false | Record<string, () => Array<ComponentReturnType | NodeReturnType>> = false,
+) {
+  try {
+    return _component(comp, args, fw, ctx);
+  } catch (e) {
+    if (IS_DEV_MODE) {
+      let ErrorOverlayClass = customElements.get('vite-error-overlay');
+      let errorOverlay!: Element;
+      let label = `<${
+        // @ts-expect-error debugName may not exist
+        comp.debugName || comp.name || comp.constructor.name
+      } ${JSON.stringify(args)} />`;
+      // @ts-expect-error message may not exit
+      e.message = `${label}\n${e.message}`;
+      if (!ErrorOverlayClass) {
+        errorOverlay = api.element('pre');
+        // @ts-expect-error stack may not exit
+        errorOverlay.textContent = `${label}\n${e.stack ?? e}`;
+        errorOverlay.setAttribute(
+          'style',
+          'color:red;border:1px solid red;padding:10px;background-color:#333;',
+        );
+      } else {
+        errorOverlay = new ErrorOverlayClass(e, true);
+      }
+
+      return {
+        ctx: null,
+        slots: {},
+        index: 0,
+        nodes: [errorOverlay],
+      };
+    } else {
+      return {
+        ctx: null,
+        slots: {},
+        index: 0,
+        // @ts-expect-error message may not exit
+        nodes: [api.text(String(e.message))],
+      };
+    }
+  }
+}
+// hello, basic component manager
+function _component(
   comp: ComponentReturnType | Component,
   args: Record<string, unknown>,
   fw: FwType,


### PR DESCRIPTION
If some component rendering fails, we show error

### Vite
<img width="1340" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/71a6d385-3ffb-4f80-8a8d-5761f4c4f54d">

### Dev mode
<img width="1334" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/18e4f472-902c-4977-b6a8-bb01ddf2e6af">

### Prod
<img width="1325" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/7ecbd2ea-cceb-454c-a255-63738bfa0ea1">


Related links: https://github.com/vitejs/vite/issues/2076

<img width="812" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/4e18cfd2-d103-4ed7-8235-72b956f7bf19">
