### PR TITLE
experiment [on with removeEventListener]

### DIFF
--- a/plugins/flags.ts
+++ b/plugins/flags.ts
@@ -11,7 +11,7 @@ export type Flags = {
 export function defaultFlags() {
   return {
     IS_GLIMMER_COMPAT_MODE: true,
-    RUN_EVENT_DESTRUCTORS_FOR_SCOPED_NODES: false,
+    RUN_EVENT_DESTRUCTORS_FOR_SCOPED_NODES: true,
     TRY_CATCH_ERROR_HANDLING: true,
     SUPPORT_SHADOW_DOM: true,
     REACTIVE_MODIFIERS: true,


### PR DESCRIPTION
<img width="842" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/54b56583-bf95-4000-8382-e52b43ce78fb">

```
clearManyItems1End phase estimated regression +42ms [39ms to 45ms] OR +9.64% [8.97% to 10.27%]
clearManyItems2End phase estimated regression +54ms [51ms to 59ms] OR +13.04% [12.28% to 14.12%]
```