### PR TITLE
[feat] add execution order

### DIFF
--- a/src/utils/reactive.ts
+++ b/src/utils/reactive.ts
@@ -170,11 +170,13 @@ function bindAllCellsToTag(cells: Set<Cell>, tag: MergedCell) {
 }
 
 // "derived" cell, it's value is calculated from other cells, and it's value can't be updated
+let tagId = 0;
 export class MergedCell {
   fn: Fn | Function;
   declare toHTML: () => string;
   isConst: boolean = false;
   isDestroyed = false;
+  id = tagId++;
   [Symbol.toPrimitive]() {
     return this.value;
   }

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -49,9 +49,14 @@ export async function syncDom() {
     }
   }
   tagsToRevalidate.clear();
-  for (const tag of sharedTags) {
+  // sort shared tags by id
+  const sharedTagsArray = Array.from(sharedTags);
+  sharedTags.clear();
+  // sort tags in order of creation to avoid stale logic
+  sharedTagsArray.sort((a, b) => a.id - b.id);
+  for (const tag of sharedTagsArray) {
+    debugger;
     await executeTag(tag);
   }
-  sharedTags.clear();
   setIsRendering(false);
 }

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -55,7 +55,6 @@ export async function syncDom() {
   // sort tags in order of creation to avoid stale logic
   sharedTagsArray.sort((a, b) => a.id - b.id);
   for (const tag of sharedTagsArray) {
-    debugger;
     await executeTag(tag);
   }
   setIsRendering(false);


### PR DESCRIPTION
Here we ensure opcodes will be executed from top to bottom (in creation order).
It eliminate cases where item has updated props and for example - removed.

```hbs
{{#if this.selectedItem}}
   {{this.selectedItem.name}}
{{/if}}
```

```js
// here all works by default
const item = this.selectedItem;
this.selectedItem = null;
item.name = ''
```

```js
// here fails, because we scheduling name opcode update before if
const item = this.selectedItem;
item.name = ''
this.selectedItem = null;
```

This PR fixes this behaviour.

During initial render, we have created 'if' opcode first, and 'updateName' opcode.
We may introduce opcode index (tag index) and sort tags before opcode evaluation.
Since we have opcode per tag - we are good.
---
<img width="854" alt="image" src="https://github.com/lifeart/glimmer-next/assets/1360552/f00c0de8-8c3a-44a7-91b6-a057e616152d">

