### PR TITLE
Add missing usage tests to context API tests

### DIFF
--- a/src/tests/integration/context-test.gts
+++ b/src/tests/integration/context-test.gts
@@ -302,4 +302,108 @@ module('Integration | Context API', function () {
       .dom('[data-test-button]')
       .hasClass('bg-red-500', 'Button receives updated theme');
   });
+
+  test('context usage in nested components', async function (assert) {
+    class NestedComponent extends Component {
+      <template>
+        <div class={{this.theme.buttonClass}} ...attributes>
+          {{yield}}
+        </div>
+      </template>
+      @context(ThemeContext) theme = {
+        buttonClass: '',
+      };
+    }
+
+    await render(
+      <template>
+        <ThemeProvider @theme={{hash buttonClass='bg-blue-500'}}>
+          <NestedComponent data-test-nested-component>
+            Nested Content
+          </NestedComponent>
+        </ThemeProvider>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-nested-component]')
+      .hasClass('bg-blue-500', 'Nested component receives theme from context');
+  });
+
+  test('context usage in yield', async function (assert) {
+    class YieldComponent extends Component {
+      <template>{{yield}}</template>
+    }
+
+    await render(
+      <template>
+        <IntlProvider @intl={{hash name='Fake'}}>
+          <YieldComponent>
+            <ThemedButton data-test-button as |intl|>{{intl.name}}</ThemedButton>
+          </YieldComponent>
+        </IntlProvider>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-button]')
+      .hasText('Fake', 'Button receives intl from root context');
+  });
+
+  test('context usage in in-element', async function (assert) {
+    let _node: HTMLDivElement;
+    function setNode(e: HTMLDivElement) {
+      _node = e;
+    }
+    function node() {
+      return _node;
+    }
+
+    await render(
+      <template>
+        <div id='foo' {{setNode}}></div>
+        <IntlProvider @intl={{hash name='Fake'}}>
+          {{#in-element node}}
+            <ThemedButton data-test-button as |intl|>{{intl.name}}</ThemedButton>
+          {{/in-element}}
+        </IntlProvider>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-button]')
+      .hasText('Fake', 'Button receives intl from root context');
+  });
+
+  test('context usage in each', async function (assert) {
+    await render(
+      <template>
+        <IntlProvider @intl={{hash name='Fake'}}>
+          {{#each (array 1) as |item|}}
+            <ThemedButton data-test-button as |intl|>{{intl.name}}</ThemedButton>{{item}}
+          {{/each}}
+        </IntlProvider>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-button]')
+      .hasText('Fake', 'Button receives intl from root context');
+  });
+
+  test('context usage in if conditions', async function (assert) {
+    await render(
+      <template>
+        <IntlProvider @intl={{hash name='Fake'}}>
+          {{#if true}}
+            <ThemedButton data-test-button as |intl|>{{intl.name}}</ThemedButton>
+          {{/if}}
+        </IntlProvider>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-button]')
+      .hasText('Fake', 'Button receives intl from root context');
+  });
 });


### PR DESCRIPTION
Add missing usage tests for context API in `src/tests/integration/context-test.gts`.

* Add test for context usage in nested components
* Add test for context usage in yield
* Add test for context usage in in-element
* Add test for context usage in each
* Add test for context usage in if conditions

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lifeart/glimmer-next/pull/183?shareId=fcbce558-77ce-48ec-9a00-d23ad5f62635).