### PR TITLE
compiler: AST-transform hook + dynamic-tag/serializer parity fixes

### DIFF
--- a/plugins/compiler/__tests__/codegen-parity.test.ts
+++ b/plugins/compiler/__tests__/codegen-parity.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'vitest';
+import { compile } from '../compile';
+
+const COMPAT = { flags: { IS_GLIMMER_COMPAT_MODE: true } } as const;
+const STANDALONE = { flags: { IS_GLIMMER_COMPAT_MODE: false } } as const;
+
+/**
+ * Extract the JS named-args object emitted inside a `$_componentHelper(...)` /
+ * `$_helperHelper(...)` call so two emissions can be compared byte-for-byte.
+ */
+function namedArgsOf(code: string, symbol: string): string {
+  const idx = code.indexOf(`${symbol}([`);
+  expect(idx, `expected ${symbol}(...) in: ${code}`).toBeGreaterThan(-1);
+  // Find the `], ` separating positional array from the named object, then the
+  // matching closing brace of the object.
+  const sep = code.indexOf('], ', idx);
+  const braceStart = code.indexOf('{', sep);
+  let depth = 0;
+  for (let i = braceStart; i < code.length; i++) {
+    if (code[i] === '{') depth++;
+    else if (code[i] === '}') {
+      depth--;
+      if (depth === 0) return code.slice(braceStart, i + 1);
+    }
+  }
+  throw new Error(`unbalanced named-args object in: ${code}`);
+}
+
+/** Extract the `globalThis.__gxtUnboundEval(...)` wrapper shape (id-normalized). */
+function unboundWrapperShape(code: string): string {
+  const m = code.match(/globalThis\.__gxtUnboundEval\(__ubCache,"__ub\d+",\(\)=>\(/);
+  expect(m, `expected unbound cache-wrapper in: ${code}`).not.toBeNull();
+  return m![0].replace(/"__ub\d+"/, '"__ubN"');
+}
+
+/**
+ * U2 — the legacy string serializer (serializeHelperCall, used for {{yield …}} /
+ * slot args) must reach parity with the JSExpression serializer (serializers/
+ * value.ts) for the inline-unbound cache-wrap and the component/helper
+ * named-args getter-wrap.
+ */
+describe('serializeHelperCall parity with the JSExpression serializer', () => {
+  describe('inline unbound cache-wrap', () => {
+    test('yielded (unbound this.x) emits the same wrapper shape as top-level {{unbound this.x}}', () => {
+      const top = compile('{{unbound this.x}}', COMPAT).code;
+      const yielded = compile('{{yield (unbound this.x)}}', COMPAT).code;
+
+      // Both go through globalThis.__gxtUnboundEval(__ubCache, "__ubN", () => (…)).
+      expect(unboundWrapperShape(yielded)).toBe(unboundWrapperShape(top));
+      // The yielded form is no longer a bare unbound(...) call.
+      expect(yielded).not.toContain('[unbound(this.x)]');
+      expect(yielded).toContain('globalThis.__gxtUnboundEval(__ubCache,"__ub0",()=>(unbound(this.x)))');
+    });
+
+    test('cache keys stay unique across both serializers (shared unboundCounter)', () => {
+      const { code } = compile('{{unbound this.a}}{{yield (unbound this.b)}}', COMPAT);
+      const ids = [...code.matchAll(/"(__ub\d+)"/g)].map((m) => m[1]);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2); // no collision
+    });
+
+    test('standalone (non-compat) keeps the bare form — no ember-only wrapper leaks', () => {
+      const { code } = compile('{{yield (unbound this.x)}}', STANDALONE);
+      expect(code).toContain('unbound(this.x)');
+      expect(code).not.toContain('__gxtUnboundEval');
+    });
+  });
+
+  describe('component/helper hash getter-wrap', () => {
+    test('yielded (component … key=this.y) emits a getter-wrapped named-args object identical to the JSExpression path', () => {
+      const yielded = compile('{{yield (component "x" foo=this.y bar="s" n=42)}}', COMPAT).code;
+      const top = compile('{{log (component "x" foo=this.y bar="s" n=42)}}', COMPAT).code;
+
+      // Byte-identical named-args objects: only the path value is getter-wrapped;
+      // the string/number literals are emitted directly.
+      expect(namedArgsOf(yielded, '$_componentHelper')).toBe(
+        namedArgsOf(top, '$_componentHelper')
+      );
+      expect(namedArgsOf(yielded, '$_componentHelper')).toBe('{ foo: () => this.y, bar: "s", n: 42 }');
+    });
+
+    test('yielded (helper … key=this.y) getter-wraps the path value', () => {
+      const { code } = compile('{{yield (helper "x" foo=this.y)}}', COMPAT);
+      expect(namedArgsOf(code, '$_helperHelper')).toBe('{ foo: () => this.y }');
+    });
+
+    test('component helper nested inside a yielded (hash …) wraps its path value too', () => {
+      const { code } = compile('{{yield (hash c=(component "x" foo=this.y))}}', COMPAT);
+      expect(code).toContain('$_componentHelper(["x"], { foo: () => this.y })');
+    });
+
+    test('standalone (non-compat) leaves component-helper hash values unwrapped', () => {
+      const { code } = compile('{{yield (component "x" foo=this.y)}}', STANDALONE);
+      expect(namedArgsOf(code, '$_componentHelper')).toBe('{ foo: this.y }');
+    });
+  });
+});

--- a/plugins/compiler/__tests__/compile.test.ts
+++ b/plugins/compiler/__tests__/compile.test.ts
@@ -4987,3 +4987,125 @@ describe('Compat mode AST transforms', () => {
     });
   });
 });
