### PR TITLE
[experiment] on attr support

### DIFF
--- a/plugins/converter.ts
+++ b/plugins/converter.ts
@@ -428,7 +428,92 @@ export function convert(
     return false;
   }
 
+  const eventprops = [
+    // Window Event Attributes
+    'onafterprint',
+    'onbeforeprint',
+    'onbeforeunload',
+    'onerror',
+    'onhashchange',
+    'onload',
+    'onmessage',
+    'onoffline',
+    'ononline',
+    'onpagehide',
+    'onpageshow',
+    'onpopstate',
+    'onresize',
+    'onstorage',
+    'onunload',
+    // Form Events
+    'onblur',
+    'onchange',
+    'oncontextmenu',
+    'onfocus',
+    'oninput',
+    'oninvalid',
+    'onreset',
+    'onsearch',
+    'onselect',
+    'onsubmit',
+    // keyboard
+    'onkeydown',
+    'onkeypress',
+    'onkeyup',
+    // Mouse Events
+    'onclick',
+    'ondblclick',
+    'onmousedown',
+    'onmousemove',
+    'onmouseout',
+    'onmouseover',
+    'onmouseup',
+    'onmousewheel',
+    'onwheel',
+    // Drag Events
+    'ondrag',
+    'ondragend',
+    'ondragenter',
+    'ondragleave',
+    'ondragover',
+    'ondragstart',
+    'ondrop',
+    'onscroll',
+    // Clipboard Events
+    'oncopy',
+    'oncut',
+    'onpaste',
+    // Media Events
+    'onabort',
+    'oncanplay',
+    'oncanplaythrough',
+    'oncuechange',
+    'ondurationchange',
+    'onemptied',
+    'onended',
+    'onerror',
+    'onloadeddata',
+    'onloadedmetadata',
+    'onloadstart',
+    'onpause',
+    'onplay',
+    'onplaying',
+    'onprogress',
+    'onratechange',
+    'onseeked',
+    'onseeking',
+    'onstalled',
+    'onsuspend',
+    'ontimeupdate',
+    'onvolumechange',
+    'onwaiting',
+    // Misc Events
+
+    'ontoggle',
+  ];
+
   const propertyKeys = [
+    ...eventprops,
     'class',
     'shadowrootmode',
     // boolean attributes (https://meiert.com/en/blog/boolean-attributes-of-html/)

--- a/src/components/pages/benchmark/Row.gts
+++ b/src/components/pages/benchmark/Row.gts
@@ -89,14 +89,14 @@ export class Row extends Component<RowArgs> {
       <td class='px-6 py-4' class={{this.className}}>
         <a
           class='cursor-pointer'
-          {{on 'click' this.onClick}}
+          onclick={{this.onClick}}
           data-no-router
           data-test-select
         >{{this.labelCell}}</a>
       </td>
       <td class='px-6 py-4' class={{this.className}}>
         <a
-          {{on 'click' this.onClickRemove}}
+          onclick={{this.onClickRemove}}
           data-no-router
           data-test-remove
           class='cursor-pointer mr-1 rounded bg-indigo-600 px-2 py-1 text-xs font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -145,7 +145,10 @@ function $prop(
   value: unknown,
   destructors: DestructorFn[],
 ) {
-  if (isFn(value)) {
+  if (key.startsWith('on')) {
+    // @ts-expect-error
+    element[key] = value();
+  } else if (isFn(value)) {
     $prop(
       element,
       key,


### PR DESCRIPTION

<img width="837" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/5149f0df-ee75-48bc-9166-41b94c361176">


Todo: 

- [ ] figure out proper flag for it (use it in events array, but follow prop flow)
- [ ] may it be just modifier? `$attrEvent('name', fn)` 
- [ ] fix compiler to auto-convert simple `{{on "click" this.foo}}` to `onclick={{this.foo}}` 
criteria: 
- there is only one `click` modifier on dom node
- dom node don't have `...attributes`
- dom node is not component


Resolves: https://github.com/lifeart/glimmer-next/issues/103