### PR TITLE
[experiment] fast list cleanup

### DIFF
--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -233,6 +233,9 @@ export function destroyElementSync(
         );
       }
     } else {
+      if (skipDom) {
+        return;
+      }
       destroyNode(component);
     }
   }
@@ -265,9 +268,10 @@ export async function destroyElement(
     | Array<ComponentReturnType | Node>
     | null
     | null[],
+  skipDom = false,
 ) {
   if (isArray(component)) {
-    await Promise.all(component.map((component) => destroyElement(component)));
+    await Promise.all(component.map((component) => destroyElement(component, skipDom)));
   } else {
     if (component === null) {
       return;
@@ -278,6 +282,9 @@ export async function destroyElement(
         runDestructors(component.ctx, destructors);
         await Promise.all(destructors);
       }
+      if (skipDom) {
+        return;
+      }
       try {
         destroyNodes(component[$nodes]);
       } catch (e) {
@@ -287,6 +294,9 @@ export async function destroyElement(
         );
       }
     } else {
+      if (skipDom) {
+        return;
+      }
       await destroyNode(component);
     }
   }

--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -208,9 +208,10 @@ export function destroyElementSync(
     | Array<ComponentReturnType | Node>
     | null
     | null[],
+  skipDom = false
 ) {
   if (isArray(component)) {
-    component.forEach((component) => destroyElementSync(component));
+    component.forEach((component) => destroyElementSync(component, skipDom));
   } else {
     if (isEmpty(component)) {
       return;
@@ -219,6 +220,9 @@ export function destroyElementSync(
     if ($nodes in component) {
       if (component.ctx !== null) {
         runDestructorsSync(component.ctx);
+      }
+      if (skipDom) {
+        return;
       }
       try {
         destroyNodes(component[$nodes]);

--- a/src/utils/control-flow/list.ts
+++ b/src/utils/control-flow/list.ts
@@ -331,6 +331,19 @@ export class SyncListComponent<
     ]);
   }
   syncList(items: T[]) {
+    if (items.length === 0) {
+      const parent = this.bottomMarker.parentElement;
+      if (parent && parent.lastChild === this.bottomMarker) {
+        parent.innerHTML = '';
+        parent.append(this.bottomMarker);
+        this.keyMap.forEach((value) => {
+          destroyElementSync(value, true);
+        })
+        this.keyMap.clear();
+        this.indexMap.clear();
+        return;
+      } 
+    }
     const { keyMap, indexMap, keyForItem } = this;
     const existingKeys = Array.from(keyMap.keys());
     const updatingKeys = new Set(items.map((item, i) => keyForItem(item, i)));
@@ -365,6 +378,19 @@ export class AsyncListComponent<
     ]);
   }
   async syncList(items: T[]) {
+    if (items.length === 0) {
+      const parent = this.bottomMarker.parentElement;
+      if (parent && parent.lastChild === this.bottomMarker) {
+        parent.innerHTML = '';
+        parent.append(this.bottomMarker);
+        this.keyMap.forEach((value) => {
+          destroyElementSync(value, true);
+        })
+        this.keyMap.clear();
+        this.indexMap.clear();
+        return;
+      } 
+    }
     const { keyMap, indexMap, keyForItem } = this;
     const existingKeys = Array.from(keyMap.keys());
     const updatingKeys = new Set(items.map((item, i) => keyForItem(item, i)));

--- a/src/utils/control-flow/list.ts
+++ b/src/utils/control-flow/list.ts
@@ -64,6 +64,7 @@ export class BasicListComponent<T extends { id: number }> {
     ctx: Component<any>,
   ) => GenericReturnType;
   bottomMarker!: Comment;
+  topMarker!: Comment;
   key: string = '@identity';
   tag!: Cell<T[]> | MergedCell;
   isSync = false;
@@ -74,6 +75,7 @@ export class BasicListComponent<T extends { id: number }> {
   constructor(
     { tag, ctx, key, ItemComponent }: ListComponentArgs<T>,
     outlet: RenderTarget,
+    topMarker: Comment,
   ) {
     this.ItemComponent = ItemComponent;
     this.parentCtx = ctx;
@@ -105,7 +107,9 @@ export class BasicListComponent<T extends { id: number }> {
     } else {
       this.bottomMarker = api.comment();
     }
+    this.topMarker = topMarker;
 
+    api.append(mainNode, this.topMarker);
     api.append(mainNode, this.bottomMarker);
 
     const originalTag = tag;
@@ -322,8 +326,8 @@ export class BasicListComponent<T extends { id: number }> {
 export class SyncListComponent<
   T extends { id: number },
 > extends BasicListComponent<T> {
-  constructor(params: ListComponentArgs<T>, outlet: RenderTarget) {
-    super(params, outlet);
+  constructor(params: ListComponentArgs<T>, outlet: RenderTarget, topMarker: Comment) {
+    super(params, outlet, topMarker);
     associateDestroyable(params.ctx, [
       opcodeFor(this.tag, (value) => {
         this.syncList(value as T[]);
@@ -333,12 +337,13 @@ export class SyncListComponent<
   syncList(items: T[]) {
     if (items.length === 0) {
       const parent = this.bottomMarker.parentElement;
-      if (parent && parent.lastChild === this.bottomMarker) {
-        parent.innerHTML = '';
-        parent.append(this.bottomMarker);
+      if (parent && parent.lastChild === this.bottomMarker && parent.firstChild === this.topMarker) {
         this.keyMap.forEach((value) => {
           destroyElementSync(value, true);
-        })
+        });
+        parent.innerHTML = '';
+        parent.append(this.topMarker);
+        parent.append(this.bottomMarker);
         this.keyMap.clear();
         this.indexMap.clear();
         return;
@@ -369,8 +374,8 @@ export class SyncListComponent<
 export class AsyncListComponent<
   T extends { id: number },
 > extends BasicListComponent<T> {
-  constructor(params: ListComponentArgs<any>, outlet: RenderTarget) {
-    super(params, outlet);
+  constructor(params: ListComponentArgs<any>, outlet: RenderTarget, topMarker: Comment) {
+    super(params, outlet, topMarker);
     associateDestroyable(params.ctx, [
       opcodeFor(this.tag, async (value) => {
         await this.syncList(value as T[]);
@@ -380,12 +385,18 @@ export class AsyncListComponent<
   async syncList(items: T[]) {
     if (items.length === 0) {
       const parent = this.bottomMarker.parentElement;
-      if (parent && parent.lastChild === this.bottomMarker) {
-        parent.innerHTML = '';
-        parent.append(this.bottomMarker);
+      if (parent && parent.lastChild === this.bottomMarker && parent.firstChild === this.topMarker) {
+        const promises = new Array(this.keyMap.size);
+        let i = 0;
         this.keyMap.forEach((value) => {
-          destroyElementSync(value, true);
-        })
+          promises[i] = destroyElement(value, true);
+          i++;
+        });
+        await Promise.all(promises);
+        promises.length = 0;
+        parent.innerHTML = '';
+        parent.append(this.topMarker);
+        parent.append(this.bottomMarker);
         this.keyMap.clear();
         this.indexMap.clear();
         return;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1055,7 +1055,7 @@ export function $_eachSync<T extends { id: number }>(
   key: string | null = null,
   ctx: Component<any>,
 ) {
-  const { outlet } = getRenderTargets('sync-each-placeholder');
+  const { outlet, placeholder } = getRenderTargets('sync-each-placeholder');
   const instance = new SyncListComponent(
     {
       tag: items as Cell<T[]>,
@@ -1064,6 +1064,7 @@ export function $_eachSync<T extends { id: number }>(
       key,
     },
     outlet,
+    placeholder,
   );
   addToTree(ctx, instance as unknown as Component<any>);
   return toNodeReturnType(outlet, instance);
@@ -1074,7 +1075,7 @@ export function $_each<T extends { id: number }>(
   key: string | null = null,
   ctx: Component<any>,
 ) {
-  const { outlet } = getRenderTargets('async-each-placeholder');
+  const { outlet, placeholder } = getRenderTargets('async-each-placeholder');
   const instance = new AsyncListComponent(
     {
       tag: items as Cell<T[]>,
@@ -1083,6 +1084,7 @@ export function $_each<T extends { id: number }>(
       ctx,
     },
     outlet,
+    placeholder,
   );
   addToTree(ctx, instance as unknown as Component<any>);
   return toNodeReturnType(outlet, instance);


### PR DESCRIPTION
In scope of this experiment we trying to optimize cleanup logic inside list for this case:

- we need to remove all elements in list
- list rendered inside "PARENT NODE"
- "PARENT NODE" node contain only list-related nodes

If all this conditions is met, we may run destructors on elements without actual DOM removal, and use `parent.innerHTML` to destroy nodes in one batch.
