### PR TITLE
Remove fallback DOM API setup and lookup in _DOM function

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -378,10 +378,13 @@ function $ev(
   } else if (eventName === EVENT_TYPE.ON_CREATED) {
     if (REACTIVE_MODIFIERS) {
       let destructor = () => void 0;
-      const updatingCell = formula(() => {
-        destructor();
-        return (fn as ModifierFn)(element);
-      }, `${element.tagName}.modifier`);
+      const updatingCell = formula(
+        () => {
+          destructor();
+          return (fn as ModifierFn)(element);
+        },
+        `${element.tagName}.modifier`,
+      );
       const opcodeDestructor = opcodeFor(updatingCell, (dest: any) => {
         if (isFn(dest)) {
           destructor = dest as any;
@@ -512,14 +515,7 @@ function _DOM(
   if (tag === 'svg') {
     provideContext(ctx, RENDERING_CONTEXT, svgDomApi);
   }
-  let oldAPI = api;
   api = getContext<typeof HTMLAPI>(ctx, RENDERING_CONTEXT)!;
-  if (!api) {
-    api = getContext<typeof HTMLAPI>(ctx, RENDERING_CONTEXT)!;
-  }
-  if (!api) {
-    api = oldAPI;
-  }
   const element = api.element(tag);
   if (IS_DEV_MODE) {
     $DEBUG_REACTIVE_CONTEXTS.push(`${tag}`);


### PR DESCRIPTION
Remove fallback mechanism for setting up and looking up the DOM API in `_DOM` function.

* Remove the fallback mechanism involving `oldAPI` and ensure `api` is correctly set without fallback logic.
* Update the `_DOM` function to use the `api` variable directly.
* Reformat the `updatingCell` formula for better readability.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lifeart/glimmer-next/pull/180?shareId=9a2cda6a-685b-488d-9aca-a0f75e1166f3).