### PR TITLE
🚨 [experiment] Attempt a monotonic revision based signals polyfill

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -5,8 +5,9 @@ on:
   push:
     branches:
       - master
+      - check-signals
   pull_request:
-    branches: [master]
+    branches: [master, check-signals]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/signal-polyfill.ts
+++ b/src/signal-polyfill.ts
@@ -1,0 +1,207 @@
+type Revision = number;
+
+interface Signal<T> {
+  get(): T;
+}
+
+const $WATCHED = Symbol('watched');
+const $UNWATCHED = Symbol('unwatched');
+const $REVISION = Symbol('revision');
+const $WATCHER_NOTIFY = Symbol('watcher notify');
+
+const WATCHERS = new Set<Watcher>();
+
+let CONSUME_TAGS: boolean = true;
+let CURRENT_REVISION: Revision = 0;
+let CURRENT_COMPUTATION: Set<Tag> | null = null;
+let CURRENT_COMPUTED: Computed | null = null;
+
+class Tag {
+  [$REVISION]: Revision = CURRENT_REVISION;
+}
+
+function dirtyTag(tag: Tag): void {
+  if (CURRENT_COMPUTATION?.has(tag))
+    throw new Error('cannot dirty tag that has been used during a computation');
+  tag[$REVISION] = ++CURRENT_REVISION;
+  notifyWatchers();
+}
+
+function consumeTag(tag: Tag): void {
+  if (CONSUME_TAGS) CURRENT_COMPUTATION?.add(tag);
+}
+
+function notifyWatchers(): void {
+  for (let watcher of WATCHERS) watcher[$WATCHER_NOTIFY]();
+}
+
+function getMax(tags: Tag[]): Revision {
+  return Math.max(...tags.map((t) => t[$REVISION]));
+}
+
+class State<T> implements Signal<T> {
+  private tag = new Tag();
+  private equals = (a: T, b: T): boolean => a === b;
+  private [$WATCHED] = (): void => {};
+  private [$UNWATCHED] = (): void => {};
+
+  constructor(private value: T, options: SignalOptions<T> = {}) {
+    this.equals = options.equals ?? this.equals;
+    this[$WATCHED] = options[$WATCHED] ?? this[$WATCHED];
+    this[$UNWATCHED] = options[$UNWATCHED] ?? this[$UNWATCHED];
+  }
+
+  get(): T {
+    consumeTag(this.tag);
+    return this.value;
+  }
+
+  set(value: T): void {
+    if (this.equals(this.value, value)) return;
+    this.value = value;
+    dirtyTag(this.tag);
+  }
+}
+
+class Computed<T = unknown> implements Signal<T> {
+  private lastTags: Tag[] | undefined;
+  private lastRevision: Revision | undefined;
+  private declare lastValue: T;
+  private equals = (a: T, b: T): boolean => a === b;
+  private [$WATCHED] = (): void => {};
+  private [$UNWATCHED] = (): void => {};
+
+  constructor(private cb: (this: Computed<T>) => T, options: SignalOptions<T> = {}) {
+    this.equals = options.equals ?? this.equals;
+    this[$WATCHED] = options[$WATCHED] ?? this[$WATCHED];
+    this[$UNWATCHED] = options[$UNWATCHED] ?? this[$UNWATCHED];
+  }
+
+  get(): T {
+    if (this.lastTags && getMax(this.lastTags) === this.lastRevision) {
+      if (CURRENT_COMPUTATION && this.lastTags.length > 0)
+        for (let tag of this.lastTags) CURRENT_COMPUTATION.add(tag);
+      return this.lastValue;
+    }
+
+    let previousComputation = CURRENT_COMPUTATION;
+
+    try {
+      this.lastValue = this.cb.call(this);
+    } finally {
+      let tags = Array.from(CURRENT_COMPUTATION ?? []);
+      this.lastTags = tags;
+      this.lastRevision = getMax(tags);
+
+      if (previousComputation && tags.length > 0)
+        for (let tag of tags) previousComputation.add(tag);
+
+      CURRENT_COMPUTATION = previousComputation;
+      CURRENT_COMPUTED = null;
+    }
+
+    return this.lastValue;
+  }
+}
+
+// This namespace includes "advanced" features that are better to
+// leave for framework authors rather than application developers.
+// Analogous to `crypto.subtle`
+function untrack<T>(cb: () => T): T {
+  try {
+    CONSUME_TAGS = false;
+    return cb();
+  } finally {
+    CONSUME_TAGS = true;
+  }
+}
+
+// Get the current computed signal which is tracking any signal reads, if any
+function currentComputed(): Computed | null {
+  return CURRENT_COMPUTED;
+}
+
+// Returns ordered list of all signals which this one referenced
+// during the last time it was evaluated.
+// For a Watcher, lists the set of signals which it is watching.
+// function introspectSources(s: Computed | Watcher): (State | Computed)[];
+
+// Returns the Watchers that this signal is contained in, plus any
+// Computed signals which read this signal last time they were evaluated,
+// if that computed signal is (recursively) watched.
+// function introspectSinks(s: State | Computed): (Computed | Watcher)[];
+
+// True if this signal is "live", in that it is watched by a Watcher,
+// or it is read by a Computed signal which is (recursively) live.
+// function hasSinks(s: State | Computed): boolean;
+
+// True if this element is "reactive", in that it depends
+// on some other signal. A Computed where hasSources is false
+// will always return the same constant.
+// function hasSources(s: Computed | Watcher): boolean;
+
+class Watcher {
+  private signals = new Set<Signal<unknown>>();
+
+  // When a (recursive) source of Watcher is written to, call this callback,
+  // if it hasn't already been called since the last `watch` call.
+  // No signals may be read or written during the notify.
+  constructor(readonly notify: (this: Watcher) => void) {}
+
+  // Add these signals to the Watcher's set, and set the watcher to run its
+  // notify callback next time any signal in the set (or one of its dependencies) changes.
+  // Can be called with no arguments just to reset the "notified" state, so that
+  // the notify callback will be invoked again.
+  watch(...signals: Signal<unknown>[]): void {
+    for (let signal of signals) {
+      this.signals.add(signal);
+    }
+    if (this.signals.size > 0) WATCHERS.add(this);
+  }
+
+  // Remove these signals from the watched set (e.g., for an effect which is disposed)
+  unwatch(...signals: Signal<unknown>[]): void {
+    for (let signal of signals) {
+      this.signals.delete(signal);
+    }
+    if (this.signals.size === 0) WATCHERS.delete(this);
+  }
+
+  // Returns the set of sources in the Watcher's set which are still dirty, or is a computed signal
+  // with a source which is dirty or pending and hasn't yet been re-evaluated
+  getPending(): Signal<unknown>[] {
+    return Array.from(this.signals);
+  }
+
+  [$WATCHER_NOTIFY](): void {
+    this.notify();
+  }
+}
+
+// Hooks to observe being watched or no longer watched
+const watched = $WATCHED;
+const unwatched = $UNWATCHED;
+
+export const Signal = {
+  State,
+  Computed,
+  subtle: {
+    Watcher,
+    currentComputed,
+    untrack,
+    watched,
+    unwatched,
+  },
+};
+
+interface SignalOptions<T> {
+  // Custom comparison function between old and new value. Default: Object.is.
+  // The signal is passed in as the this value for context.
+  equals?: (this: Signal<T>, t: T, t2: T) => boolean;
+
+  // Callback called when isWatched becomes true, if it was previously false
+  [$WATCHED]?: (this: Signal<T>) => void;
+
+  // Callback called whenever isWatched becomes false, if it was previously true
+  [$UNWATCHED]?: (this: Signal<T>) => void;
+}

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -517,7 +517,6 @@ export function $_inElement(
       } else if (isTagLike(elementRef)) {
         appendRef = elementRef.value;
       } else {
-        // @ts-expect-error
         appendRef = elementRef;
       }
       const destructors: Destructors = [];