+
+describe('compile() — transforms hook (CompileOptions.transforms)', () => {
+  test('no transforms: output is byte-identical to baseline', () => {
+    const tpl = '<div class="card">{{this.greeting}}<span>{{count}}</span></div>';
+    const baseline = compile(tpl);
+    // Passing undefined, an empty array, and omitting entirely must all match.
+    expect(compile(tpl, {}).code).toBe(baseline.code);
+    expect(compile(tpl, { transforms: undefined }).code).toBe(baseline.code);
+    expect(compile(tpl, { transforms: [] }).code).toBe(baseline.code);
+    expect(baseline.errors).toHaveLength(0);
+  });
+
+  test('bare NodeVisitor: renames a mustache path before lowering', () => {
+    const tpl = '<div>{{greeting}}</div>';
+    const baseline = compile(tpl);
+    // Baseline references the original free-var helper name.
+    expect(baseline.code).toContain('greeting');
+    expect(baseline.code).not.toContain('salutation');
+
+    const result = compile(tpl, {
+      transforms: [
+        {
+          MustacheStatement(node: any) {
+            if (
+              node.path.type === 'PathExpression' &&
+              node.path.original === 'greeting'
+            ) {
+              node.path.original = 'salutation';
+              node.path.parts = ['salutation'];
+            }
+          },
+        },
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    // The AST mutation is reflected in the emitted code.
+    expect(result.code).toContain('salutation');
+    expect(result.code).not.toContain('greeting');
+  });
+
+  test('bare NodeVisitor: rewrites an element tag', () => {
+    const tpl = '<div>hello</div>';
+    const result = compile(tpl, {
+      transforms: [
+        {
+          ElementNode(node: any) {
+            if (node.tag === 'div') {
+              node.tag = 'section';
+            }
+          },
+        },
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.code).toContain("'section'");
+    expect(result.code).not.toContain("'div'");
+  });
+
+  test('ASTPluginBuilder shape: (env) => ({ name, visitor }) is supported', () => {
+    const tpl = '<div>{{greeting}}</div>';
+    let seenEnv: any;
+
+    const result = compile(tpl, {
+      transforms: [
+        (env: any) => {
+          seenEnv = env;
+          return {
+            name: 'rename-greeting',
+            visitor: {
+              MustacheStatement(node: any) {
+                if (
+                  node.path.type === 'PathExpression' &&
+                  node.path.original === 'greeting'
+                ) {
+                  node.path.original = 'salutation';
+                  node.path.parts = ['salutation'];
+                }
+              },
+            },
+          };
+        },
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.code).toContain('salutation');
+    expect(result.code).not.toContain('greeting');
+    // env exposes the @glimmer/syntax surface like classic plugins.ast.
+    expect(typeof seenEnv.syntax.builders).toBe('object');
+    expect(typeof seenEnv.syntax.traverse).toBe('function');
+  });
+
+  test('multiple transforms apply in order', () => {
+    const tpl = '<div>{{a}}</div>';
+    const result = compile(tpl, {
+      transforms: [
+        {
+          MustacheStatement(node: any) {
+            if (node.path.type === 'PathExpression' && node.path.original === 'a') {
+              node.path.original = 'b';
+              node.path.parts = ['b'];
+            }
+          },
+        },
+        {
+          MustacheStatement(node: any) {
+            if (node.path.type === 'PathExpression' && node.path.original === 'b') {
+              node.path.original = 'c';
+              node.path.parts = ['c'];
+            }
+          },
+        },
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.code).toContain('c');
+    expect(result.code).not.toMatch(/\b(a|b)\(/);
+  });
+});

--- a/plugins/compiler/__tests__/dynamic-at-tag.test.ts
+++ b/plugins/compiler/__tests__/dynamic-at-tag.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'vitest';
+import { compile } from '../compile';
+
+const COMPAT = { flags: { IS_GLIMMER_COMPAT_MODE: true } } as const;
+
+/**
+ * U1 — dynamic component tags whose head is an `@arg` must resolve the head
+ * through the args alias ($a) instead of leaking a raw `@identifier` token into
+ * the emitted JS (a SyntaxError outside decorator position).
+ */
+describe('dynamic @-path component tag normalization', () => {
+  test('<@model.componentName /> resolves the @-head through $a (no raw @ token)', () => {
+    const { code } = compile('<@model.componentName />', COMPAT);
+    expect(code).toContain('$a.model.componentName');
+    // The raw `@identifier` token must NOT leak into emitted code.
+    expect(code).not.toMatch(/@[A-Za-z_$]/);
+    // Still a dynamic-component getter call.
+    expect(code).toContain('() => $a.model.componentName');
+  });
+
+  test('{{component @model.componentName}} normalizes the same way', () => {
+    const { code } = compile('{{component @model.componentName}}', COMPAT);
+    expect(code).toContain('() => $a.model.componentName');
+    expect(code).not.toMatch(/@[A-Za-z_$]/);
+  });
+
+  test('@-head with special characters uses bracket notation', () => {
+    const { code } = compile('<@weird-name.Foo />', COMPAT);
+    expect(code).toContain('() => $a["weird-name"].Foo');
+    expect(code).not.toMatch(/@[A-Za-z_$]/);
+  });
+
+  test('sibling this-path dynamic tag is unchanged (was already valid)', () => {
+    const { code } = compile('<this.foo.Bar />', COMPAT);
+    expect(code).toContain('() => this.foo.Bar');
+  });
+});

--- a/plugins/compiler/compile.ts
+++ b/plugins/compiler/compile.ts
@@ -5,7 +5,18 @@
  * This provides a clean, dependency-injected interface for template compilation.
  */
 
-import { preprocess, type ASTv1 } from '@glimmer/syntax';
+import {
+  preprocess,
+  traverse,
+  builders,
+  print,
+  Walker,
+  type ASTv1,
+  type ASTPlugin,
+  type ASTPluginBuilder,
+  type ASTPluginEnvironment,
+  type NodeVisitor,
+} from '@glimmer/syntax';
 
 /**
  * Find the index of the first whitespace character in a string, or -1 if none.
@@ -88,7 +99,7 @@ function parseModuleName(msg: string): string | null {
   if (endQuote === -1) return null;
   return afterMarker.substring(0, endQuote);
 }
-import type { CompileOptions, CompileResult, HBSChild, SourceMapV3, SourceMapOptions } from './types';
+import type { AstTransform, CompileOptions, CompileResult, HBSChild, SourceMapV3, SourceMapOptions } from './types';
 import { createContext, initializeVisitors, setSerializeChildFunction, type CompilerContext } from './context';
 import { visit, visitChildren, setSourceForRanges } from './visitors';
 import { serialize, build, B, serializeJS } from './serializers';
@@ -142,6 +153,12 @@ export function compile(
 
     // Set source for accurate line/column to offset conversion
     setSourceForRanges(template);
+
+    // Public AST-transform hook: run any caller-supplied `@glimmer/syntax`
+    // visitors/plugins on the parsed AST before lowering/codegen. When no
+    // transforms are passed this is a no-op (the `for` loop never runs), so
+    // behavior is byte-identical to today.
+    applyTransforms(ast, options.transforms, options.filename);
 
     // Visit and convert the AST
     const children = visitAndFilter(ctx, ast.body);
@@ -313,6 +330,60 @@ export function compile(
       warnings: ctx.warnings,
       bindings: ctx.scopeTracker.getAllBindingNames(),
     };
+  }
+}
+
+/**
+ * Apply caller-supplied AST transforms to the parsed template AST.
+ *
+ * Accepts the standard `@glimmer/syntax` AST-plugin shapes (the same ones
+ * classic Ember AST plugins use):
+ *   - a bare `NodeVisitor` object, or
+ *   - an `ASTPluginBuilder` factory `(env) => ({ name, visitor })`.
+ *
+ * Each transform is applied in order via `@glimmer/syntax`'s `traverse`, which
+ * mutates the AST in place. When `transforms` is `undefined`/empty the loop
+ * never runs, so this is a true no-op (the critical behavior-neutral invariant).
+ *
+ * @internal
+ */
+function applyTransforms(
+  ast: ASTv1.Template,
+  transforms: readonly AstTransform[] | undefined,
+  filename: string | undefined
+): void {
+  if (!transforms || transforms.length === 0) {
+    return;
+  }
+
+  // A `Syntax` environment mirroring `@glimmer/syntax`'s public surface, so
+  // builder-style plugins can use `env.syntax.builders` etc. just like they
+  // would inside Ember's classic `plugins.ast` pipeline.
+  const syntax = {
+    parse: preprocess,
+    builders,
+    print,
+    traverse,
+    Walker,
+  };
+
+  for (const transform of transforms) {
+    let visitor: NodeVisitor;
+
+    if (typeof transform === 'function') {
+      // ASTPluginBuilder: (env) => { name, visitor }
+      const env: ASTPluginEnvironment = {
+        meta: { moduleName: filename } as object,
+        syntax: syntax as ASTPluginEnvironment['syntax'],
+      };
+      const plugin: ASTPlugin = (transform as ASTPluginBuilder)(env);
+      visitor = plugin.visitor;
+    } else {
+      // Bare NodeVisitor object
+      visitor = transform as NodeVisitor;
+    }
+
+    traverse(ast, visitor);
   }
 }
 

--- a/plugins/compiler/index.ts
+++ b/plugins/compiler/index.ts
@@ -27,6 +27,7 @@ export type {
   MappingTreeNode,
   CompilerFlags,
   CompileOptions,
+  AstTransform,
   CompileResult,
   CompilerError,
   CompilerWarning,

--- a/plugins/compiler/serializers/element.ts
+++ b/plugins/compiler/serializers/element.ts
@@ -729,8 +729,27 @@ function buildComponentCall(
   if (isDynamic) {
     // Wrap in reactive getter for dynamic component paths
     // This allows re-evaluation when the component reference changes
-    // Use runtimeRef to preserve source map name for debugger hover
-    const tagRef = B.runtimeRef(tag, tagRange);
+    // Use runtimeRef to preserve source map name for debugger hover.
+    //
+    // Normalize an arg-headed dynamic tag (e.g. `<@model.componentName/>` or
+    // `{{component @model.componentName}}`) so the `@` head resolves through the
+    // args alias ($a) instead of leaking a raw `@` token into emitted JS — a bare
+    // `@ident` is only valid in decorator position, so `$_dc(() => @model.x, …)`
+    // is a SyntaxError. Mirrors the @→$a rule used by the path/helper/modifier
+    // serializers (serializers/value.ts:363-370). Non-arg dynamic tags such as
+    // `this.foo.Bar` already emit valid JS and are left untouched.
+    let dynamicTag = tag;
+    if (dynamicTag.startsWith('@')) {
+      const dotIndex = dynamicTag.indexOf('.');
+      const head = dotIndex === -1 ? dynamicTag.slice(1) : dynamicTag.slice(1, dotIndex);
+      const rest = dotIndex === -1 ? '' : dynamicTag.slice(dotIndex);
+      // Use bracket notation for head segments with special characters (hyphens etc.).
+      const needsBracket = !/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(head);
+      dynamicTag = needsBracket
+        ? `${SYMBOLS.ARGS_ALIAS}["${head}"]${rest}`
+        : `${SYMBOLS.ARGS_ALIAS}.${head}${rest}`;
+    }
+    const tagRef = B.runtimeRef(dynamicTag, tagRange);
     const tagGetter = B.reactiveGetter(tagRef, tagRange);
     return B.call(SYMBOLS.DYNAMIC_COMPONENT, [tagGetter, argsExpr, B.id(ctxName)], sourceRange, formatted, 'ElementNode');
   }

--- a/plugins/compiler/types.ts
+++ b/plugins/compiler/types.ts
@@ -3,6 +3,11 @@
  * All types are explicitly defined here to ensure type safety throughout.
  */
 
+// Type-only import: used for the public `CompileOptions.transforms` hook so
+// callers can supply standard `@glimmer/syntax` AST plugins/visitors. This is
+// erased at build time and adds no runtime dependency.
+import type { ASTPluginBuilder, NodeVisitor } from '@glimmer/syntax';
+
 // ============================================================================
 // Source Range & Mapping Types
 // ============================================================================
@@ -499,6 +504,22 @@ export interface TypeHints {
 }
 
 /**
+ * A single AST transform that runs on the parsed `@glimmer/syntax` AST after
+ * `preprocess` and before glimmer-next's own lowering/codegen.
+ *
+ * Two shapes are accepted — the same ones classic Ember AST plugins use:
+ *
+ * - A bare {@link NodeVisitor} object, e.g.
+ *   `{ MustacheStatement(node) { … }, ElementNode(node) { … } }`.
+ * - An {@link ASTPluginBuilder} factory `(env) => ({ name, visitor })`, where
+ *   `env` exposes `{ syntax, meta }` (`env.syntax.builders` mirrors
+ *   `@glimmer/syntax`'s builders).
+ *
+ * Transforms mutate the AST in place; their return values are ignored.
+ */
+export type AstTransform = NodeVisitor | ASTPluginBuilder;
+
+/**
  * Options for the compile() function.
  */
 export interface CompileOptions {
@@ -520,6 +541,32 @@ export interface CompileOptions {
   readonly lexicalScope?: (variable: string) => boolean;
   /** Type hints for type-directed optimization. Only used when WITH_TYPE_OPTIMIZATION is true. */
   readonly typeHints?: TypeHints;
+  /**
+   * Public AST-transform hook. Standard `@glimmer/syntax`-style visitors/plugins
+   * (the same shape classic Ember AST plugins use) that run on the parsed AST
+   * **after `preprocess`, before lowering/codegen**, applied in order via
+   * `@glimmer/syntax`'s `traverse`.
+   *
+   * When absent or empty, compilation behaves byte-for-byte identically to
+   * having no hook at all — this is an opt-in feature.
+   *
+   * @example
+   * ```typescript
+   * compile('<div>{{greeting}}</div>', {
+   *   transforms: [
+   *     {
+   *       MustacheStatement(node) {
+   *         if (node.path.type === 'PathExpression' && node.path.original === 'greeting') {
+   *           node.path.original = 'salutation';
+   *           node.path.parts = ['salutation'];
+   *         }
+   *       },
+   *     },
+   *   ],
+   * });
+   * ```
+   */
+  readonly transforms?: readonly AstTransform[];
 }
 
 // ============================================================================

--- a/plugins/compiler/visitors/block.ts
+++ b/plugins/compiler/visitors/block.ts
@@ -477,7 +477,7 @@ function extractBlockOptions(
     } else {
       const result = getVisit(ctx)(ctx, keyPair.value, false);
       if (result !== null && isSerializedValue(result)) {
-        keyValue = serializeValueToString(result);
+        keyValue = serializeValueToString(result, ctx);
       }
     }
   }

--- a/plugins/compiler/visitors/mustache.ts
+++ b/plugins/compiler/visitors/mustache.ts
@@ -226,7 +226,7 @@ function createYieldExpression(
     } else {
       const result = getVisit(ctx)(ctx, toPair.value, false);
       if (result !== null && isSerializedValue(result)) {
-        slotName = serializeValueToString(result);
+        slotName = serializeValueToString(result, ctx);
       }
     }
   }
@@ -236,7 +236,7 @@ function createYieldExpression(
     const result = getVisit(ctx)(ctx, p, false);
     if (result === null) return '';
     if (typeof result === 'string') return result;
-    if (isSerializedValue(result)) return serializeValueToString(result);
+    if (isSerializedValue(result)) return serializeValueToString(result, ctx);
     return '';
   });
 

--- a/plugins/compiler/visitors/utils.ts
+++ b/plugins/compiler/visitors/utils.ts
@@ -419,7 +419,7 @@ export function resolvePath(ctx: CompilerContext, pathStr: string): string {
  * Note: For CodeBuilder-based serialization during serialization phase,
  * use serializeValue from serializers/value.ts instead.
  */
-export function serializeValueToString(value: SerializedValue): string {
+export function serializeValueToString(value: SerializedValue, ctx?: CompilerContext): string {
   switch (value.kind) {
     case 'literal':
       if (value.value === undefined) return 'undefined';
@@ -437,13 +437,13 @@ export function serializeValueToString(value: SerializedValue): string {
       return value.code;
 
     case 'helper':
-      return serializeHelperCall(value);
+      return serializeHelperCall(value, ctx);
 
     case 'getter':
-      return `() => ${serializeValueToString(value.value)}`;
+      return `() => ${serializeValueToString(value.value, ctx)}`;
 
     case 'concat':
-      return `[${value.parts.map(p => serializeValueToString(p)).join(',')}].join('')`;
+      return `[${value.parts.map(p => serializeValueToString(p, ctx)).join(',')}].join('')`;
 
     default:
       // Exhaustive check - TypeScript will error if a kind is not handled
@@ -452,7 +452,7 @@ export function serializeValueToString(value: SerializedValue): string {
   }
 }
 
-function buildValueToExpr(value: SerializedValue): JSExpression {
+function buildValueToExpr(value: SerializedValue, ctx?: CompilerContext): JSExpression {
   switch (value.kind) {
     case 'literal':
       if (value.value === undefined) return B.undef(value.sourceRange);
@@ -469,20 +469,20 @@ function buildValueToExpr(value: SerializedValue): JSExpression {
     case 'helper':
       switch (value.name) {
         case INTERNAL_HELPERS.ELEMENT_HELPER:
-          return buildElementHelperExpr(value);
+          return buildElementHelperExpr(value, ctx);
         case INTERNAL_HELPERS.ON_HANDLER:
-          return buildOnHandlerExpr(value);
+          return buildOnHandlerExpr(value, ctx);
         case INTERNAL_HELPERS.ON_CREATED_HANDLER:
-          return buildOnCreatedHandlerExpr(value);
+          return buildOnCreatedHandlerExpr(value, ctx);
         case INTERNAL_HELPERS.STYLE_SETTER:
-          return buildStyleSetterExpr(value);
+          return buildStyleSetterExpr(value, ctx);
         default:
-          return B.raw(serializeHelperCall(value));
+          return B.raw(serializeHelperCall(value, ctx));
       }
     case 'getter':
-      return B.reactiveGetter(buildValueToExpr(value.value), value.sourceRange);
+      return B.reactiveGetter(buildValueToExpr(value.value, ctx), value.sourceRange);
     case 'concat': {
-      const exprs = value.parts.map((part) => buildValueToExpr(part));
+      const exprs = value.parts.map((part) => buildValueToExpr(part, ctx));
       return B.methodCall(B.array(exprs), 'join', [B.string('')], value.sourceRange);
     }
     default:
@@ -490,16 +490,16 @@ function buildValueToExpr(value: SerializedValue): JSExpression {
   }
 }
 
-function buildElementHelperExpr(value: SerializedValue & { kind: 'helper' }): JSExpression {
+function buildElementHelperExpr(value: SerializedValue & { kind: 'helper' }, ctx?: CompilerContext): JSExpression {
   const tagValue = value.positional[0];
   let tagExpr: JSExpression;
 
   if (!tagValue) {
     tagExpr = B.string('div');
   } else if (tagValue.kind === 'literal' || tagValue.kind === 'getter') {
-    tagExpr = buildValueToExpr(tagValue);
+    tagExpr = buildValueToExpr(tagValue, ctx);
   } else {
-    tagExpr = B.reactiveGetter(buildValueToExpr(tagValue));
+    tagExpr = B.reactiveGetter(buildValueToExpr(tagValue, ctx));
   }
 
   return B.elementHelperWrapper(tagExpr, {
@@ -514,28 +514,28 @@ function buildElementHelperExpr(value: SerializedValue & { kind: 'helper' }): JS
   }, value.sourceRange);
 }
 
-function buildOnHandlerExpr(value: SerializedValue & { kind: 'helper' }): JSExpression {
+function buildOnHandlerExpr(value: SerializedValue & { kind: 'helper' }, ctx?: CompilerContext): JSExpression {
   const [handlerArg, ...tailArgs] = value.positional;
-  const handlerExpr = handlerArg ? buildValueToExpr(handlerArg) : B.nil();
-  const tailExprs = tailArgs.map((arg) => buildValueToExpr(arg));
+  const handlerExpr = handlerArg ? buildValueToExpr(handlerArg, ctx) : B.nil();
+  const tailExprs = tailArgs.map((arg) => buildValueToExpr(arg, ctx));
   const callArgs: JSExpression[] = [B.id('$e'), B.id('$n'), ...tailExprs];
   return B.arrow(['$e', '$n'], B.call(handlerExpr, callArgs), value.sourceRange);
 }
 
-function buildOnCreatedHandlerExpr(value: SerializedValue & { kind: 'helper' }): JSExpression {
+function buildOnCreatedHandlerExpr(value: SerializedValue & { kind: 'helper' }, ctx?: CompilerContext): JSExpression {
   const [handlerArg, ...tailArgs] = value.positional;
-  const handlerExpr = handlerArg ? buildValueToExpr(handlerArg) : B.nil();
-  const tailExprs = tailArgs.map((arg) => buildValueToExpr(arg));
+  const handlerExpr = handlerArg ? buildValueToExpr(handlerArg, ctx) : B.nil();
+  const tailExprs = tailArgs.map((arg) => buildValueToExpr(arg, ctx));
   const callArgs: JSExpression[] = [B.id('$n'), ...tailExprs];
   return B.arrow(['$n'], B.call(handlerExpr, callArgs), value.sourceRange);
 }
 
-function buildStyleSetterExpr(value: SerializedValue & { kind: 'helper' }): JSExpression {
+function buildStyleSetterExpr(value: SerializedValue & { kind: 'helper' }, ctx?: CompilerContext): JSExpression {
   const [propValue, styleValue] = value.positional;
   const propertyName = propValue && propValue.kind === 'literal' && typeof propValue.value === 'string'
     ? propValue.value
     : '';
-  const valueExpr = styleValue ? buildValueToExpr(styleValue) : B.nil();
+  const valueExpr = styleValue ? buildValueToExpr(styleValue, ctx) : B.nil();
   return B.styleSetter(propertyName, valueExpr, {
     TO_VALUE: SYMBOLS.TO_VALUE,
     LOCAL_VALUE: SYMBOLS.LOCAL_VALUE,
@@ -548,7 +548,7 @@ function buildStyleSetterExpr(value: SerializedValue & { kind: 'helper' }): JSEx
 /**
  * Serialize a helper call to JavaScript.
  */
-function serializeHelperCall(value: SerializedValue & { kind: 'helper' }): string {
+function serializeHelperCall(value: SerializedValue & { kind: 'helper' }, ctx?: CompilerContext): string {
   let args: string[] = [];
   let helperName = value.name;
 
@@ -558,7 +558,7 @@ function serializeHelperCall(value: SerializedValue & { kind: 'helper' }): strin
     helperName === INTERNAL_HELPERS.ON_CREATED_HANDLER ||
     helperName === INTERNAL_HELPERS.STYLE_SETTER
   ) {
-    return serializeJS(buildValueToExpr(value));
+    return serializeJS(buildValueToExpr(value, ctx));
   }
 
   // Handle @arg-prefixed helper names (helper passed as argument)
@@ -577,24 +577,24 @@ function serializeHelperCall(value: SerializedValue & { kind: 'helper' }): strin
     helperName = 'if';
     // unless(cond, true, false) -> if(cond, false, true)
     if (value.positional.length >= 2) {
-      args.push(serializeValueToString(value.positional[0])); // condition
+      args.push(serializeValueToString(value.positional[0], ctx)); // condition
       if (value.positional.length >= 3) {
-        args.push(serializeValueToString(value.positional[2])); // false value (becomes true branch)
-        args.push(serializeValueToString(value.positional[1])); // true value (becomes false branch)
+        args.push(serializeValueToString(value.positional[2], ctx)); // false value (becomes true branch)
+        args.push(serializeValueToString(value.positional[1], ctx)); // true value (becomes false branch)
       } else {
         args.push('""'); // empty string for false branch
-        args.push(serializeValueToString(value.positional[1])); // true value becomes false branch
+        args.push(serializeValueToString(value.positional[1], ctx)); // true value becomes false branch
       }
     } else {
       // Just condition - pass through
       for (const arg of value.positional) {
-        args.push(serializeValueToString(arg));
+        args.push(serializeValueToString(arg, ctx));
       }
     }
   } else {
     // Add positional args normally
     for (const arg of value.positional) {
-      args.push(serializeValueToString(arg));
+      args.push(serializeValueToString(arg, ctx));
     }
   }
 
@@ -607,7 +607,7 @@ function serializeHelperCall(value: SerializedValue & { kind: 'helper' }): strin
     const namedPairs: string[] = [];
     for (const [key, val] of value.named) {
       // Wrap each value in a getter
-      namedPairs.push(`${quoteKey(key)}: () => ${serializeValueToString(val)}`);
+      namedPairs.push(`${quoteKey(key)}: () => ${serializeValueToString(val, ctx)}`);
     }
     return `${symbolName}({ ${namedPairs.join(', ')} })`;
   }
@@ -616,7 +616,7 @@ function serializeHelperCall(value: SerializedValue & { kind: 'helper' }): strin
   if (value.named.size > 0) {
     const namedPairs: string[] = [];
     for (const [key, val] of value.named) {
-      namedPairs.push(`${quoteKey(key)}: ${serializeValueToString(val)}`);
+      namedPairs.push(`${quoteKey(key)}: ${serializeValueToString(val, ctx)}`);
     }
     args.push(`{ ${namedPairs.join(', ')} }`);
   }
@@ -644,17 +644,46 @@ function serializeHelperCall(value: SerializedValue & { kind: 'helper' }): strin
     symbolName === SYMBOLS.MODIFIER_HELPER
   ) {
     // Build positional as array
-    const positionalArgs = value.positional.map(arg => serializeValueToString(arg));
-    // Build named as object
+    const positionalArgs = value.positional.map(arg => serializeValueToString(arg, ctx));
+    // Build named as object.
+    //
+    // Parity with the JSExpression serializer (serializers/value.ts
+    // buildBuiltInHelper -> buildNamedArgsObject -> buildValue): in compat mode,
+    // path-kind hash values are wrapped in `() => expr` getters so curried
+    // component/helper/modifier args stay reactive. Only `path` values are
+    // wrapped — literals/helpers/hash are emitted directly, exactly matching
+    // buildValue's compat-mode behavior (which getter-wraps only paths).
+    // $_componentHelper unwraps each value through $_unwrapHelperArg (which calls
+    // function values), so this is snapshot-equivalent for standalone; we still
+    // gate on compat mode to byte-match the JSExpression path, which only wraps
+    // when IS_GLIMMER_COMPAT_MODE is set.
+    const wrapNamed = ctx?.flags.IS_GLIMMER_COMPAT_MODE === true;
     const namedPairs: string[] = [];
     for (const [key, val] of value.named) {
-      namedPairs.push(`${quoteKey(key)}: ${serializeValueToString(val)}`);
+      const serialized = serializeValueToString(val, ctx);
+      const emitted = wrapNamed && val.kind === 'path' ? `() => ${serialized}` : serialized;
+      namedPairs.push(`${quoteKey(key)}: ${emitted}`);
     }
     const namedObj = namedPairs.length > 0 ? `{ ${namedPairs.join(', ')} }` : '{}';
     return `${symbolName}([${positionalArgs.join(', ')}], ${namedObj})`;
   }
 
-  return `${symbolName}(${args.join(', ')})`;
+  const callStr = `${symbolName}(${args.join(', ')})`;
+
+  // Parity with the JSExpression serializer (serializers/value.ts:441-448): wrap
+  // an inline `{{unbound X}}` sub-expression (e.g. `{{yield (unbound this.x)}}`)
+  // in the same caching wrapper the top-level mustache form emits, so the value
+  // is snapshot once instead of re-read on every consumer evaluation. Uses the
+  // shared ctx.unboundCounter (cache keys stay unique across both serializers)
+  // and the same `()=>(…)` arrow shape. Gated on compat mode — the only mode in
+  // which the Ember host defines globalThis.__gxtUnboundEval / __ubCache — so
+  // standalone output keeps the bare form, exactly as the value.ts path does.
+  if (ctx?.flags.IS_GLIMMER_COMPAT_MODE && value.name === 'unbound') {
+    const ubId = `__ub${ctx.unboundCounter++}`;
+    return `globalThis.__gxtUnboundEval(__ubCache,"${ubId}",()=>(${callStr}))`;
+  }
+
+  return callStr;
 }
 
 /**

--- a/plugins/runtime-compiler.ts
+++ b/plugins/runtime-compiler.ts
@@ -40,12 +40,12 @@
  * Using eval with untrusted input is a security risk.
  */
 
-import { compile as compilerCompile, type CompileOptions, type CompileResult } from './compiler/index';
+import { compile as compilerCompile, type CompileOptions, type CompileResult, type AstTransform } from './compiler/index';
 import { SYMBOLS, CONSTANTS, EVENT_TYPE } from './symbols';
 import { type Flags } from './flags';
 
 // Re-export types
-export type { CompileOptions, CompileResult, Flags };
+export type { CompileOptions, CompileResult, AstTransform, Flags };
 export { SYMBOLS, CONSTANTS, EVENT_TYPE };
 
 // Import GXT runtime primitives from dom.ts
@@ -205,6 +205,13 @@ export interface RuntimeCompileOptions {
   flags?: Partial<Flags>;
   /** Scope values to make available in the template */
   scopeValues?: Record<string, unknown>;
+  /**
+   * Public AST-transform hook. Standard `@glimmer/syntax`-style visitors/plugins
+   * (the same shape classic Ember AST plugins use) that run on the parsed AST
+   * after `preprocess`, before lowering/codegen. When absent or empty, behavior
+   * is byte-identical to having no hook. See {@link AstTransform}.
+   */
+  transforms?: readonly AstTransform[];
 }
 
 /**
@@ -253,6 +260,9 @@ export function compileTemplate(
     filename: options.moduleName || 'runtime-template',
     bindings: options.bindings || new Set(),
     flags,
+    // Thread the public AST-transform hook through. Undefined when not provided,
+    // keeping the no-transforms path byte-identical.
+    transforms: options.transforms,
   };
 
   const result = compilerCompile(template, compileOptions);


### PR DESCRIPTION
Re-lands three commits stranded on the merged #217 branch (pushed after the squash-merge), rebased onto master.

## What's included

1. **`feat(compiler): public AST-transform hook (CompileOptions.transforms)`** — optional `transforms?: readonly AstTransform[]` (`NodeVisitor | ASTPluginBuilder`, the standard `@glimmer/syntax` shapes), applied between `preprocess` and lowering. Byte-identical output when unused. Threaded through `runtime-compiler`'s `template()`/`compile()`. Ember's gxt-backend uses this to express its template-dialect rewrites ({{outlet}}, {{#each-in}}, {{on}} hash args, …) as AST visitors instead of string-rewriting.

2. **`fix(compiler): normalize @-path dynamic component tags`** — `<@model.componentName />` previously emitted `$_dc(() => @model.componentName, …)` (raw `@` = JS SyntaxError). The dynamic string-tag path now applies the same `@→$a` normalization the expression serializer already uses (incl. bracket notation for special-char heads).

3. **`fix(compiler): serializeHelperCall parity`** — the legacy string serializer (used for `{{yield …}}`/slot args) drifted from the JSExpression path: it emitted bare `unbound(...)` (no cache wrapper) and direct named-arg values (no getter wrap) for `(component … key=this.y)`. Both wraps are now applied, gated on `IS_GLIMMER_COMPAT_MODE`, byte-matching the JSExpression path; standalone emission is unchanged. (`$_componentHelper` unwraps hash values via `$_unwrapHelperArg`, which calls function values — getter-wrapping is transparent.)

Verified: tsc clean, vitest 3801/3801 (11 new tests), qunit 1219/0, check-errors clean, renderers 2/2, build-lib OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)