### PR TITLE
[perf] remove node return type and index

### DIFF
--- a/plugins/converter.test.ts
+++ b/plugins/converter.test.ts
@@ -141,7 +141,7 @@ describe.each([
     describe('basic element helper support', () => {
       test('it return kinda valid component-like code', () => {
         expect($t<ASTv1.BlockStatement>(`{{(element "tag")}}`)).toEqual(
-          `$:() => $:function(args,props){const $slots = $_GET_SLOTS(this, arguments);return{[$nodes]:[$_tag("tag",[props[$propsProp],props[$attrsProp],props[$eventsProp]],[()=>$_slot('default',()=>[],$slots)], this)[$node]],[$slotsProp]:$slots,index:0, ctx: this};}`,
+          `$:() => $:function(args,props){const $slots = $_GET_SLOTS(this, arguments);return{[$nodes]:[$_tag("tag",[props[$propsProp],props[$attrsProp],props[$eventsProp]],[()=>$_slot('default',()=>[],$slots)], this)],[$slotsProp]:$slots, ctx: this};}`,
         );
       });
     });

--- a/plugins/converter.ts
+++ b/plugins/converter.ts
@@ -112,9 +112,9 @@ export function convert(seenNodes: Set<ASTv1.Node>, flags: Flags) {
           SYMBOLS.$attrsProp
         }],props[${SYMBOLS.$eventsProp}]],[()=>${
           SYMBOLS.SLOT
-        }('default',()=>[],$slots)], this)[${SYMBOLS.$node}]],[${
+        }('default',()=>[],$slots)], this)],[${
           SYMBOLS.$slotsProp
-        }]:$slots,index:0, ctx: this};}`;
+        }]:$slots, ctx: this};}`;
       } else if (node.path.original === SYMBOLS.$__hash) {
         const hashArgs: [string, PrimitiveJSType][] = node.hash.pairs.map(
           (pair) => {

--- a/plugins/symbols.ts
+++ b/plugins/symbols.ts
@@ -16,7 +16,6 @@ export const SYMBOLS = {
   $template: '$template',
   $_hasBlockParams: '$_hasBlockParams',
   $_hasBlock: '$_hasBlock',
-  $node: '$node',
   $nodes: '$nodes',
   $args: '$args',
   $slotsProp: '$slotsProp',

--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -10,7 +10,6 @@ import {
   isFn,
   $template,
   $nodes,
-  $node,
   $args,
   $fwProp,
   RENDER_TREE,
@@ -27,8 +26,8 @@ export type ComponentRenderTarget =
 
 export type GenericReturnType =
   | ComponentReturnType
-  | NodeReturnType
-  | Array<ComponentReturnType | NodeReturnType>
+  | Node
+  | Array<ComponentReturnType | Node>
   | null
   | null[];
 
@@ -58,8 +57,6 @@ export function renderElement(
     if (isPrimitive(el)) {
       // @ts-expect-error
       renderNode(target, api.text(el), placeholder);
-    } else if ($node in el) {
-      renderNode(target, el[$node], placeholder);
     } else if ($nodes in el) {
       el[$nodes].forEach((node) => {
         renderElement(target, node, placeholder);
@@ -183,8 +180,8 @@ function destroyNode(node: Node) {
 export function destroyElementSync(
   component:
     | ComponentReturnType
-    | NodeReturnType
-    | Array<ComponentReturnType | NodeReturnType>
+    | Node
+    | Array<ComponentReturnType | Node>
     | null
     | null[],
 ) {
@@ -208,18 +205,16 @@ export function destroyElementSync(
         );
       }
     } else {
-      destroyNode(component[$node]);
+      destroyNode(component);
     }
   }
 }
 
-function internalDestroyNode(el: Node | ComponentReturnType | NodeReturnType) {
+function internalDestroyNode(el: Node | ComponentReturnType) {
   if ('nodeType' in el) {
     destroyNode(el);
-  } else if ($nodes in el) {
-    destroyNodes(el[$nodes]);
   } else {
-    destroyNode(el[$node]);
+    destroyNodes(el[$nodes]);
   }
 }
 
@@ -227,8 +222,7 @@ function destroyNodes(
   roots:
     | Node
     | ComponentReturnType
-    | NodeReturnType
-    | Array<Node | ComponentReturnType | NodeReturnType>,
+    | Array<Node | ComponentReturnType>,
 ) {
   if (Array.isArray(roots)) {
     for (let i = 0; i < roots.length; i++) {
@@ -242,8 +236,8 @@ function destroyNodes(
 export async function destroyElement(
   component:
     | ComponentReturnType
-    | NodeReturnType
-    | Array<ComponentReturnType | NodeReturnType>
+    | Node
+    | Array<ComponentReturnType | Node>
     | null
     | null[],
 ) {
@@ -268,7 +262,7 @@ export async function destroyElement(
         );
       }
     } else {
-      await destroyNode(component[$node]);
+      await destroyNode(component);
     }
   }
 }
@@ -375,18 +369,14 @@ export type Slots = Record<
   string,
   (
     ...params: unknown[]
-  ) => Array<ComponentReturnType | NodeReturnType | Comment | string | number>
+  ) => Array<ComponentReturnType | Node | Comment | string | number>
 >;
 export type ComponentReturnType = {
   nodes: Node[];
-  index: number;
   ctx: Component<any> | null;
   slots: Slots;
 };
-export type NodeReturnType = {
-  node: Node;
-  index: number;
-};
+
 const noop = () => {};
 
 export function addEventListener(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,7 +19,6 @@ export * from '@/utils/dom';
 export * from '@/utils/helpers/index';
 export {
   $template,
-  $node,
   $nodes,
   $args,
   $fwProp,

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -11,7 +11,6 @@ export const $nodes = 'nodes' as const;
 export const $args = 'args' as const;
 export const $_debug_args = '_debug_args' as const;
 export const $fwProp = '$fw' as const;
-export const $node = 'node' as const;
 export const $slotsProp = 'slots' as const;
 export const $propsProp = 'props' as const;
 export const $attrsProp = 'attrs' as const;

--- a/src/utils/template.test.ts
+++ b/src/utils/template.test.ts
@@ -8,7 +8,6 @@ describe('template package', () => {
       expect(hbs`123`).toEqual({
         [$nodes]: [],
         [$slotsProp]: {},
-        index: 0,
         ctx: null,
         tpl: ['123'],
       });

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -4,7 +4,6 @@ export function hbs(tpl: TemplateStringsArray) {
   return {
     [$nodes]: [],
     [$slotsProp]: {},
-    index: 0,
     ctx: null,
     tpl,
   };


### PR DESCRIPTION
In general, `NodeReturn` type not needed, because primitive types may be produced during rendering.
Once we removed `NodReturnType` we could skip `index` generation in components and use it only in lists with extra set

<img width="793" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/fe478764-eb12-4810-aa40-a30cbec20c86">