--- a/src/utils/glimmer-validator.ts
+++ b/src/utils/glimmer-validator.ts
@@ -41,7 +41,6 @@ export function trackedData<T extends object, K extends keyof T>(
   let hasInitializer = typeof initializer === 'function';
 
   function getter(self: T) {
-    // @ts-expect-error
     consumeTag(cellFor(self, key));
 
     let value;

--- a/src/utils/if.ts
+++ b/src/utils/if.ts
@@ -83,7 +83,6 @@ export function ifCondition(
       }
     },
     runExistingDestructors,
-    // @ts-expect-error
     opcodeFor(cell, (value) => {
       if (throwedError) {
         Promise.resolve().then(() => {

--- a/src/utils/list.ts
+++ b/src/utils/list.ts
@@ -110,7 +110,6 @@ export class BasicListComponent<T extends { id: number }> {
     if (!isTagLike(tag)) {
       if (isArray(tag)) {
         console.warn('iterator for @each should be a cell');
-        // @ts-expect-error
         tag = new Cell(tag, 'list tag');
       } else if (isFn(originalTag)) {
         tag = formula(() => deepFnValue(originalTag), 'list tag');
@@ -298,7 +297,6 @@ export class SyncListComponent<
   constructor(params: ListComponentArgs<T>, outlet: RenderTarget) {
     super(params, outlet);
     associateDestroyable(params.ctx, [
-      // @ts-expect-error
       opcodeFor(this.tag, (value) => {
         this.syncList(value as T[]);
       }),
@@ -333,7 +331,6 @@ export class AsyncListComponent<
   constructor(params: ListComponentArgs<any>, outlet: RenderTarget) {
     super(params, outlet);
     associateDestroyable(params.ctx, [
-      // @ts-expect-error
       opcodeFor(this.tag, async (value) => {
         await this.syncList(value as T[]);
       }),

--- a/src/utils/reactive.ts
+++ b/src/utils/reactive.ts
@@ -4,7 +4,7 @@
   We explicitly update DOM only when it's needed and only if tags are changed.
 */
 import { isFn, isTag, isTagLike, debugContext } from '@/utils/shared';
-import { Signal } from "signal-polyfill";
+import { Signal } from "../signal-polyfill";
 
 
 export const asyncOpcodes = new WeakSet<tagOp>();

--- a/src/utils/reactive.ts
+++ b/src/utils/reactive.ts
@@ -104,7 +104,7 @@ export function setIsRendering(value: boolean) {
 
 // "data" cell, it's value can be updated, and it's used to create derived cells
 export class Cell<T extends unknown = unknown> {
-  _value!: Signal.State<T>;
+  _value!: any;
   declare toHTML: () => string;
   [Symbol.toPrimitive]() {
     return this.value;
@@ -115,7 +115,6 @@ export class Cell<T extends unknown = unknown> {
     this._value = new Signal.State(value);
     if (IS_DEV_MODE) {
       this._debugName = debugContext(debugName);
-      // @ts-expect-error
       DEBUG_CELLS.add(this);
     }
   }
@@ -202,7 +201,6 @@ export function cellFor<T extends object, K extends keyof T>(
     obj[key],
     `${obj.constructor.name}.${String(key)}`,
   );
-  // @ts-expect-error
   refs.set(key, cellValue);
   cellsMap.set(obj, refs);
   Object.defineProperty(obj, key, {

--- a/src/utils/signals.ts
+++ b/src/utils/signals.ts
@@ -1,4 +1,4 @@
-import { Signal } from "signal-polyfill";
+import { Signal } from "../signal-polyfill";
 import { isRehydrationScheduled } from "./rehydration";
 import { setIsRendering } from "./reactive";
 

--- a/src/utils/vm.ts
+++ b/src/utils/vm.ts
@@ -8,7 +8,7 @@ import {
   inNewTrackingFrame,
 } from './reactive';
 import { isFn } from './shared';
-import { Signal } from "signal-polyfill";
+import { Signal } from "../signal-polyfill";
 
 import { w } from './signals';
 type maybeDestructor = undefined | (() => void);


### PR DESCRIPTION
Prior to this change, we used the current signals polyfill which had some performance troubles.

This change implements the signals API but uses Pzurek's monotonic revision to handle tracking and reactivity.

This is an attempt to see if it shows performance improvements.

Paired-with: NullVoxPopulli

re-wind of https://github.com/lifeart/glimmer-next/pull/145

<img width="661" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/032ef188-9c22-4a2a-a543-f233e432e42f">
