### PR TITLE
feat: expose tracker accessors and bump 0.0.60 for ember integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lifeart/gxt",
   "private": false,
-  "version": "0.0.59",
+  "version": "0.0.60",
   "type": "module",
   "license": "MIT",
   "author": "Aleksandr Kanunnikov <lifeart92@gmail.com>",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,6 +8,8 @@ export {
   cell,
   cellFor,
   tracked,
+  getTracker,
+  setTracker,
   type Cell,
   type MergedCell,
   formula,


### PR DESCRIPTION
## Summary

- Re-export `getTracker` / `setTracker` from the public entry (`src/core/index.ts`) so downstream packages (notably the ember.js integration in [emberjs/ember.js#21340](https://github.com/emberjs/ember.js/pull/21340)) can read and swap the active tracker without reaching into internals.
- Bump version to `0.0.60` so a fresh tarball ships these symbols along with the existing `./runtime-compiler` and `./suspense` exports map entries (those were already on master but never published — last published version `0.0.59` predates them).

## Why

The ember.js PR statically imports `createRoot`, `setParentContext`, `getParentContext`, `provideContext`, `RENDERING_CONTEXT`, `RENDERED_NODES_PROPERTY`, `HTMLBrowserDOMApi`, `setTracker`, `getTracker` from `@lifeart/gxt`, plus the `./runtime-compiler` subpath. All of those except `getTracker`/`setTracker` were already exported on master but missing from the published `0.0.59` tarball; this commit closes the last gap and triggers a fresh publish.

## Verification

After `pnpm build-lib`:

```
$ grep -oE 'createRoot|setParentContext|getParentContext|provideContext|RENDERING_CONTEXT|RENDERED_NODES_PROPERTY|HTMLBrowserDOMApi|setTracker|getTracker' dist/gxt.index.es.js | sort -u
HTMLBrowserDOMApi
RENDERED_NODES_PROPERTY
RENDERING_CONTEXT
createRoot
getParentContext
getTracker
provideContext
setParentContext
setTracker
```

`package.json` `exports."./runtime-compiler"` and `exports."./suspense"` already point at the existing built artifacts (`dist/gxt.runtime-compiler.es.js`, `dist/gxt.suspense.es.js`) — both files are produced by the existing vite lib build entry list.

## Test plan

- [x] `pnpm build-lib` succeeds and produces `dist/gxt.index.es.js` containing all 9 required symbols
- [x] `dist/gxt.runtime-compiler.es.js` is built and reachable through the `./runtime-compiler` exports entry
- [ ] After publish: ember.js PR #21340 bumps `@lifeart/gxt` to `0.0.60` and re-runs CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)