### PR TITLE
perf(list): keyedSelector primitive + opt-in row recycling ("sliding window of references")

### DIFF
--- a/RESEARCH_LIST_TRACKING_OPTIMIZATION.md
+++ b/RESEARCH_LIST_TRACKING_OPTIMIZATION.md
@@ -1,0 +1,329 @@
+# Research: Per-Item Tracking Context in `{{#each}}` — Sliding-Window Contexts & Hierarchical (Binary) Validation
+
+> Status: research only, no implementation. 2026-06-09.
+>
+> Question under research (paraphrased): *"In each loop we create a tracking
+> context per item, and it's a slowdown. Could we do better — e.g. a 'sliding
+> window of references' where general render logic lives in one instance and we
+> just swap the context during render? And could we use 'binary validation'
+> (binary search) instead of per-item tags?"*
+
+---
+
+## 1. What "tracking context per item" actually costs today
+
+First, an important framing fact that changes both proposals:
+
+**GXT's reactivity is push-based, not pull-based.** A dirty `Cell` maps
+*directly* to its DOM opcodes (`opsForTag: Map<cellId, tagOp[]>` in
+`src/core/reactive.ts:25`) and to subscriber formulas
+(`relatedTags: Map<cellId, Set<MergedCell>>`, `reactive.ts:32`). The drain
+(`syncDomSync`, `src/core/runtime.ts:111`) iterates only dirty cells and their
+subscribers. **There is no per-render validation walk over per-item tags at
+all.** This is unlike Glimmer-VM, where every render revalidates the tag tree
+and per-item tags are a *read*-time cost.
+
+Consequence: per-item tags in GXT are **not** a steady-state update slowdown.
+For "update every 10th row" (Krausest), the drain touches exactly the ~100
+dirty label cells and their ~100 opcodes — already O(dirty), optimal. The
+per-item cost is paid at **row create, row destroy, and shared-cell fan-out**.
+
+### 1.1 Per-row creation inventory (Krausest `Row`, compat mode, `hasIndex=false`)
+
+Measured statically from the code paths involved
+(`src/core/control-flow/list.ts` → `src/core/dom.ts`):
+
+| # | Cost | Source |
+|---|------|--------|
+| 1 | key string + 7 map/set entries (`keyMap`, `indexMap`, `boundItemMap`, `itemMarkers`, `markerSet`, `rowCtxMap`, dup-cache) | `list.ts` `updateItems` / `_buildAndInsertRow` |
+| 2 | 1 `Comment` marker DOM node per row | `list.ts:1218` |
+| 3 | **RowContext** object + `cId()` + `addToTree` (→ `TREE.set`, `CHILD` Set alloc + add, `PARENT.set`, flag, destructor closure + registry entry) | `list.ts:413` `rowBodyCtx` |
+| 4 | Component instance (`new Row(...)`) + `$_GET_ARGS` → **second** `cId()` + `addToTree` (another TREE/CHILD/PARENT/destructor set) + args `Proxy` | `dom.ts:1686`, `dom.ts:1243` |
+| 5 | ~10 DOM elements created **one by one** (`api.element` + ~15 static `api.attr` calls). **No `cloneNode` anywhere in `src/core`** | `_DOM` in `dom.ts` |
+| 6 | ~4–6 `MergedCell` formulas (3× `class={{this.className}}`, 1 modifier cell, text resolution), each: closure + lazily a tracker `Set` + pooled ops array + opcode closure + `relatedTags` Set entry + destructor closure | `dom.ts:252` `resolveBindingValue`, `$prop`, `$ev` |
+| 7 | 2 `addEventListener` | `$ev` |
+| 8 | `registerDestructorBatch(rowCtx, destructors)` | `dom.ts:900` |
+
+Ballpark: **~25–40 heap allocations and ~15–20 map/set mutations per row**
+beyond the unavoidable DOM. For create-1000 that's ~30k reactive-layer
+allocations; the GC pressure and Map churn is the "slowdown" being asked about.
+
+Note the duplication in row ownership: each row pays for **two** tree
+identities (RowContext *and* the component instance), each with its own id,
+tree entries and cleanup closure.
+
+### 1.2 Where O(N) really appears at update time
+
+`class={{this.className}}` evaluates `this.args.selected === this.id` → each
+of the 3 class bindings per row is a `MergedCell` subscribed to the single
+`_selected` cell. Selecting a row therefore:
+
+1. dirties `_selected` → drain collects its `relatedTags` set: **3N formulas**;
+2. sorts them (`sortSharedTags`, O(3N log 3N));
+3. re-executes each: epoch `WeakMap` get/set, tracker `Set.clear()` + re-track +
+   re-subscribe (`bindAllCellsToTag`), opcode run (DOM write skipped by
+   `prevPropValue` guard for the N−2 unaffected rows).
+
+So the *only* genuinely O(N) update in the benchmark is **shared-cell
+fan-out**, and per-item tags are not the cause — per-item *subscriptions to a
+shared cell* are. This has a well-known targeted fix (§4.2) that neither
+proposal addresses directly.
+
+### 1.3 Already-optimized paths (for context)
+
+Clear → `fastCleanup` bulk `clearChildren` (O(N) destructors, O(1) DOM);
+append → `_appendOnlyVerdict` incremental path; reorder → LIS with reusable
+buffers; `hasIndex=false` skips per-row index formulas. The remaining hot
+paths are **create / full replace** and **select fan-out**.
+
+---
+
+## 2. Proposal A — "Sliding window of references" (shared render program, swapped context)
+
+Two distinct techniques hide inside this idea. They are separable and have
+very different cost/risk profiles.
+
+### 2.A1 Shared row program + compact per-row frames (million.js-block style)
+
+Compile the each-body once into:
+
+- a static `<template>` (cloned per row with `cloneNode(true)`), and
+- a static **slot table**: `[ {path: [0,1], kind: text}, {path: [0], kind: class}, ... ]`
+  shared by all rows of this list, plus one shared `update(frame, item, shared)`
+  function generated by the compiler;
+- per row, only a **frame**: `{ nodes: Node[k], values: unknown[k], item }` —
+  one object + two arrays instead of 4–6 formulas/Sets/closures + 2 tree
+  identities.
+
+Render = clone + walk paths once to collect slot nodes + run `update`.
+This is exactly the architecture of million.js `block()`, Stage0/domc, ivi
+templates, and Vue Vapor; all sit at the top of js-framework-benchmark
+precisely because create/replace cost collapses to "clone + k slot writes".
+
+**How updates reach a frame without per-binding subscriptions** — that's the
+real design decision, and it's where Proposal B (validation) comes in:
+
+| Dep class | Route |
+|-----------|-------|
+| per-item cell (`cellFor(item,'label')`) | ONE subscription per row (not per binding): cell → frame. Opcode = shared `update` + frame state. Still push, still O(dirty). |
+| shared cell (`selected`) | ONE subscription per **list**. On change, sweep all frames running only the slots that read shared state — tight array loop, no formula machinery, no re-subscription churn. Or better: keyed selector (§4.2) for `===` patterns. |
+| block-param re-bind (keyed reuse with ref swap) | `frame.item = newItem; update(frame)` — subsumes the existing `__gxtRebindEachItem` hook (`list.ts:1323`). |
+
+**What it wins:** per-row reactive-layer allocations drop from ~25–40 to ~4–6
+(frame + 1 cell subscription + marker); create/replace becomes dominated by
+`cloneNode`, which is dramatically cheaper than per-element `createElement` +
+per-attr `setAttribute`. Memory per 10k rows drops by MBs. Destroy gets
+cheaper too (drop one map entry + one subscription instead of a destructor
+cascade over 5-6 closures and two tree identities).
+
+**What it costs / breaks:**
+
+1. **Applicability boundary.** Only "stable" bodies qualify: single-root or
+   fixed-shape DOM, bindings that are attr/class/text/event slots, no nested
+   control flow, no component invocations (or only inlinable ones). The
+   Krausest row qualifies *only if the compiler can inline `<Row/>`* (it is a
+   component with getters, an `...attributes` splat and a modifier). A
+   realistic first milestone is inline-element bodies
+   (`{{#each}}<tr>...</tr>{{/each}}`); component-bodied lists keep the current
+   path. The existing `hasStableChildsForControlNode` detection
+   (`plugins/compiler/serializers/control.ts:204`) is the natural gate.
+2. **A second rendering path to keep correct forever.** `list.ts` is 2083
+   lines of accumulated correctness: duplicate keys, position-qualified keys,
+   re-entry guards, SSR/rehydration, async destructors/animation, HMR,
+   Ember-host hooks (`__gxtRebindEachItem`, marker registry, KVO re-entry).
+   Every one of those behaviors needs an answer in the fast path or an
+   explicit bail-out to the slow path. This is the dominant cost of the
+   proposal — not the runtime code, the *matrix*.
+3. **Events** need delegation or per-row listeners anyway (per-row listener
+   cost stays; delegation is its own project).
+4. **Lifecycle/destructors:** modifiers returning destructors, `{{on}}`
+   teardown — frames must carry an optional destructor list, reintroducing
+   some of RowContext for rows that use them (pay-as-you-go is fine).
+
+**Verdict:** sound and proven architecture; big create/replace win; high
+implementation+maintenance cost. Worth doing **as a compiler-gated fast path
+for stable inline-element bodies only**, after the cheaper wins in §4.
+
+### 2.A2 Row recycling with re-pointable references (the literal "sliding window")
+
+Render N row instances **once**; bindings read through a per-row *holder*
+cell (`Cell<T>`); list changes re-point `holder.value = newItem` instead of
+destroy+create. All subscriptions/opcodes/DOM survive; replace-all becomes
+"swap N references and let push reactivity rewrite k slots per row".
+
+GXT already has 80% of the plumbing: the keyed-reuse re-bind path
+(`boundItemMap` + `__gxtRebindEachItem`, `list.ts:1314-1329`) does exactly
+this for the stale-key case, and morph-retirement (f3c5c30) gives retired-row
+bookkeeping. A retire-pool + re-bind generalization is a small runtime change
+*mechanically*, **but**:
+
+- It changes **keyed semantics**: row DOM identity no longer follows item
+  identity. CSS transitions, focus/selection state, input values, third-party
+  widgets inside rows will bleed across items. js-framework-benchmark would
+  reclassify the implementation as non-keyed if applied by default.
+- Therefore it must be **opt-in** (`{{#each items recycle=true}}` or a
+  `@recycle` arg), like Ember's old `{{#each ... key="@index"}}` pattern or
+  react-window row recycling.
+
+**Verdict:** cheap to prototype, real-world useful for huge lists
+(virtualized tables, log views), must never be the default. Orthogonal to A1
+and composes with it.
+
+---
+
+## 3. Proposal B — "Binary validation" (binary search over hierarchical tags instead of per-item tags)
+
+The idea maps to a known technique: **hierarchical dirty tracking** — a
+balanced tree (segment tree / Fenwick / B-tree of tag combinators) over row
+slots where each node stores `max(childRevision)`. Finding dirty rows =
+descend from the root, skipping clean subtrees: O(d·log N) for d dirty rows.
+This is what pull-based systems effectively do (Glimmer-VM's combinator tags
+validate-and-skip subtrees; Merkle trees in databases; Adapton).
+
+### 3.1 Standalone (replacing the push model for list rows): **net loss**
+
+- Today a label update is O(1) per dirty cell: `tagsToRevalidate.add(cell)` →
+  drain → direct opcode array. No search of any kind happens.
+- With pull validation, the same update needs: bump a row version (requires a
+  cell→row-slot map — the *same* bookkeeping as today's `opsForTag`), then at
+  drain time descend the tree: O(log N) per dirty row **plus** tree
+  maintenance on every insert/remove/reorder (rows move; the tree is over
+  positions, so either remap on reorder or allocate stable leaf slots with a
+  free-list — extra complexity exactly where `list.ts` is already hairy).
+- It also doesn't fix the select fan-out: `selected === id` is a *computation*
+  per row; a validation tree only tells you "row i is dirty", something must
+  still mark all N rows dirty when `selected` changes — or you're back to
+  per-row subscriptions.
+
+So as a replacement for per-item tags *while keeping everything else*, binary
+validation strictly adds work. **Push already beats binary search**: O(d) < O(d·log N).
+
+### 3.2 As a companion to subscription-free frames (A1): **coherent, still probably unnecessary**
+
+If frames (A1) remove per-binding subscriptions, something must route "item X
+changed" to "frame i". Options:
+
+- **(a) keep one push subscription per row** (cell → frame): O(d) updates,
+  ~1 map entry per row. Simple; reuses 100% of existing reactive core.
+- **(b) version-stamped items + segment tree**: zero per-row subscriptions,
+  O(d·log N) discovery, but needs item→slot mapping (a map per row again…),
+  reorder-stable leaf allocation, and a way for `cellFor(item,'label')` to
+  know it should bump a row version instead of scheduling its own opcodes —
+  i.e. a parallel invalidation channel through `Cell.update`.
+
+(b) saves one Map entry + one Set entry per row versus (a) and costs a log
+factor at update plus a new invalidation channel in `reactive.ts`. The
+allocation delta is ~2 of the ~30 per-row allocations. **The win is in the
+noise compared to A1 itself; (a) is the right routing.**
+
+### 3.3 Where a coarse two-level version check *is* worth stealing
+
+One cheap idea from this family fits GXT today: a **per-list epoch guard**.
+`cached()` already uses global/per-cell revisions (`reactive.ts:743`). The
+list-tag formula could snapshot `currentGlobalRevision()` and let `syncList`
+early-exit when re-entered with no possible item-level change (Ember host
+re-fires, KVO echoes). That's a 2-level "validation tree" (root only) — all of
+the benefit that matters for the common case, none of the tree maintenance.
+
+**Verdict:** do not build a binary/segment-tree validation layer. Keep push.
+Adopt only the root-level epoch guard if profiling shows redundant `syncList`
+re-entries.
+
+---
+
+## 4. What I'd actually do, in order of value/risk
+
+1. **Template cloning for static structure** (create-path, all components, not
+   just lists). `src/core` never calls `cloneNode` today; rows are built
+   element-by-element. Compile stable subtrees to a shared `<template>` +
+   `cloneNode(true)` + path-walk to dynamic slots. This is the single biggest
+   create/replace win, requires no reactivity changes, no semantic changes,
+   and it is a prerequisite shared with Proposal A1 anyway. (Vue Vapor, ivi,
+   Solid all do this.)
+2. **Keyed selector primitive** (update-path): a `selectorFor(listCell|cell, key)`
+   à la Solid's `createSelector` — `Map<id, Cell<boolean>>`; on `selected`
+   change only the old+new ids' cells dirty. Kills the 3N-formula fan-out →
+   O(2). Compiler can pattern-match `{{eq @selected item.id}}`-shaped
+   bindings, or it's exposed as a userland helper first. Small, isolated,
+   high leverage; also removes the 3N re-subscription churn per select
+   (`relatedTags` delete/re-add cycle in the drain).
+3. **Slim the per-row ownership overhead** (create/destroy path, no new
+   architecture):
+   - lazy `rowBodyCtx` — allocate RowContext only when the body actually
+     registers destructors (today it's unconditional, `list.ts:1279`);
+   - single tree identity per row — let RowContext *be* the component's tree
+     node for single-component bodies instead of two `cId()`/`addToTree`
+     rounds;
+   - pool RowContext objects (morph-retirement already gives the lifecycle
+     hooks).
+4. **A1 fast path for stable inline-element each-bodies** (the "sliding
+   window" proper): shared slot-program + per-row frames, gated by the
+   existing stable-children compiler detection, bailing to the current path
+   for everything exotic. Reuses (1) and routes updates per §2.A1. Large
+   effort; do after 1–3 and only with the e2e matrix (dup keys, SSR,
+   rehydration, async destructors, HMR, Ember host) green on the bail-out
+   boundary.
+5. **Opt-in row recycling** (`recycle=true`): generalize
+   `boundItemMap`/`__gxtRebindEachItem` re-bind + retire-pool. Never default,
+   document the identity caveats.
+6. **Skip:** segment-tree/binary validation as an invalidation mechanism
+   (§3.1/3.2). Keep the push model; optionally add the root-level epoch guard
+   (§3.3).
+
+### Expected impact (rough, per 1k-row create)
+
+| Change | Reactive-layer allocs/row | DOM build | Select cost |
+|---|---|---|---|
+| today | ~25–40 | ~10× `createElement` + ~15× `setAttribute` | O(3N) formulas |
+| +cloning (1) | ~25–40 | 1× `cloneNode` + k slot writes | O(3N) |
+| +selector (2) | ~25–40 | — | **O(2)** |
+| +slim ctx (3) | ~15–25 | — | O(2) |
+| +frames (4) | **~4–6** | 1× `cloneNode` | O(2) |
+
+---
+
+## 5. Appendix — Measured results (experiments run 2026-06-10)
+
+All six proposals were prototyped in parallel git worktrees branched from
+`exp/perf-baseline` (= this branch's HEAD + a shared harness,
+`src/core/list-perf.bench.test.ts`: Krausest-shaped `{{#each}}` rendered via
+the runtime compiler, happy-dom, median of 5 rounds). Numbers below are the
+manager's **serial re-runs on an idle machine** (agent self-reports on the
+loaded box were discarded where they didn't replicate). Experiment branches: `exp/perf-baseline` (harness), `exp/e1-selector`,
+`exp/e2-slim-ctx`, `exp/e3-recycle`, `exp/e4-clone`, `exp/e5-frames`,
+`exp/e6-binary-validation` (local worktrees). Full suite (3792 tests) green on every branch; the only
+failing file everywhere incl. baseline is the pre-existing
+`glint-environment-gxt` collect error (missing sub-package `common-tags`).
+
+Idle baseline (ms): create1k 239.7 · update10th 1.53 · select20 38.45 ·
+append1k 277.5 · replace1k 579.5 · clear1k 128.5 · create5k 3749.9.
+
+| Experiment | Headline (verified) | Verdict |
+|---|---|---|
+| E1 `keyedSelector` (`src/core/selector.ts`, commit 7cace71) | select20 38.45→**23.97** (reactive work ≈−80%; residual is the harness settle floor); create1k +2% (per-key Cell alloc) | **Land** after adding a key-pruning hook tied to row teardown |
+| E2 slim row ownership (commit 158557c) | All scenarios **within noise** of baseline — the agent's loaded-machine −24% claims did not replicate | Architectural cleanup only (lazy CHILD membership, removes redundant per-row destructor closure); don't sell as perf |
+| E3 opt-in recycling `key="@recycle"` (commit 99a4fbb) | replaceAll1k **16.25 vs 579.5 (35.7×)** · recreate-from-pool −48% · clear −39% · update10th parity · **select20 +31%** (holder-cell entanglement) · default path untouched | Powerful but sharp-edged: strictly opt-in (non-keyed semantics, state bleed); the select regression needs holder-dep exclusion for shared-dep bindings |
+| E4 cloneNode static block (`src/core/static-template.ts`, commit 2b56259) | create1k 240.4→**48.8 (4.9×)** with identical reactivity; Chromium raw-DOM check: native clone vs createElement only ~15% apart — the win is *skipping per-element framework work* | Confirms research §4.1; prerequisite shared with E5 |
+| E5 frames / sliding window (`src/core/frame-list.ts`, commit 46440dd) | create1k **65.1 (3.7×)** · replace1k **73.3 (7.9×)** · clear1k **10.7 (12×)** · select20 24.0 (1.6× via list-level sweep) · update10th parity (push already O(dirty), as predicted §1) | **The architecture to pursue** as a compiler-gated fast path for stable inline-element bodies |
+| E6 segment-tree validation (commit 6d188d7) | §3.1's micro-claim **partially refuted**: flat typed-array constants invert the asymptotics — setup 228× cheaper than real push wiring, drains tie at d≤10 and win 3–16× at d≥100; push only wins reorder. Architectural caveat stands: bench gets the row index free; cell→row routing re-requires per-row bookkeeping, so still not a drop-in. Bonus finding: **pushReal is 4–6× slower than a minimal push model** — GXT's own drain bookkeeping (dirty-set sort, relatedTags churn, epoch WeakMap) is a standalone optimization target | Don't build as invalidation replacement; revisit as the dirty-routing channel if/when frames (E5) land; fix drain overhead regardless |
+
+Revised landing order based on evidence: **(1)** E4+E5 (one project: static
+template + frame fast path) — the create/replace/clear collapse is the
+dominant win and survived clean measurement; **(2)** E1 selector with key
+pruning; **(3)** drain-overhead diet motivated by E6 (pushReal vs pushMinimal
+gap); **(4)** E3 recycling as a documented opt-in for replace-heavy
+scenarios; **(5)** E2 as cleanup-only refactor; **skip** standalone binary
+validation (unchanged from §3, now with numbers).
+
+## 6. Prior art quick-reference
+
+- **Glimmer-VM**: pull validation over tag combinators — what "binary
+  validation" generalizes; GXT deliberately moved *away* from this to push.
+- **million.js `block()` / Stage0 / domc / ivi / Vue Vapor**: compile-to-clone
+  + slot tables + per-instance frames — Proposal A1.
+- **SolidJS `createSelector`**: keyed selector for `selected === id` fan-out —
+  §4.2.
+- **Svelte 5 each blocks**: per-item effect scopes (closer to GXT today) but
+  with template cloning for statics — supports doing (1) before (4).
+- **react-window / Ember list-view lineage**: row recycling semantics and its
+  keyed-identity caveats — Proposal A2.

--- a/plugins/compiler/serializers/control.ts
+++ b/plugins/compiler/serializers/control.ts
@@ -13,6 +13,12 @@ import { SYMBOLS } from './symbols';
 import { buildValue } from './value';
 import { B, serializeJS, type JSExpression, type JSStatement } from '../builder';
 
+// Sentinel each-key that opts a block into row recycling. Mirrors RECYCLE_KEY
+// in src/core/control-flow/list-recycle.ts (no cross-boundary import: plugins
+// must not pull runtime modules). Detected at compile time so the recycle
+// runtime stays tree-shakable — see buildEach.
+const RECYCLE_KEY = '@recycle';
+
 // Forward declarations - set from index.ts to avoid circular dependency
 let buildChildrenExprs: (ctx: CompilerContext, children: readonly HBSChild[], ctxName: string) => JSExpression[];
 let nextCtxName: (ctx: CompilerContext) => string;
@@ -198,7 +204,24 @@ function buildEach(
   // Async iteration is the correct default; opt-in `sync=true` on the
   // block (e.g. `{{#each items sync=true as |item|}}`) keeps the
   // synchronous-teardown variant available for hosts that need it.
-  const fnName = control.isSync ? SYMBOLS.EACH_SYNC : SYMBOLS.EACH;
+  //
+  // Opt-in row recycling: `key="@recycle"` routes through the dedicated
+  // `$_eachRecycled` / `$_eachSyncRecycled` entry points (src/core/
+  // control-flow/list-recycle.ts) instead of `$_each` / `$_eachSync`.
+  // Resolving the sentinel at COMPILE time keeps the ~400-line recycle
+  // runtime tree-shakable: apps that never use key="@recycle" never import
+  // the recycled entry points, so bundlers drop the module entirely; the
+  // list classes themselves carry only a tiny dispatch hook. The runtime
+  // entry points accept the same positional args (the key slot is ignored —
+  // recycled rows are positional).
+  const isRecycled = eachKey === RECYCLE_KEY;
+  const fnName = isRecycled
+    ? control.isSync
+      ? SYMBOLS.EACH_SYNC_RECYCLED
+      : SYMBOLS.EACH_RECYCLED
+    : control.isSync
+      ? SYMBOLS.EACH_SYNC
+      : SYMBOLS.EACH;
 
   // Check for stable children
   const hasStable = hasStableChildsForControlNode(control.children);

--- a/plugins/compiler/serializers/symbols.ts
+++ b/plugins/compiler/serializers/symbols.ts
@@ -20,6 +20,10 @@ export const SYMBOLS = {
   IF: '$_if',
   EACH: '$_each',
   EACH_SYNC: '$_eachSync',
+  // Opt-in row recycling (key="@recycle") — dedicated entry points so the
+  // recycle runtime module stays tree-shakable (list-recycle.ts).
+  EACH_RECYCLED: '$_eachRecycled',
+  EACH_SYNC_RECYCLED: '$_eachSyncRecycled',
   SLOT: '$_slot',
   IN_ELEMENT: '$_inElement',
 
@@ -199,6 +203,8 @@ export const PURE_FUNCTIONS: ReadonlySet<string> = new Set([
   SYMBOLS.IF,                     // $_if
   SYMBOLS.EACH,                   // $_each
   SYMBOLS.EACH_SYNC,              // $_eachSync
+  SYMBOLS.EACH_RECYCLED,          // $_eachRecycled
+  SYMBOLS.EACH_SYNC_RECYCLED,     // $_eachSyncRecycled
   SYMBOLS.SLOT,                   // $_slot
 
   // Built-in helpers (subexpressions)

--- a/plugins/runtime-compiler.ts
+++ b/plugins/runtime-compiler.ts
@@ -83,6 +83,14 @@ import {
 
 // Import reactive primitives for Ember integration
 import { cellFor, formula, cell, tagsToRevalidate, cellsMap } from '../src/core/reactive';
+
+// Opt-in row recycling entry points (key="@recycle"). Live in a dedicated
+// module so they stay tree-shakable for compiled-ahead apps; the runtime
+// compiler must still expose them for runtime-compiled templates.
+import {
+  $_eachRecycled,
+  $_eachSyncRecycled,
+} from '../src/core/control-flow/list-recycle';
 import { effect } from '../src/core/vm';
 import { syncDom } from '../src/core/runtime';
 import { ensureReactiveCollectionsPatched } from '../src/core/reactive-collections';
@@ -110,6 +118,8 @@ export const GXT_RUNTIME_SYMBOLS = {
   $_if,
   $_each,
   $_eachSync,
+  $_eachRecycled,
+  $_eachSyncRecycled,
   $_slot,
   $_edp,
   $_args,

--- a/plugins/symbols.ts
+++ b/plugins/symbols.ts
@@ -7,6 +7,10 @@ export const SYMBOLS = {
   IF: '$_if',
   EACH: '$_each',
   EACH_SYNC: '$_eachSync',
+  // Opt-in row recycling (key="@recycle") — emitted by the compiler instead
+  // of EACH/EACH_SYNC so the recycle runtime stays tree-shakable.
+  EACH_RECYCLED: '$_eachRecycled',
+  EACH_SYNC_RECYCLED: '$_eachSyncRecycled',
   SLOT: '$_slot',
   EMPTY_DOM_PROPS: '$_edp',
   ARGS: '$_args',

--- a/src/components/pages/Benchmark.gts
+++ b/src/components/pages/Benchmark.gts
@@ -5,7 +5,13 @@ import {
   type Item,
 } from '@/core/benchmark/data';
 import { Component } from '@lifeart/gxt';
-import { tracked, cellFor, type Cell } from '@lifeart/gxt';
+import {
+  tracked,
+  cellFor,
+  keyedSelector,
+  type Cell,
+  type KeyedSelector,
+} from '@lifeart/gxt';
 import { Header } from './benchmark/Header.gts';
 import { Row } from './benchmark/Row.gts';
 
@@ -35,6 +41,15 @@ export class Benchmark extends Component {
   set selected(value: number) {
     this._selected = value;
   }
+  // Keyed selector over the selected row id: each Row subscribes to its OWN
+  // per-id boolean cell instead of the shared `_selected` cell, so a selection
+  // change re-runs O(2) row bindings instead of O(rows). Keyed {{#each}}
+  // semantics are untouched — this only rewires the fan-out.
+  rowSelected: KeyedSelector<number> = keyedSelector(
+    () => this._selected,
+    this,
+    'benchmark.selected',
+  );
   rootNode!: HTMLElement;
   removeItem = (item: Item) => {
     this._items = this._items.filter((i) => i.id !== item.id);
@@ -103,7 +118,7 @@ export class Benchmark extends Component {
               <Row
                 @item={{item}}
                 @onSelect={{this.onSelect}}
-                @selected={{this.selected}}
+                @isSelected={{this.rowSelected}}
                 @onRemove={{this.removeItem}}
               />
             {{/each}}

--- a/src/components/pages/benchmark/Row.gts
+++ b/src/components/pages/benchmark/Row.gts
@@ -1,12 +1,12 @@
 import { RemoveIcon } from './RemoveIcon.gts';
 import type { Item } from '@/core/benchmark/data';
 import { Component } from '@lifeart/gxt';
-import { type Cell, cellFor, formula } from '@lifeart/gxt';
+import { cellFor, formula } from '@lifeart/gxt';
 
 type RowArgs = {
   Args: {
     item: Item;
-    selected: number | Cell<number>;
+    isSelected: (id: number) => boolean;
     onRemove: (item: Item) => void;
     onSelect: (item: Item) => void;
   };
@@ -42,12 +42,9 @@ export class Row extends Component<RowArgs> {
     return this.args.item.id;
   }
   get isSelected() {
-    const selected = this.args.selected;
-    if (IS_GLIMMER_COMPAT_MODE) {
-      return (selected as unknown as number) === this.id;
-    } else {
-      return (selected as unknown as Cell<number>).value === this.id;
-    }
+    // Tracked read of THIS row's keyed-selector cell — the row's class
+    // bindings subscribe per-id instead of to the shared selected cell.
+    return this.args.isSelected(this.id);
   }
   get className() {
     if (IS_GLIMMER_COMPAT_MODE) {

--- a/src/core/__test-utils__/list-harness.ts
+++ b/src/core/__test-utils__/list-harness.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared helpers for the list perf harness and its derived benches/tests
+ * (list-perf.bench.test.ts, list-perf.recycle.bench.test.ts,
+ * control-flow/list.recycle.test.ts).
+ *
+ * The perf-harness contract is "identical methodology across variants" —
+ * timing, item shape and the mount ritual live HERE so the files can't drift
+ * apart silently. Variants differ only in their template string and scenario
+ * list.
+ */
+import { Component } from '../component';
+import { RENDERED_NODES_PROPERTY, addToTree } from '../shared';
+import { $_c, $_args, $_edp } from '../dom';
+import { cellFor } from '../reactive';
+import { renderElement } from '../render-core';
+import {
+  setupGlobalScope,
+  GXT_RUNTIME_SYMBOLS,
+} from '../../../plugins/runtime-compiler';
+import type { DOMFixture } from './index';
+
+export interface HarnessItem {
+  id: number;
+  label: string;
+}
+
+let nextItemId = 1;
+
+/**
+ * Build benchmark items. Each gets a cell-backed `label` accessor
+ * (replicating the Krausest Row's `cellFor(item,'label')` getter) so
+ * `item.label = x` routes through `Cell.update`.
+ */
+export function buildItems(count: number, labelFor?: (i: number) => string): HarnessItem[] {
+  const data: HarnessItem[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = nextItemId++;
+    const item: HarnessItem = {
+      id,
+      label: labelFor ? labelFor(i) : `item ${id} body`,
+    };
+    cellFor(item, 'label');
+    data.push(item);
+  }
+  return data;
+}
+
+/** Drain the microtask-scheduled syncDom. */
+export const settle = () => new Promise<void>((r) => setTimeout(r, 0));
+
+export async function timed(fn: () => void | Promise<void>): Promise<number> {
+  const start = performance.now();
+  await fn();
+  await settle();
+  return performance.now() - start;
+}
+
+export const median = (xs: number[]) =>
+  [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+
+/**
+ * Install the runtime-compiler globals. Call from beforeEach (after
+ * createDOMFixture) — `template()`-compiled classes resolve `$_tag` & co.
+ * from globalThis at render time.
+ */
+export function setupRuntimeTemplateGlobals(): void {
+  setupGlobalScope();
+  const g = globalThis as Record<string, unknown>;
+  Object.entries(GXT_RUNTIME_SYMBOLS).forEach(([name, value]) => {
+    g[name] = value;
+  });
+}
+
+/**
+ * Mount a `template()`-based root component into the fixture container and
+ * return the instance. Encapsulates the instance-capture trick: `$_c` returns
+ * the render output, not the instance, so we capture `this` via a subclass.
+ */
+export function mountRoot<T extends Component<any>>(
+  fixture: DOMFixture,
+  RootClass: new (args: any) => T,
+): T {
+  const parentComponent = new Component({});
+  (parentComponent as any)[RENDERED_NODES_PROPERTY] = [];
+  addToTree(fixture.root, parentComponent);
+  let instance!: T;
+  class Probe extends (RootClass as new (args: any) => Component<any>) {
+    constructor(args: any) {
+      super(args);
+      instance = this as unknown as T;
+    }
+  }
+  const rendered = $_c(
+    Probe as any,
+    $_args({}, false, $_edp as any),
+    parentComponent,
+  );
+  renderElement(fixture.api, parentComponent, fixture.container, rendered);
+  return instance;
+}

--- a/src/core/__test-utils__/list-harness.ts
+++ b/src/core/__test-utils__/list-harness.ts
@@ -4,16 +4,17 @@
  * control-flow/list.recycle.test.ts).
  *
  * The perf-harness contract is "identical methodology across variants" —
- * timing, item shape and the mount ritual live HERE so the files can't drift
- * apart silently. Variants differ only in their template string and scenario
- * list.
+ * timing, item shape, the root component and the mount ritual live HERE so
+ * the files can't drift apart silently. Variants differ only in the each key
+ * and their scenario list.
  */
 import { Component } from '../component';
-import { RENDERED_NODES_PROPERTY, addToTree } from '../shared';
+import { RENDERED_NODES_PROPERTY, addToTree, $template } from '../shared';
 import { $_c, $_args, $_edp } from '../dom';
 import { cellFor } from '../reactive';
 import { renderElement } from '../render-core';
 import {
+  template,
   setupGlobalScope,
   GXT_RUNTIME_SYMBOLS,
 } from '../../../plugins/runtime-compiler';
@@ -43,6 +44,45 @@ export function buildItems(count: number, labelFor?: (i: number) => string): Har
     data.push(item);
   }
   return data;
+}
+
+/**
+ * The Krausest-shaped bench root: one static-ish <tr> per item, a reactive
+ * text binding (per-item label cell) and two bindings on the shared
+ * `_selected` cell (the select fan-out path). `eachKey` is the only variant
+ * knob — `"id"` for the keyed harness, `"@recycle"` for the recycling one.
+ */
+export function defineBenchRoot(eachKey: string): new (args: any) => Component<any> & {
+  _items: HarnessItem[];
+  _selected: number;
+  readonly items: HarnessItem[];
+} {
+  const LIST_TEMPLATE = `
+    <table><tbody>
+      {{#each this.items key="${eachKey}" as |item|}}
+        <tr class={{this.rowClass item.id}}>
+          <td>{{item.id}}</td>
+          <td><a class={{this.rowClass item.id}}>{{item.label}}</a></td>
+          <td><span>x</span></td>
+        </tr>
+      {{/each}}
+    </tbody></table>
+  `;
+  class BenchRoot extends Component {
+    _items: HarnessItem[] = [];
+    _selected = 0;
+    constructor(args: any) {
+      super(args);
+      cellFor(this as any, '_items');
+      cellFor(this as any, '_selected');
+    }
+    get items() {
+      return this._items;
+    }
+    rowClass = (id: number) => (this._selected === id ? 'danger' : '');
+    [$template] = template(LIST_TEMPLATE);
+  }
+  return BenchRoot as any;
 }
 
 /** Drain the microtask-scheduled syncDom. */

--- a/src/core/control-flow/list-recycle.ts
+++ b/src/core/control-flow/list-recycle.ts
@@ -1,0 +1,528 @@
+/**
+ * Opt-in row recycling — "sliding window of references"
+ * (reference-swap variant; RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A2).
+ *
+ * Opt-in surface: `{{#each items key="@recycle" as |item|}}`. The compiler
+ * (plugins/compiler/serializers/control.ts buildEach) detects the sentinel key
+ * at COMPILE time and emits `$_eachRecycled` / `$_eachSyncRecycled` instead of
+ * `$_each` / `$_eachSync`. That keeps this entire module TREE-SHAKABLE: apps
+ * that never write key="@recycle" never import these entry points, so a
+ * bundler drops the ~400 lines of recycle machinery from the shipped bundle.
+ * Apps that do use it pay automatically — no manual setup.
+ *
+ * Activation channel: the entry points construct the regular list classes and
+ * thread `syncRecycle` through `ListComponentArgs.recycle`; the list keeps
+ * only a tiny nullable `recycleImpl` dispatch hook checked in `syncList`
+ * (see list.ts). Per-list recycle STATE lives here, in a WeakMap keyed by the
+ * list instance — list.ts carries zero recycle fields.
+ *
+ * NOTE: constructing a list class DIRECTLY with `key: '@recycle'` (without
+ * these entry points) now treats '@recycle' as a property-name key — the
+ * dev-mode "Key for item not found" guard surfaces the misuse. Template users
+ * are unaffected: the compiler routes `key="@recycle"` here.
+ *
+ * Semantics (INTENTIONALLY different from keyed {{#each}}):
+ *   - Rows are reused strictly by POSITION, never by key. Row DOM identity
+ *     does NOT follow item identity (non-keyed in js-framework-benchmark
+ *     terms). Focus/selection/input state, CSS transitions and third-party
+ *     widget state inside a row BLEED across items on replace.
+ *   - The block param the body renders against is NOT the raw item: it is a
+ *     stable per-row STATE object whose property reads forward through a
+ *     re-pointable holder `Cell<T>` to the currently-bound item. So `item`
+ *     inside the body has a different object identity than the array element
+ *     (`===` against raw items, or passing the block param to code that
+ *     mutates/compares identities, will not behave like keyed mode).
+ *   - A list replace becomes "swap N holder references"; push reactivity
+ *     re-runs only the k bindings per row. All subscriptions, opcodes and
+ *     DOM survive — no destroy/create.
+ *   - Shrinking retires trailing rows into a pool (DOM detached into a
+ *     per-row fragment; subscriptions stay LIVE — a shared-cell fan-out,
+ *     e.g. `selected`, still re-runs pooled rows' formulas against detached
+ *     DOM). Growth re-inserts pooled rows (re-bind + one fragment insert)
+ *     before building new ones. The pool is capped (RECYCLE_POOL_LIMIT);
+ *     overflow rows get real teardown so a one-off size spike doesn't pin
+ *     memory and per-update CPU to the historical maximum forever.
+ *
+ * Reactivity routing: a body binding evaluating `state.prop` reads
+ * (1) `holder.value` — entangling with the per-row holder cell (the
+ * reference swap channel), and (2) `item.prop` through the raw item's own
+ * accessor — so `cellFor(item, 'prop')`-backed items keep their fine-grained
+ * push path (`item.label = x` still updates exactly that row's binding).
+ *
+ * Known limitations (acceptable for an opt-in mode, documented here so they
+ * are decisions rather than surprises):
+ *   - object items only (dev-mode warning otherwise);
+ *   - inverse (else) teardown is synchronous even under AsyncListComponent —
+ *     async element/modifier destructors on inverse content are not awaited;
+ *   - dev-mode HMR swaps row components by walking `keyMap`, which recycling
+ *     doesn't populate — hot-reloading a recycled row body needs a full reload;
+ *   - rehydration falls back to the default keyed path (see entry points).
+ */
+
+import type { Component, ComponentReturnType } from '@/core/component-class';
+import type { ComponentLike, DOMApi } from '@/core/types';
+import { renderElement } from '@/core/render-core';
+import {
+  Cell,
+  type MergedCell,
+  // Recycle-mode reference swaps happen INSIDE the drain (the list-tag opcode
+  // runs from syncDomSync), where a plain Cell.update() is dropped by the
+  // drain's terminal tagsToRevalidate.clear(). applyCellUpdateSync is the
+  // drain-safe path: direct mutate + synchronous subscriber flush.
+  applyCellUpdateSync,
+} from '@/core/reactive';
+import { initDOM } from '@/core/context';
+import { isRehydrationScheduled } from '@/core/ssr/rehydration';
+import { setParentContext } from '@/core/tracking';
+import { $_each, $_eachSync, $_fin } from '@/core/dom';
+import {
+  AsyncListComponent,
+  SyncListComponent,
+  type BasicListComponent,
+  type InverseFn,
+} from './list';
+
+type GenericReturnType = Array<ComponentLike | Node> | ComponentLike | Node;
+
+export const RECYCLE_KEY = '@recycle';
+
+// Retired rows kept for reuse. Beyond this, shrink tears rows down for real:
+// pooled rows keep live subscriptions (shared-cell changes re-execute their
+// formulas against detached DOM), so an unbounded pool would tax every later
+// update with the list's historical maximum size.
+const RECYCLE_POOL_LIMIT = 256;
+
+type RecycledRow<T> = {
+  /** Stable per-row state object the body rendered against (the block param). */
+  state: T;
+  /** Re-pointable reference every `state.*` read routes through. */
+  holder: Cell<T>;
+  /** Props with forwarding accessors materialized on `state`. */
+  props: Set<string>;
+  /** Raw item currently bound (ref-compare fast path for no-op rebinds). */
+  boundItem: T;
+  /** Row top boundary; DOM extent = [marker, nextRowMarker | bottomMarker). */
+  marker: Comment;
+  /** Position-independent internal key (rowCtxMap / teardown bookkeeping). */
+  key: string;
+  /** Reactive index cell — only allocated when the body reads `{{index}}`. */
+  indexCell: Cell<number> | null;
+  /** Holds the row's detached DOM while pooled; reused across retire cycles. */
+  fragment: DocumentFragment | null;
+};
+
+/**
+ * Structural view of the list-instance members the recycle functions touch.
+ * `rowBodyCtx`/`destroyRowCtx` are `protected` on BasicListComponent, so the
+ * dispatch entry casts the instance to this interface; everything stays on
+ * the existing list machinery (per-row destructor-owner ctxs, marker
+ * registry, inverse rendering).
+ */
+interface RecycleHost<T> {
+  api: DOMApi;
+  bottomMarker: Comment;
+  markerSet: Set<Comment>;
+  hasIndex: boolean;
+  inverseFn: InverseFn | null;
+  inverseContent: GenericReturnType | null;
+  ItemComponent(
+    item: T,
+    index: number | MergedCell,
+    ctx: Component<any>,
+  ): GenericReturnType;
+  rowBodyCtx(key: string): ComponentLike;
+  destroyRowCtx(key: string): void;
+  destroyInverseSync(): void;
+  renderInverse(): void;
+}
+
+/**
+ * Per-list recycle state, lazily created on first dispatch. Keyed by the list
+ * instance in a module-level WeakMap so the list class carries ZERO recycle
+ * fields and the state is GC'd with the list.
+ */
+type RecycleState<T> = {
+  active: Array<RecycledRow<T>>;
+  pool: Array<RecycledRow<T>>;
+  /** Monotonic per-list row-key sequence (`@r0`, `@r1`, ...). */
+  seq: number;
+  /** True while syncRecycle is applying items; see the guard in syncRecycle. */
+  syncInProgress: boolean;
+};
+
+const RECYCLE_STATES: WeakMap<object, RecycleState<any>> = new WeakMap();
+
+// ==========================================================================
+// Row recycling — positional sync (see RECYCLE_KEY docs above).
+// Installed as the list's `recycleImpl` dispatch hook; replaces the whole
+// keyed diff:
+//   - overlapping positions: swap each row's holder reference (re-bind);
+//   - shrink: retire trailing rows into the pool (DOM detached, alive);
+//   - growth: re-insert + re-bind pooled rows first, then build new rows.
+// Fully synchronous — no destroy cascades in steady state. Real teardown
+// (opcode unsubscription, rowCtx destruction) only happens when the LIST
+// itself is destroyed, via the existing TREE cascade over rowCtxMap.
+// ==========================================================================
+export function syncRecycle<T extends { id: number }>(
+  list: BasicListComponent<T>,
+  items: T[],
+): void {
+  let state = RECYCLE_STATES.get(list) as RecycleState<T> | undefined;
+  if (state === undefined) {
+    state = { active: [], pool: [], seq: 0, syncInProgress: false };
+    RECYCLE_STATES.set(list, state);
+  }
+  // Re-entry guard, shared by the Sync and Async subclasses: a holder flush
+  // can run host code that synchronously mutates the source array, and a
+  // nested syncRecycle would corrupt active/pool while the outer pass is
+  // still iterating. The outer call already applies the current tag value;
+  // nested calls are safe to drop.
+  if (state.syncInProgress) return;
+  state.syncInProgress = true;
+  try {
+    syncRecycleInner(list as unknown as RecycleHost<T>, state, items);
+  } finally {
+    state.syncInProgress = false;
+  }
+}
+
+function syncRecycleInner<T>(
+  host: RecycleHost<T>,
+  state: RecycleState<T>,
+  items: T[],
+): void {
+  const api = host.api;
+  const { active, pool } = state;
+  const { bottomMarker } = host;
+  if (items.length > 0 && host.inverseContent !== null) {
+    host.destroyInverseSync();
+  }
+  const prevCount = active.length;
+  const nextCount = items.length;
+  const shared = prevCount < nextCount ? prevCount : nextCount;
+  // 1) Overlapping positions: the reference swap. Push reactivity re-runs
+  //    the k bindings of each row whose holder actually changed.
+  for (let i = 0; i < shared; i++) {
+    rebindRecycledRow(active[i], items[i], i);
+  }
+  if (nextCount > prevCount) {
+    // 2) Growth. ALL new/reused rows are appended IN ORDER into a single
+    //    detached batch fragment (append-only — no per-row anchor scans),
+    //    then moved into the live DOM with ONE insertBefore(bottomMarker).
+    const batch = api.fragment();
+    let index = prevCount;
+    // 2a) Reuse pooled rows: one fragment re-insert + one reference swap.
+    while (index < nextCount && pool.length > 0) {
+      const rec = pool.pop()!;
+      api.insert(batch, rec.fragment!);
+      rebindRecycledRow(rec, items[index], index);
+      active.push(rec);
+      index++;
+    }
+    // 2b) Build brand-new rows for the remainder. `buildRecycledRow`
+    // resolves the insert parent via `api.parent(targetNode)`, and a bare
+    // DocumentFragment has NO parent — so (mirroring `getTargetNode(0)`)
+    // give the batch a tail marker to act as the in-fragment anchor, and
+    // drop it once the batch lands in the live DOM.
+    if (index < nextCount) {
+      const batchTail = IS_DEV_MODE
+        ? api.comment('recycle batch tail')
+        : api.comment();
+      api.insert(batch, batchTail);
+      const self = host as unknown as ComponentLike;
+      setParentContext(self);
+      for (; index < nextCount; index++) {
+        active.push(buildRecycledRow(host, state, items[index], index, batchTail));
+      }
+      setParentContext(null);
+      api.destroy(batchTail);
+    }
+    api.insert(api.parent(bottomMarker)!, batch, bottomMarker);
+  } else if (nextCount < prevCount) {
+    // 3) Shrink: retire trailing rows into the pool. Iterate forward so each
+    //    row's end boundary (the NEXT row's marker) is still connected when
+    //    we detach its extent.
+    for (let i = nextCount; i < prevCount; i++) {
+      const rec = active[i];
+      const end: Node = i + 1 < prevCount ? active[i + 1].marker : bottomMarker;
+      retireRecycledRow(host, rec, end);
+      if (pool.length < RECYCLE_POOL_LIMIT) {
+        pool.push(rec);
+      } else {
+        destroyRecycledRow(host, rec);
+      }
+    }
+    active.length = nextCount;
+  }
+  if (nextCount === 0 && host.inverseFn) {
+    host.renderInverse();
+  }
+}
+
+/**
+ * Real teardown for a retired row that exceeds the pool cap: unsubscribe its
+ * binding opcodes (rowCtx cascade), unregister its boundary marker, and drop
+ * the fragment so the detached DOM becomes collectable. Mirrors what list
+ * destruction would eventually do for pooled rows, just eagerly.
+ */
+function destroyRecycledRow<T>(host: RecycleHost<T>, rec: RecycledRow<T>): void {
+  host.destroyRowCtx(rec.key);
+  host.markerSet.delete(rec.marker);
+  const _unreg = (
+    globalThis as { __gxtUnregisterListMarker?: (m: Comment) => void }
+  ).__gxtUnregisterListMarker;
+  if (_unreg) _unreg(rec.marker);
+  rec.fragment = null;
+}
+
+/**
+ * Re-point a recycled row at `item` (the actual "swap one reference" op).
+ * No-ops when the row is already bound to the same object reference —
+ * which also keeps same-ref correctness: any in-place item mutation routed
+ * through `cellFor(item, prop)` stayed subscribed the whole time.
+ */
+function rebindRecycledRow<T>(rec: RecycledRow<T>, item: T, index: number): void {
+  // applyCellUpdateSync (not Cell.update + manual flush): update() defers to
+  // the host _cellUpdateDeferralHook when one is installed, which would
+  // leave `_value` stale while we synchronously re-execute subscribers.
+  if (rec.indexCell !== null) {
+    applyCellUpdateSync(rec.indexCell, index);
+  }
+  if (rec.boundItem === item) {
+    return;
+  }
+  rec.boundItem = item;
+  // Heterogeneous item shapes: materialize forwarding accessors for any
+  // prop this row hasn't seen yet. Homogeneous case = one Set.has per prop.
+  defineRecycledStateProps(rec.state, rec.holder, item, rec.props);
+  // The reference swap: every body binding that read `state.*` is
+  // subscribed to `holder` and re-evaluates against the new item (also
+  // re-entangling with the NEW item's own cellFor-backed accessors).
+  applyCellUpdateSync(rec.holder, item);
+}
+
+/**
+ * Define forwarding accessors on the row's state object for every own
+ * enumerable prop of `item` not yet materialized. Reads route through the
+ * holder cell (reference-swap subscription) AND the raw item's accessor
+ * (fine-grained per-item cell push, e.g. `cellFor(item,'label')`). Writes
+ * forward to the currently-bound item.
+ *
+ * Forwarded props are everything `for..in` reaches: own enumerable props
+ * AND enumerable prototype accessors (legacy `@tracked` installs enumerable
+ * prototype getters — filtering to own props would render tracked class
+ * items blank). Non-enumerable prototype members (regular class methods/
+ * getters) are not forwarded.
+ *
+ * Limitation (documented): props that exist on NO item bound so far have no
+ * accessor, so a body read of them returns undefined without holder
+ * entanglement. Items with a stable shape — the recycling use case — are
+ * unaffected.
+ */
+function defineRecycledStateProps<T>(
+  state: T,
+  holder: Cell<T>,
+  item: T,
+  props: Set<string>,
+): void {
+  if (item === null || typeof item !== 'object') {
+    // The state-object indirection forwards PROPERTY reads; a primitive item
+    // has nothing to forward, so the body would render the empty state
+    // object instead of the value. Recycling is documented as object-items
+    // only — surface the misuse instead of rendering garbage.
+    if (IS_DEV_MODE) {
+      console.warn(
+        `key="@recycle" requires object items; got ${item === null ? 'null' : typeof item} — the row body will not see this value`,
+      );
+    }
+    return;
+  }
+  for (const prop in item) {
+    if (props.has(prop)) continue;
+    props.add(prop);
+    Object.defineProperty(state, prop, {
+      get() {
+        return (holder.value as Record<string, unknown>)[prop];
+      },
+      set(v: unknown) {
+        (holder.value as Record<string, unknown>)[prop] = v;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+}
+
+/**
+ * Build a fresh recycled row at `index`, rendered against a stable state
+ * object + holder cell instead of the raw item. Inserted before
+ * `targetNode` (bottomMarker, or the batched fill fragment's marker).
+ */
+function buildRecycledRow<T>(
+  host: RecycleHost<T>,
+  state: RecycleState<T>,
+  item: T,
+  index: number,
+  targetNode: Node,
+): RecycledRow<T> {
+  const api = host.api;
+  const key = `@r${state.seq++}`;
+  const marker = IS_DEV_MODE
+    ? api.comment(`recycle row ${key}`)
+    : api.comment();
+  // Same contract as keyed per-item markers: track in markerSet (the list
+  // destructor's unregister loop walks it) and tell the host registry the
+  // comment is load-bearing — Ember's artifact stripper prunes unregistered
+  // empty comments, which would orphan the row's retire boundary.
+  host.markerSet.add(marker);
+  const _reg = (
+    globalThis as { __gxtRegisterListMarker?: (m: Comment) => void }
+  ).__gxtRegisterListMarker;
+  if (_reg) _reg(marker);
+  const holder = new Cell<T>(
+    item,
+    IS_DEV_MODE ? `recycle-holder:${key}` : undefined,
+  );
+  const rowState = {} as T;
+  const props = new Set<string>();
+  defineRecycledStateProps(rowState, holder, item, props);
+  let idx: number | Cell<number> = index;
+  let indexCell: Cell<number> | null = null;
+  if (host.hasIndex) {
+    // Positional index — a plain Cell is enough (rows never reorder in
+    // recycle mode; only pool reuse / rebind can change a row's position).
+    indexCell = new Cell<number>(
+      index,
+      IS_DEV_MODE ? `recycle-index:${key}` : undefined,
+    );
+    idx = indexCell;
+  }
+  const parent = api.parent(targetNode)!;
+  api.insert(parent, marker, targetNode);
+  // Per-row destructor-owner ctx (TREE child of the list) — real teardown
+  // of the row's binding opcodes happens via the list-destroy cascade.
+  const bodyCtx = host.rowBodyCtx(key);
+  const row = host.ItemComponent(
+    rowState,
+    idx as unknown as number | MergedCell,
+    bodyCtx as unknown as Component<any>,
+  );
+  if (row !== undefined && row !== null) {
+    renderElement(
+      api,
+      host as unknown as ComponentLike,
+      parent,
+      row,
+      targetNode,
+    );
+  }
+  return {
+    state: rowState,
+    holder,
+    props,
+    boundItem: item,
+    marker,
+    key,
+    indexCell,
+    fragment: null,
+  };
+}
+
+/**
+ * Retire a row: detach its DOM extent [marker, end) into the row's own
+ * reusable fragment. NOTHING is destroyed — subscriptions, opcodes and DOM
+ * survive for later re-insertion.
+ */
+function retireRecycledRow<T>(
+  host: RecycleHost<T>,
+  rec: RecycledRow<T>,
+  end: Node,
+): void {
+  const api = host.api;
+  const fragment = rec.fragment ?? (rec.fragment = api.fragment());
+  let node: Node | null = rec.marker;
+  let next: Node | null;
+  while (node !== null && node !== end) {
+    next = node.nextSibling;
+    api.insert(fragment, node);
+    node = next;
+  }
+}
+
+// ==========================================================================
+// Compiler entry points. buildEach emits these instead of $_each/$_eachSync
+// when the each key is the '@recycle' sentinel. Signature mirrors
+// $_each/$_eachSync 1:1 (the key slot is accepted but ignored — rows are
+// positional) so the compiler's arg-slot layout is unchanged.
+// ==========================================================================
+function eachRecycled<T extends { id: number }>(
+  items: Cell<T[]> | MergedCell,
+  fn: (item: T) => Array<ComponentReturnType | Node>,
+  ctx: Component<any>,
+  inverseFn: InverseFn | undefined,
+  hasIndex: boolean | undefined,
+  sync: boolean,
+) {
+  // Rehydration bail: the recycle sync path builds rows from scratch and
+  // knows nothing about adopting server-rendered DOM, so a rehydrating
+  // render falls back to the default keyed path (@identity) — correct,
+  // just without recycling for that initial pass.
+  if (isRehydrationScheduled()) {
+    if (IS_DEV_MODE) {
+      console.warn(
+        'key="@recycle" is not supported during rehydration; falling back to keyed rendering',
+      );
+    }
+    return sync
+      ? $_eachSync(items, fn, null, ctx, inverseFn, hasIndex)
+      : $_each(items, fn, null, ctx, inverseFn, hasIndex);
+  }
+  const api = initDOM(ctx);
+  // Mirrors dom.ts getRenderTargets minus the rehydration branch (handled
+  // by the keyed fallback above).
+  const placeholder = IS_DEV_MODE
+    ? api.comment('recycled-each-placeholder')
+    : api.comment('');
+  const outlet = api.fragment();
+  api.insert(outlet, placeholder);
+  // `key: null` — rows are positional; `this.key` stays '@identity' so the
+  // dev-mode key validation never misfires if a keyed path is reached.
+  const args = {
+    tag: items as Cell<T[]>,
+    ItemComponent: fn,
+    key: null,
+    ctx,
+    inverseFn,
+    hasIndex,
+    recycle: syncRecycle as (
+      list: BasicListComponent<any>,
+      items: any[],
+    ) => void,
+  };
+  const instance = sync
+    ? new SyncListComponent<T>(args, outlet, placeholder)
+    : new AsyncListComponent<T>(args, outlet, placeholder);
+  return $_fin(Array.from(outlet.childNodes), instance);
+}
+
+export function $_eachRecycled<T extends { id: number }>(
+  items: Cell<T[]> | MergedCell,
+  fn: (item: T) => Array<ComponentReturnType | Node>,
+  _key: string | null = null,
+  ctx: Component<any>,
+  inverseFn?: InverseFn,
+  hasIndex?: boolean,
+) {
+  return eachRecycled(items, fn, ctx, inverseFn, hasIndex, false);
+}
+
+export function $_eachSyncRecycled<T extends { id: number }>(
+  items: Cell<T[]> | MergedCell,
+  fn: (item: T) => Array<ComponentReturnType | Node>,
+  _key: string | null = null,
+  ctx: Component<any>,
+  inverseFn?: InverseFn,
+  hasIndex?: boolean,
+) {
+  return eachRecycled(items, fn, ctx, inverseFn, hasIndex, true);
+}

--- a/src/core/control-flow/list.recycle.test.ts
+++ b/src/core/control-flow/list.recycle.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Functional coverage for opt-in row recycling (`{{#each items key="@recycle"}}`).
+ * Perf characteristics live in src/core/list-perf.recycle.bench.test.ts (gated
+ * behind RUN_LIST_PERF); this file covers the semantic contract:
+ *   - positional reuse: replacing the data REBINDS rows in place (DOM node
+ *     identity survives — the intentional, documented difference from keyed mode);
+ *   - shrink retires rows into the (capped) pool, growth reuses them before
+ *     building new;
+ *   - per-item cell updates and shared-cell bindings stay reactive through the
+ *     state-object indirection — including prototype-accessor (@tracked-style)
+ *     items;
+ *   - empty data renders the inverse block.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { Component } from '../component';
+import { $template } from '../shared';
+import { createDOMFixture, type DOMFixture } from '../__test-utils__';
+import {
+  buildItems,
+  settle,
+  mountRoot,
+  setupRuntimeTemplateGlobals,
+  type HarnessItem,
+} from '../__test-utils__/list-harness';
+import { cellFor } from '../reactive';
+import { template } from '../../../plugins/runtime-compiler';
+
+const LIST_TEMPLATE = `
+  <table><tbody>
+    {{#each this.items key="@recycle" as |item|}}
+      <tr class={{this.rowClass item.id}}><td>{{item.id}}</td><td>{{item.label}}</td></tr>
+    {{else}}
+      <tr data-empty="true"><td>empty</td></tr>
+    {{/each}}
+  </tbody></table>
+`;
+
+class RecycleRoot extends Component {
+  _items: HarnessItem[] = [];
+  _selected = 0;
+  constructor(args: any) {
+    super(args);
+    cellFor(this as any, '_items');
+    cellFor(this as any, '_selected');
+  }
+  get items() {
+    return this._items;
+  }
+  rowClass = (id: number) => (this._selected === id ? 'selected' : '');
+  [$template] = template(LIST_TEMPLATE);
+}
+
+describe('{{#each}} key="@recycle" (opt-in row recycling)', () => {
+  let fixture: DOMFixture;
+  let root: RecycleRoot;
+
+  beforeEach(async () => {
+    fixture = createDOMFixture();
+    setupRuntimeTemplateGlobals();
+    root = mountRoot(fixture, RecycleRoot);
+    await settle();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  const rows = () =>
+    Array.from(fixture.container.querySelectorAll('tbody tr:not([data-empty])'));
+  const rowText = (tr: Element) =>
+    `${tr.children[0]!.textContent}:${tr.children[1]!.textContent}`;
+  const setItems = async (items: HarnessItem[]) => {
+    (root as any)._items = items;
+    await settle();
+  };
+  const labels = (...ls: string[]) => buildItems(ls.length, (i) => ls[i]);
+
+  test('renders items and rebinds rows in place on replace (DOM identity survives)', async () => {
+    const first = labels('a', 'b', 'c');
+    await setItems(first);
+    expect(rows().map(rowText)).toEqual(first.map((i) => `${i.id}:${i.label}`));
+
+    const initialNodes = rows();
+    const second = labels('x', 'y', 'z');
+    await setItems(second);
+
+    const replaced = rows();
+    expect(replaced.map(rowText)).toEqual(
+      second.map((i) => `${i.id}:${i.label}`),
+    );
+    // The recycle contract: same <tr> elements, new data.
+    expect(replaced).toHaveLength(3);
+    replaced.forEach((tr, i) => expect(tr).toBe(initialNodes[i]));
+  });
+
+  test('shrink retires rows; growth reuses pooled rows before building new ones', async () => {
+    const four = labels('a', 'b', 'c', 'd');
+    await setItems(four);
+    const fullNodes = rows();
+    expect(fullNodes).toHaveLength(4);
+
+    await setItems(four.slice(0, 2));
+    expect(rows()).toHaveLength(2);
+
+    const six = labels('p', 'q', 'r', 's', 't', 'u');
+    await setItems(six);
+    const grown = rows();
+    expect(grown.map(rowText)).toEqual(six.map((i) => `${i.id}:${i.label}`));
+    // First two rows never moved; rows 3-4 came back from the pool.
+    expect(grown[0]).toBe(fullNodes[0]);
+    expect(grown[1]).toBe(fullNodes[1]);
+    expect(grown.slice(2, 4)).toEqual(
+      expect.arrayContaining([fullNodes[2], fullNodes[3]]),
+    );
+  });
+
+  test('per-item cell updates reach the DOM through the state object', async () => {
+    const items = labels('a', 'b', 'c');
+    await setItems(items);
+
+    items[1].label = 'B!';
+    await settle();
+
+    expect(rows()[1].children[1]!.textContent).toBe('B!');
+    expect(rows()[0].children[1]!.textContent).toBe('a');
+  });
+
+  test('prototype-accessor items (legacy @tracked shape) are forwarded', async () => {
+    // Legacy `@tracked` installs ENUMERABLE accessors on the prototype — the
+    // state object must forward those, not just own properties.
+    class TrackedItem {
+      id: number;
+      _label: string;
+      declare label: string;
+      constructor(id: number, label: string) {
+        this.id = id;
+        this._label = label;
+        cellFor(this as any, '_label');
+      }
+    }
+    Object.defineProperty(TrackedItem.prototype, 'label', {
+      get(this: TrackedItem) {
+        return this._label;
+      },
+      set(this: TrackedItem, v: string) {
+        this._label = v;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    const items = [
+      new TrackedItem(9001, 'proto-a'),
+      new TrackedItem(9002, 'proto-b'),
+    ] as unknown as HarnessItem[];
+    await setItems(items);
+
+    expect(rows().map(rowText)).toEqual(['9001:proto-a', '9002:proto-b']);
+
+    (items[0] as unknown as TrackedItem).label = 'proto-a2';
+    await settle();
+    expect(rows()[0].children[1]!.textContent).toBe('proto-a2');
+  });
+
+  test('shared-cell bindings (selection) stay reactive across rebinds', async () => {
+    const items = labels('a', 'b', 'c');
+    await setItems(items);
+
+    (root as any)._selected = items[1].id;
+    await settle();
+    expect(rows()[1].className).toBe('selected');
+    expect(rows()[0].className).toBe('');
+
+    // Rebind the selected row to a different item: the class binding
+    // re-evaluates against the new id and deselects.
+    const swapped = [items[0], labels('n')[0], items[2]];
+    await setItems(swapped);
+    expect(rows()[1].className).toBe('');
+    expect(rows()[1].children[1]!.textContent).toBe('n');
+  });
+
+  test('empty data renders the inverse block; refill restores rows', async () => {
+    await setItems(labels('a', 'b'));
+    expect(rows()).toHaveLength(2);
+
+    await setItems([]);
+    expect(rows()).toHaveLength(0);
+    expect(fixture.container.querySelector('[data-empty]')).not.toBeNull();
+
+    const refill = labels('c');
+    await setItems(refill);
+    expect(fixture.container.querySelector('[data-empty]')).toBeNull();
+    expect(rows().map(rowText)).toEqual(refill.map((i) => `${i.id}:${i.label}`));
+  });
+
+  test('pool is capped: shrinking far below the cap still grows back correctly', async () => {
+    // RECYCLE_POOL_LIMIT is 256 — retire 300 rows so 44 overflow rows get
+    // real teardown, then grow back mixing pooled + freshly built rows.
+    const big = buildItems(300);
+    await setItems(big);
+    expect(rows()).toHaveLength(300);
+
+    await setItems([]);
+    expect(rows()).toHaveLength(0);
+
+    const next = buildItems(300);
+    await setItems(next);
+    expect(rows()).toHaveLength(300);
+    expect(rows().map(rowText)).toEqual(next.map((i) => `${i.id}:${i.label}`));
+
+    // Reactivity intact for both pooled and freshly built rows.
+    next[0].label = 'pooled!';
+    next[299].label = 'fresh!';
+    await settle();
+    expect(rows()[0].children[1]!.textContent).toBe('pooled!');
+    expect(rows()[299].children[1]!.textContent).toBe('fresh!');
+  });
+});

--- a/src/core/control-flow/list.ts
+++ b/src/core/control-flow/list.ts
@@ -18,6 +18,11 @@ import {
   formula,
   deepFnValue,
   registerLeafOwnersForFormula,
+  // Recycle-mode reference swaps happen INSIDE the drain (the list-tag opcode
+  // runs from syncDomSync), where a plain Cell.update() is dropped by the
+  // drain's terminal tagsToRevalidate.clear(). applyCellUpdateSync is the
+  // drain-safe path: direct mutate + synchronous subscriber flush.
+  applyCellUpdateSync,
 } from '@/core/reactive';
 import { opcodeFor } from '@/core/vm';
 import {
@@ -77,6 +82,81 @@ type RowContext = {
 };
 
 export type InverseFn = (ctx: Component<any>) => GenericReturnType | null;
+
+// ============================================================================
+// Opt-in row recycling — "sliding window of references"
+// (reference-swap variant; RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A2).
+//
+// Opt-in surface (prototype): `{{#each items key="@recycle" as |item|}}`.
+// The sentinel key flows through the existing compiler `key` argument with
+// ZERO compiler changes. A production API should instead be a dedicated
+// named arg threaded like `sync`/`hasIndex` (e.g.
+// `{{#each items recycle=true as |item|}}` → `ListComponentArgs.recycle`),
+// with a compiler warning documenting the semantic trade.
+//
+// Semantics (INTENTIONALLY different from keyed {{#each}}):
+//   - Rows are reused strictly by POSITION, never by key. Row DOM identity
+//     does NOT follow item identity (non-keyed in js-framework-benchmark
+//     terms). Focus/selection/input state, CSS transitions and third-party
+//     widget state inside a row BLEED across items on replace.
+//   - The block param the body renders against is NOT the raw item: it is a
+//     stable per-row STATE object whose property reads forward through a
+//     re-pointable holder `Cell<T>` to the currently-bound item. So `item`
+//     inside the body has a different object identity than the array element
+//     (`===` against raw items, or passing the block param to code that
+//     mutates/compares identities, will not behave like keyed mode).
+//   - A list replace becomes "swap N holder references"; push reactivity
+//     re-runs only the k bindings per row. All subscriptions, opcodes and
+//     DOM survive — no destroy/create.
+//   - Shrinking retires trailing rows into a pool (DOM detached into a
+//     per-row fragment; subscriptions stay LIVE — a shared-cell fan-out,
+//     e.g. `selected`, still re-runs pooled rows' formulas against detached
+//     DOM). Growth re-inserts pooled rows (re-bind + one fragment insert)
+//     before building new ones. The pool is capped (RECYCLE_POOL_LIMIT);
+//     overflow rows get real teardown so a one-off size spike doesn't pin
+//     memory and per-update CPU to the historical maximum forever.
+//
+// Reactivity routing: a body binding evaluating `state.prop` reads
+// (1) `holder.value` — entangling with the per-row holder cell (the
+// reference swap channel), and (2) `item.prop` through the raw item's own
+// accessor — so `cellFor(item, 'prop')`-backed items keep their fine-grained
+// push path (`item.label = x` still updates exactly that row's binding).
+//
+// Known limitations (acceptable for an opt-in mode, documented here so they
+// are decisions rather than surprises):
+//   - object items only (dev-mode warning otherwise);
+//   - inverse (else) teardown is synchronous even under AsyncListComponent —
+//     async element/modifier destructors on inverse content are not awaited;
+//   - dev-mode HMR swaps row components by walking `keyMap`, which recycling
+//     doesn't populate — hot-reloading a recycled row body needs a full reload;
+//   - rehydration falls back to the default keyed path (see constructor).
+// ============================================================================
+export const RECYCLE_KEY = '@recycle';
+
+// Retired rows kept for reuse. Beyond this, shrink tears rows down for real:
+// pooled rows keep live subscriptions (shared-cell changes re-execute their
+// formulas against detached DOM), so an unbounded pool would tax every later
+// update with the list's historical maximum size.
+const RECYCLE_POOL_LIMIT = 256;
+
+type RecycledRow<T> = {
+  /** Stable per-row state object the body rendered against (the block param). */
+  state: T;
+  /** Re-pointable reference every `state.*` read routes through. */
+  holder: Cell<T>;
+  /** Props with forwarding accessors materialized on `state`. */
+  props: Set<string>;
+  /** Raw item currently bound (ref-compare fast path for no-op rebinds). */
+  boundItem: T;
+  /** Row top boundary; DOM extent = [marker, nextRowMarker | bottomMarker). */
+  marker: Comment;
+  /** Position-independent internal key (rowCtxMap / teardown bookkeeping). */
+  key: string;
+  /** Reactive index cell — only allocated when the body reads `{{index}}`. */
+  indexCell: Cell<number> | null;
+  /** Holds the row's detached DOM while pooled; reused across retire cycles. */
+  fragment: DocumentFragment | null;
+};
 
 type ListComponentArgs<T> = {
   tag: Cell<T[]> | MergedCell;
@@ -527,6 +607,14 @@ export class BasicListComponent<T extends { id: number }> {
   private _relocateFragment!: DocumentFragment;
   declare api: DOMApi;
   hasIndex = false;
+  // Opt-in row recycling state. Lazily initialized so the default
+  // keyed path pays zero allocation for the feature.
+  recycleEnabled = false;
+  protected _recycleActive: Array<RecycledRow<T>> | null = null;
+  protected _recyclePool: Array<RecycledRow<T>> | null = null;
+  private _recycleSeq = 0;
+  // True while syncRecycle is applying items; see the guard in syncRecycle.
+  private _recycleSyncInProgress = false;
   constructor(
     { tag, ctx, key, ItemComponent, inverseFn, hasIndex }: ListComponentArgs<T>,
     outlet: RenderTarget,
@@ -561,7 +649,27 @@ export class BasicListComponent<T extends { id: number }> {
     // @ts-expect-error typings error
     addToTree(parentCtx, this, 'from list constructor');
     this[RENDERED_NODES_PROPERTY] = [];
-    if (key) {
+    if (key === RECYCLE_KEY) {
+      // Opt-in row recycling. Rows are positional; the keyed keyForItem
+      // machinery is unused (this.key stays '@identity' so the dev-mode key
+      // validation never misfires if a keyed path is reached).
+      //
+      // Rehydration bail: the recycle sync path builds rows from scratch and
+      // knows nothing about adopting server-rendered DOM, so a rehydrating
+      // render falls back to the default keyed path (@identity) — correct,
+      // just without recycling for that initial pass.
+      if (isRehydrationScheduled()) {
+        if (IS_DEV_MODE) {
+          console.warn(
+            'key="@recycle" is not supported during rehydration; falling back to keyed rendering',
+          );
+        }
+      } else {
+        this.recycleEnabled = true;
+        this._recycleActive = [];
+        this._recyclePool = [];
+      }
+    } else if (key) {
       this.key = key;
     }
     this.setupKeyForItem();
@@ -1088,6 +1196,280 @@ export class BasicListComponent<T extends { id: number }> {
     }
   }
 
+  // ==========================================================================
+  // Row recycling — positional sync (see RECYCLE_KEY docs).
+  // Replaces the whole keyed diff when `recycleEnabled` is on:
+  //   - overlapping positions: swap each row's holder reference (re-bind);
+  //   - shrink: retire trailing rows into the pool (DOM detached, alive);
+  //   - growth: re-insert + re-bind pooled rows first, then build new rows.
+  // Fully synchronous — no destroy cascades in steady state. Real teardown
+  // (opcode unsubscription, rowCtx destruction) only happens when the LIST
+  // itself is destroyed, via the existing TREE cascade over rowCtxMap.
+  // ==========================================================================
+  protected syncRecycle(items: T[]): void {
+    // Re-entry guard, shared by the Sync and Async subclasses: a holder flush
+    // can run host code that synchronously mutates the source array, and a
+    // nested syncRecycle would corrupt _recycleActive/_recyclePool while the
+    // outer pass is still iterating. The outer call already applies the
+    // current tag value; nested calls are safe to drop.
+    if (this._recycleSyncInProgress) return;
+    this._recycleSyncInProgress = true;
+    try {
+      this._syncRecycleInner(items);
+    } finally {
+      this._recycleSyncInProgress = false;
+    }
+  }
+  private _syncRecycleInner(items: T[]): void {
+    const api = this.api;
+    const active = this._recycleActive!;
+    const pool = this._recyclePool!;
+    const { bottomMarker } = this;
+    if (items.length > 0 && this.inverseContent !== null) {
+      this.destroyInverseSync();
+    }
+    const prevCount = active.length;
+    const nextCount = items.length;
+    const shared = prevCount < nextCount ? prevCount : nextCount;
+    // 1) Overlapping positions: the reference swap. Push reactivity re-runs
+    //    the k bindings of each row whose holder actually changed.
+    for (let i = 0; i < shared; i++) {
+      this._rebindRecycledRow(active[i], items[i], i);
+    }
+    if (nextCount > prevCount) {
+      // 2) Growth. ALL new/reused rows are appended IN ORDER into a single
+      //    detached batch fragment (append-only — no per-row anchor scans),
+      //    then moved into the live DOM with ONE insertBefore(bottomMarker).
+      const batch = api.fragment();
+      let index = prevCount;
+      // 2a) Reuse pooled rows: one fragment re-insert + one reference swap.
+      while (index < nextCount && pool.length > 0) {
+        const rec = pool.pop()!;
+        api.insert(batch, rec.fragment!);
+        this._rebindRecycledRow(rec, items[index], index);
+        active.push(rec);
+        index++;
+      }
+      // 2b) Build brand-new rows for the remainder. `_buildRecycledRow`
+      // resolves the insert parent via `api.parent(targetNode)`, and a bare
+      // DocumentFragment has NO parent — so (mirroring `getTargetNode(0)`)
+      // give the batch a tail marker to act as the in-fragment anchor, and
+      // drop it once the batch lands in the live DOM.
+      if (index < nextCount) {
+        const batchTail = IS_DEV_MODE
+          ? api.comment('recycle batch tail')
+          : api.comment();
+        api.insert(batch, batchTail);
+        const self = this as unknown as ComponentLike;
+        setParentContext(self);
+        for (; index < nextCount; index++) {
+          active.push(this._buildRecycledRow(items[index], index, batchTail));
+        }
+        setParentContext(null);
+        api.destroy(batchTail);
+      }
+      api.insert(api.parent(bottomMarker)!, batch, bottomMarker);
+    } else if (nextCount < prevCount) {
+      // 3) Shrink: retire trailing rows into the pool. Iterate forward so each
+      //    row's end boundary (the NEXT row's marker) is still connected when
+      //    we detach its extent.
+      for (let i = nextCount; i < prevCount; i++) {
+        const rec = active[i];
+        const end: Node =
+          i + 1 < prevCount ? active[i + 1].marker : bottomMarker;
+        this._retireRecycledRow(rec, end);
+        if (pool.length < RECYCLE_POOL_LIMIT) {
+          pool.push(rec);
+        } else {
+          this._destroyRecycledRow(rec);
+        }
+      }
+      active.length = nextCount;
+    }
+    if (nextCount === 0 && this.inverseFn) {
+      this.renderInverse();
+    }
+  }
+  /**
+   * Real teardown for a retired row that exceeds the pool cap: unsubscribe its
+   * binding opcodes (rowCtx cascade), unregister its boundary marker, and drop
+   * the fragment so the detached DOM becomes collectable. Mirrors what list
+   * destruction would eventually do for pooled rows, just eagerly.
+   */
+  private _destroyRecycledRow(rec: RecycledRow<T>): void {
+    this.destroyRowCtx(rec.key);
+    this.markerSet.delete(rec.marker);
+    const _unreg = (
+      globalThis as { __gxtUnregisterListMarker?: (m: Comment) => void }
+    ).__gxtUnregisterListMarker;
+    if (_unreg) _unreg(rec.marker);
+    rec.fragment = null;
+  }
+  /**
+   * Re-point a recycled row at `item` (the actual "swap one reference" op).
+   * No-ops when the row is already bound to the same object reference —
+   * which also keeps same-ref correctness: any in-place item mutation routed
+   * through `cellFor(item, prop)` stayed subscribed the whole time.
+   */
+  private _rebindRecycledRow(rec: RecycledRow<T>, item: T, index: number): void {
+    // applyCellUpdateSync (not Cell.update + manual flush): update() defers to
+    // the host _cellUpdateDeferralHook when one is installed, which would
+    // leave `_value` stale while we synchronously re-execute subscribers.
+    if (rec.indexCell !== null) {
+      applyCellUpdateSync(rec.indexCell, index);
+    }
+    if (rec.boundItem === item) {
+      return;
+    }
+    rec.boundItem = item;
+    // Heterogeneous item shapes: materialize forwarding accessors for any
+    // prop this row hasn't seen yet. Homogeneous case = one Set.has per prop.
+    this._defineRecycledStateProps(rec.state, rec.holder, item, rec.props);
+    // The reference swap: every body binding that read `state.*` is
+    // subscribed to `holder` and re-evaluates against the new item (also
+    // re-entangling with the NEW item's own cellFor-backed accessors).
+    applyCellUpdateSync(rec.holder, item);
+  }
+  /**
+   * Define forwarding accessors on the row's state object for every own
+   * enumerable prop of `item` not yet materialized. Reads route through the
+   * holder cell (reference-swap subscription) AND the raw item's accessor
+   * (fine-grained per-item cell push, e.g. `cellFor(item,'label')`). Writes
+   * forward to the currently-bound item.
+   *
+   * Forwarded props are everything `for..in` reaches: own enumerable props
+   * AND enumerable prototype accessors (legacy `@tracked` installs enumerable
+   * prototype getters — filtering to own props would render tracked class
+   * items blank). Non-enumerable prototype members (regular class methods/
+   * getters) are not forwarded.
+   *
+   * Limitation (documented): props that exist on NO item bound so far have no
+   * accessor, so a body read of them returns undefined without holder
+   * entanglement. Items with a stable shape — the recycling use case — are
+   * unaffected.
+   */
+  private _defineRecycledStateProps(
+    state: T,
+    holder: Cell<T>,
+    item: T,
+    props: Set<string>,
+  ): void {
+    if (item === null || typeof item !== 'object') {
+      // The state-object indirection forwards PROPERTY reads; a primitive item
+      // has nothing to forward, so the body would render the empty state
+      // object instead of the value. Recycling is documented as object-items
+      // only — surface the misuse instead of rendering garbage.
+      if (IS_DEV_MODE) {
+        console.warn(
+          `key="@recycle" requires object items; got ${item === null ? 'null' : typeof item} — the row body will not see this value`,
+        );
+      }
+      return;
+    }
+    for (const prop in item) {
+      if (props.has(prop)) continue;
+      props.add(prop);
+      Object.defineProperty(state, prop, {
+        get() {
+          return (holder.value as Record<string, unknown>)[prop];
+        },
+        set(v: unknown) {
+          (holder.value as Record<string, unknown>)[prop] = v;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+  /**
+   * Build a fresh recycled row at `index`, rendered against a stable state
+   * object + holder cell instead of the raw item. Inserted before
+   * `targetNode` (bottomMarker, or the batched fill fragment's marker).
+   */
+  private _buildRecycledRow(
+    item: T,
+    index: number,
+    targetNode: Node,
+  ): RecycledRow<T> {
+    const api = this.api;
+    const key = `@r${this._recycleSeq++}`;
+    const marker = IS_DEV_MODE
+      ? api.comment(`recycle row ${key}`)
+      : api.comment();
+    // Same contract as keyed per-item markers: track in markerSet (the list
+    // destructor's unregister loop walks it) and tell the host registry the
+    // comment is load-bearing — Ember's artifact stripper prunes unregistered
+    // empty comments, which would orphan the row's retire boundary.
+    this.markerSet.add(marker);
+    const _reg = (
+      globalThis as { __gxtRegisterListMarker?: (m: Comment) => void }
+    ).__gxtRegisterListMarker;
+    if (_reg) _reg(marker);
+    const holder = new Cell<T>(
+      item,
+      IS_DEV_MODE ? `recycle-holder:${key}` : undefined,
+    );
+    const state = {} as T;
+    const props = new Set<string>();
+    this._defineRecycledStateProps(state, holder, item, props);
+    let idx: number | Cell<number> = index;
+    let indexCell: Cell<number> | null = null;
+    if (this.hasIndex) {
+      // Positional index — a plain Cell is enough (rows never reorder in
+      // recycle mode; only pool reuse / rebind can change a row's position).
+      indexCell = new Cell<number>(
+        index,
+        IS_DEV_MODE ? `recycle-index:${key}` : undefined,
+      );
+      idx = indexCell;
+    }
+    const parent = api.parent(targetNode)!;
+    api.insert(parent, marker, targetNode);
+    // Per-row destructor-owner ctx (TREE child of the list) — real teardown
+    // of the row's binding opcodes happens via the list-destroy cascade.
+    const bodyCtx = this.rowBodyCtx(key);
+    const row = this.ItemComponent(
+      state,
+      idx as unknown as number | MergedCell,
+      bodyCtx as unknown as Component<any>,
+    );
+    if (row !== undefined && row !== null) {
+      renderElement(
+        api,
+        this as unknown as ComponentLike,
+        parent,
+        row,
+        targetNode,
+      );
+    }
+    return {
+      state,
+      holder,
+      props,
+      boundItem: item,
+      marker,
+      key,
+      indexCell,
+      fragment: null,
+    };
+  }
+  /**
+   * Retire a row: detach its DOM extent [marker, end) into the row's own
+   * reusable fragment. NOTHING is destroyed — subscriptions, opcodes and DOM
+   * survive for later re-insertion.
+   */
+  private _retireRecycledRow(rec: RecycledRow<T>, end: Node): void {
+    const api = this.api;
+    const fragment = rec.fragment ?? (rec.fragment = api.fragment());
+    let node: Node | null = rec.marker;
+    let next: Node | null;
+    while (node !== null && node !== end) {
+      next = node.nextSibling;
+      api.insert(fragment, node);
+      node = next;
+    }
+  }
+
   updateItems(items: T[], amountOfKeys: number, removedCount: number) {
     const {
       indexMap,
@@ -1563,6 +1945,12 @@ export class SyncListComponent<
     // and corrupts it. Skip nested calls — the outer one is already applying
     // `items`, which is either the final desired state or `[]` (teardown).
     if (this._syncInProgress) return;
+    // Opt-in row recycling bypasses the keyed diff entirely (re-entry guard
+    // lives inside syncRecycle, shared with the async subclass).
+    if (this.recycleEnabled) {
+      this.syncRecycle(items);
+      return;
+    }
     this._syncInProgress = true;
     // Invalidate the duplicate-key detection cache for this sync pass — a
     // mutated-in-place array would otherwise carry stale verdict forward.
@@ -1938,6 +2326,13 @@ export class AsyncListComponent<
     // Defensive normalization (see SyncListComponent.syncList).
     if (!Array.isArray(items)) {
       items = normalizeIterableValue<T>(items);
+    }
+    // Opt-in row recycling bypasses the keyed diff entirely (fully
+    // synchronous — no destroys in steady state, nothing to await; re-entry
+    // guard lives inside syncRecycle, shared with the sync subclass).
+    if (this.recycleEnabled) {
+      this.syncRecycle(items);
+      return;
     }
     // Invalidate per-items-array duplicate-key cache (see SyncListComponent)
     this._dupItemsRef = null;

--- a/src/core/control-flow/list.ts
+++ b/src/core/control-flow/list.ts
@@ -18,11 +18,6 @@ import {
   formula,
   deepFnValue,
   registerLeafOwnersForFormula,
-  // Recycle-mode reference swaps happen INSIDE the drain (the list-tag opcode
-  // runs from syncDomSync), where a plain Cell.update() is dropped by the
-  // drain's terminal tagsToRevalidate.clear(). applyCellUpdateSync is the
-  // drain-safe path: direct mutate + synchronous subscriber flush.
-  applyCellUpdateSync,
 } from '@/core/reactive';
 import { opcodeFor } from '@/core/vm';
 import {
@@ -83,81 +78,6 @@ type RowContext = {
 
 export type InverseFn = (ctx: Component<any>) => GenericReturnType | null;
 
-// ============================================================================
-// Opt-in row recycling — "sliding window of references"
-// (reference-swap variant; RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A2).
-//
-// Opt-in surface (prototype): `{{#each items key="@recycle" as |item|}}`.
-// The sentinel key flows through the existing compiler `key` argument with
-// ZERO compiler changes. A production API should instead be a dedicated
-// named arg threaded like `sync`/`hasIndex` (e.g.
-// `{{#each items recycle=true as |item|}}` → `ListComponentArgs.recycle`),
-// with a compiler warning documenting the semantic trade.
-//
-// Semantics (INTENTIONALLY different from keyed {{#each}}):
-//   - Rows are reused strictly by POSITION, never by key. Row DOM identity
-//     does NOT follow item identity (non-keyed in js-framework-benchmark
-//     terms). Focus/selection/input state, CSS transitions and third-party
-//     widget state inside a row BLEED across items on replace.
-//   - The block param the body renders against is NOT the raw item: it is a
-//     stable per-row STATE object whose property reads forward through a
-//     re-pointable holder `Cell<T>` to the currently-bound item. So `item`
-//     inside the body has a different object identity than the array element
-//     (`===` against raw items, or passing the block param to code that
-//     mutates/compares identities, will not behave like keyed mode).
-//   - A list replace becomes "swap N holder references"; push reactivity
-//     re-runs only the k bindings per row. All subscriptions, opcodes and
-//     DOM survive — no destroy/create.
-//   - Shrinking retires trailing rows into a pool (DOM detached into a
-//     per-row fragment; subscriptions stay LIVE — a shared-cell fan-out,
-//     e.g. `selected`, still re-runs pooled rows' formulas against detached
-//     DOM). Growth re-inserts pooled rows (re-bind + one fragment insert)
-//     before building new ones. The pool is capped (RECYCLE_POOL_LIMIT);
-//     overflow rows get real teardown so a one-off size spike doesn't pin
-//     memory and per-update CPU to the historical maximum forever.
-//
-// Reactivity routing: a body binding evaluating `state.prop` reads
-// (1) `holder.value` — entangling with the per-row holder cell (the
-// reference swap channel), and (2) `item.prop` through the raw item's own
-// accessor — so `cellFor(item, 'prop')`-backed items keep their fine-grained
-// push path (`item.label = x` still updates exactly that row's binding).
-//
-// Known limitations (acceptable for an opt-in mode, documented here so they
-// are decisions rather than surprises):
-//   - object items only (dev-mode warning otherwise);
-//   - inverse (else) teardown is synchronous even under AsyncListComponent —
-//     async element/modifier destructors on inverse content are not awaited;
-//   - dev-mode HMR swaps row components by walking `keyMap`, which recycling
-//     doesn't populate — hot-reloading a recycled row body needs a full reload;
-//   - rehydration falls back to the default keyed path (see constructor).
-// ============================================================================
-export const RECYCLE_KEY = '@recycle';
-
-// Retired rows kept for reuse. Beyond this, shrink tears rows down for real:
-// pooled rows keep live subscriptions (shared-cell changes re-execute their
-// formulas against detached DOM), so an unbounded pool would tax every later
-// update with the list's historical maximum size.
-const RECYCLE_POOL_LIMIT = 256;
-
-type RecycledRow<T> = {
-  /** Stable per-row state object the body rendered against (the block param). */
-  state: T;
-  /** Re-pointable reference every `state.*` read routes through. */
-  holder: Cell<T>;
-  /** Props with forwarding accessors materialized on `state`. */
-  props: Set<string>;
-  /** Raw item currently bound (ref-compare fast path for no-op rebinds). */
-  boundItem: T;
-  /** Row top boundary; DOM extent = [marker, nextRowMarker | bottomMarker). */
-  marker: Comment;
-  /** Position-independent internal key (rowCtxMap / teardown bookkeeping). */
-  key: string;
-  /** Reactive index cell — only allocated when the body reads `{{index}}`. */
-  indexCell: Cell<number> | null;
-  /** Holds the row's detached DOM while pooled; reused across retire cycles. */
-  fragment: DocumentFragment | null;
-};
-
 type ListComponentArgs<T> = {
   tag: Cell<T[]> | MergedCell;
   key: string | null;
@@ -170,6 +90,13 @@ type ListComponentArgs<T> = {
   // index formula and pass the raw number instead — this saves one
   // MergedCell + closure capture per item on every render.
   hasIndex?: boolean;
+  // Opt-in row recycling (key="@recycle"). Installed by the dedicated
+  // `$_eachRecycled` entry points in list-recycle.ts; when set, the subclass
+  // syncList paths route items through it instead of the keyed diff. Kept as
+  // an opaque callback so the entire recycle implementation (and its per-list
+  // state, held in a WeakMap inside list-recycle.ts) stays TREE-SHAKABLE —
+  // this class carries only this dispatch hook.
+  recycle?: (list: BasicListComponent<any>, items: any[]) => void;
 };
 type RenderTarget = HTMLElement | DocumentFragment;
 
@@ -607,16 +534,21 @@ export class BasicListComponent<T extends { id: number }> {
   private _relocateFragment!: DocumentFragment;
   declare api: DOMApi;
   hasIndex = false;
-  // Opt-in row recycling state. Lazily initialized so the default
-  // keyed path pays zero allocation for the feature.
-  recycleEnabled = false;
-  protected _recycleActive: Array<RecycledRow<T>> | null = null;
-  protected _recyclePool: Array<RecycledRow<T>> | null = null;
-  private _recycleSeq = 0;
-  // True while syncRecycle is applying items; see the guard in syncRecycle.
-  private _recycleSyncInProgress = false;
+  // Opt-in row-recycling dispatch hook (see ListComponentArgs.recycle).
+  // Undefined unless a `$_eachRecycled` entry point installed an
+  // implementation at construction; type-only declaration → zero bytes on
+  // the default keyed path.
+  recycleImpl?: (list: BasicListComponent<any>, items: any[]) => void;
   constructor(
-    { tag, ctx, key, ItemComponent, inverseFn, hasIndex }: ListComponentArgs<T>,
+    {
+      tag,
+      ctx,
+      key,
+      ItemComponent,
+      inverseFn,
+      hasIndex,
+      recycle,
+    }: ListComponentArgs<T>,
     outlet: RenderTarget,
     topMarker: Comment,
   ) {
@@ -649,27 +581,16 @@ export class BasicListComponent<T extends { id: number }> {
     // @ts-expect-error typings error
     addToTree(parentCtx, this, 'from list constructor');
     this[RENDERED_NODES_PROPERTY] = [];
-    if (key === RECYCLE_KEY) {
-      // Opt-in row recycling. Rows are positional; the keyed keyForItem
-      // machinery is unused (this.key stays '@identity' so the dev-mode key
-      // validation never misfires if a keyed path is reached).
-      //
-      // Rehydration bail: the recycle sync path builds rows from scratch and
-      // knows nothing about adopting server-rendered DOM, so a rehydrating
-      // render falls back to the default keyed path (@identity) — correct,
-      // just without recycling for that initial pass.
-      if (isRehydrationScheduled()) {
-        if (IS_DEV_MODE) {
-          console.warn(
-            'key="@recycle" is not supported during rehydration; falling back to keyed rendering',
-          );
-        }
-      } else {
-        this.recycleEnabled = true;
-        this._recycleActive = [];
-        this._recyclePool = [];
-      }
-    } else if (key) {
+    // Opt-in row recycling (key="@recycle"): the compiler routes such blocks
+    // through `$_eachRecycled` (list-recycle.ts), which threads the recycle
+    // implementation here. NOTE: there is intentionally NO '@recycle' sentinel
+    // check on `key` — constructing a list directly with key='@recycle' (and
+    // no `recycle` callback) treats it as a property-name key; the dev-mode
+    // 'Key for item not found' guard surfaces that misuse.
+    if (recycle !== undefined) {
+      this.recycleImpl = recycle;
+    }
+    if (key) {
       this.key = key;
     }
     this.setupKeyForItem();
@@ -1196,280 +1117,6 @@ export class BasicListComponent<T extends { id: number }> {
     }
   }
 
-  // ==========================================================================
-  // Row recycling — positional sync (see RECYCLE_KEY docs).
-  // Replaces the whole keyed diff when `recycleEnabled` is on:
-  //   - overlapping positions: swap each row's holder reference (re-bind);
-  //   - shrink: retire trailing rows into the pool (DOM detached, alive);
-  //   - growth: re-insert + re-bind pooled rows first, then build new rows.
-  // Fully synchronous — no destroy cascades in steady state. Real teardown
-  // (opcode unsubscription, rowCtx destruction) only happens when the LIST
-  // itself is destroyed, via the existing TREE cascade over rowCtxMap.
-  // ==========================================================================
-  protected syncRecycle(items: T[]): void {
-    // Re-entry guard, shared by the Sync and Async subclasses: a holder flush
-    // can run host code that synchronously mutates the source array, and a
-    // nested syncRecycle would corrupt _recycleActive/_recyclePool while the
-    // outer pass is still iterating. The outer call already applies the
-    // current tag value; nested calls are safe to drop.
-    if (this._recycleSyncInProgress) return;
-    this._recycleSyncInProgress = true;
-    try {
-      this._syncRecycleInner(items);
-    } finally {
-      this._recycleSyncInProgress = false;
-    }
-  }
-  private _syncRecycleInner(items: T[]): void {
-    const api = this.api;
-    const active = this._recycleActive!;
-    const pool = this._recyclePool!;
-    const { bottomMarker } = this;
-    if (items.length > 0 && this.inverseContent !== null) {
-      this.destroyInverseSync();
-    }
-    const prevCount = active.length;
-    const nextCount = items.length;
-    const shared = prevCount < nextCount ? prevCount : nextCount;
-    // 1) Overlapping positions: the reference swap. Push reactivity re-runs
-    //    the k bindings of each row whose holder actually changed.
-    for (let i = 0; i < shared; i++) {
-      this._rebindRecycledRow(active[i], items[i], i);
-    }
-    if (nextCount > prevCount) {
-      // 2) Growth. ALL new/reused rows are appended IN ORDER into a single
-      //    detached batch fragment (append-only — no per-row anchor scans),
-      //    then moved into the live DOM with ONE insertBefore(bottomMarker).
-      const batch = api.fragment();
-      let index = prevCount;
-      // 2a) Reuse pooled rows: one fragment re-insert + one reference swap.
-      while (index < nextCount && pool.length > 0) {
-        const rec = pool.pop()!;
-        api.insert(batch, rec.fragment!);
-        this._rebindRecycledRow(rec, items[index], index);
-        active.push(rec);
-        index++;
-      }
-      // 2b) Build brand-new rows for the remainder. `_buildRecycledRow`
-      // resolves the insert parent via `api.parent(targetNode)`, and a bare
-      // DocumentFragment has NO parent — so (mirroring `getTargetNode(0)`)
-      // give the batch a tail marker to act as the in-fragment anchor, and
-      // drop it once the batch lands in the live DOM.
-      if (index < nextCount) {
-        const batchTail = IS_DEV_MODE
-          ? api.comment('recycle batch tail')
-          : api.comment();
-        api.insert(batch, batchTail);
-        const self = this as unknown as ComponentLike;
-        setParentContext(self);
-        for (; index < nextCount; index++) {
-          active.push(this._buildRecycledRow(items[index], index, batchTail));
-        }
-        setParentContext(null);
-        api.destroy(batchTail);
-      }
-      api.insert(api.parent(bottomMarker)!, batch, bottomMarker);
-    } else if (nextCount < prevCount) {
-      // 3) Shrink: retire trailing rows into the pool. Iterate forward so each
-      //    row's end boundary (the NEXT row's marker) is still connected when
-      //    we detach its extent.
-      for (let i = nextCount; i < prevCount; i++) {
-        const rec = active[i];
-        const end: Node =
-          i + 1 < prevCount ? active[i + 1].marker : bottomMarker;
-        this._retireRecycledRow(rec, end);
-        if (pool.length < RECYCLE_POOL_LIMIT) {
-          pool.push(rec);
-        } else {
-          this._destroyRecycledRow(rec);
-        }
-      }
-      active.length = nextCount;
-    }
-    if (nextCount === 0 && this.inverseFn) {
-      this.renderInverse();
-    }
-  }
-  /**
-   * Real teardown for a retired row that exceeds the pool cap: unsubscribe its
-   * binding opcodes (rowCtx cascade), unregister its boundary marker, and drop
-   * the fragment so the detached DOM becomes collectable. Mirrors what list
-   * destruction would eventually do for pooled rows, just eagerly.
-   */
-  private _destroyRecycledRow(rec: RecycledRow<T>): void {
-    this.destroyRowCtx(rec.key);
-    this.markerSet.delete(rec.marker);
-    const _unreg = (
-      globalThis as { __gxtUnregisterListMarker?: (m: Comment) => void }
-    ).__gxtUnregisterListMarker;
-    if (_unreg) _unreg(rec.marker);
-    rec.fragment = null;
-  }
-  /**
-   * Re-point a recycled row at `item` (the actual "swap one reference" op).
-   * No-ops when the row is already bound to the same object reference —
-   * which also keeps same-ref correctness: any in-place item mutation routed
-   * through `cellFor(item, prop)` stayed subscribed the whole time.
-   */
-  private _rebindRecycledRow(rec: RecycledRow<T>, item: T, index: number): void {
-    // applyCellUpdateSync (not Cell.update + manual flush): update() defers to
-    // the host _cellUpdateDeferralHook when one is installed, which would
-    // leave `_value` stale while we synchronously re-execute subscribers.
-    if (rec.indexCell !== null) {
-      applyCellUpdateSync(rec.indexCell, index);
-    }
-    if (rec.boundItem === item) {
-      return;
-    }
-    rec.boundItem = item;
-    // Heterogeneous item shapes: materialize forwarding accessors for any
-    // prop this row hasn't seen yet. Homogeneous case = one Set.has per prop.
-    this._defineRecycledStateProps(rec.state, rec.holder, item, rec.props);
-    // The reference swap: every body binding that read `state.*` is
-    // subscribed to `holder` and re-evaluates against the new item (also
-    // re-entangling with the NEW item's own cellFor-backed accessors).
-    applyCellUpdateSync(rec.holder, item);
-  }
-  /**
-   * Define forwarding accessors on the row's state object for every own
-   * enumerable prop of `item` not yet materialized. Reads route through the
-   * holder cell (reference-swap subscription) AND the raw item's accessor
-   * (fine-grained per-item cell push, e.g. `cellFor(item,'label')`). Writes
-   * forward to the currently-bound item.
-   *
-   * Forwarded props are everything `for..in` reaches: own enumerable props
-   * AND enumerable prototype accessors (legacy `@tracked` installs enumerable
-   * prototype getters — filtering to own props would render tracked class
-   * items blank). Non-enumerable prototype members (regular class methods/
-   * getters) are not forwarded.
-   *
-   * Limitation (documented): props that exist on NO item bound so far have no
-   * accessor, so a body read of them returns undefined without holder
-   * entanglement. Items with a stable shape — the recycling use case — are
-   * unaffected.
-   */
-  private _defineRecycledStateProps(
-    state: T,
-    holder: Cell<T>,
-    item: T,
-    props: Set<string>,
-  ): void {
-    if (item === null || typeof item !== 'object') {
-      // The state-object indirection forwards PROPERTY reads; a primitive item
-      // has nothing to forward, so the body would render the empty state
-      // object instead of the value. Recycling is documented as object-items
-      // only — surface the misuse instead of rendering garbage.
-      if (IS_DEV_MODE) {
-        console.warn(
-          `key="@recycle" requires object items; got ${item === null ? 'null' : typeof item} — the row body will not see this value`,
-        );
-      }
-      return;
-    }
-    for (const prop in item) {
-      if (props.has(prop)) continue;
-      props.add(prop);
-      Object.defineProperty(state, prop, {
-        get() {
-          return (holder.value as Record<string, unknown>)[prop];
-        },
-        set(v: unknown) {
-          (holder.value as Record<string, unknown>)[prop] = v;
-        },
-        enumerable: true,
-        configurable: true,
-      });
-    }
-  }
-  /**
-   * Build a fresh recycled row at `index`, rendered against a stable state
-   * object + holder cell instead of the raw item. Inserted before
-   * `targetNode` (bottomMarker, or the batched fill fragment's marker).
-   */
-  private _buildRecycledRow(
-    item: T,
-    index: number,
-    targetNode: Node,
-  ): RecycledRow<T> {
-    const api = this.api;
-    const key = `@r${this._recycleSeq++}`;
-    const marker = IS_DEV_MODE
-      ? api.comment(`recycle row ${key}`)
-      : api.comment();
-    // Same contract as keyed per-item markers: track in markerSet (the list
-    // destructor's unregister loop walks it) and tell the host registry the
-    // comment is load-bearing — Ember's artifact stripper prunes unregistered
-    // empty comments, which would orphan the row's retire boundary.
-    this.markerSet.add(marker);
-    const _reg = (
-      globalThis as { __gxtRegisterListMarker?: (m: Comment) => void }
-    ).__gxtRegisterListMarker;
-    if (_reg) _reg(marker);
-    const holder = new Cell<T>(
-      item,
-      IS_DEV_MODE ? `recycle-holder:${key}` : undefined,
-    );
-    const state = {} as T;
-    const props = new Set<string>();
-    this._defineRecycledStateProps(state, holder, item, props);
-    let idx: number | Cell<number> = index;
-    let indexCell: Cell<number> | null = null;
-    if (this.hasIndex) {
-      // Positional index — a plain Cell is enough (rows never reorder in
-      // recycle mode; only pool reuse / rebind can change a row's position).
-      indexCell = new Cell<number>(
-        index,
-        IS_DEV_MODE ? `recycle-index:${key}` : undefined,
-      );
-      idx = indexCell;
-    }
-    const parent = api.parent(targetNode)!;
-    api.insert(parent, marker, targetNode);
-    // Per-row destructor-owner ctx (TREE child of the list) — real teardown
-    // of the row's binding opcodes happens via the list-destroy cascade.
-    const bodyCtx = this.rowBodyCtx(key);
-    const row = this.ItemComponent(
-      state,
-      idx as unknown as number | MergedCell,
-      bodyCtx as unknown as Component<any>,
-    );
-    if (row !== undefined && row !== null) {
-      renderElement(
-        api,
-        this as unknown as ComponentLike,
-        parent,
-        row,
-        targetNode,
-      );
-    }
-    return {
-      state,
-      holder,
-      props,
-      boundItem: item,
-      marker,
-      key,
-      indexCell,
-      fragment: null,
-    };
-  }
-  /**
-   * Retire a row: detach its DOM extent [marker, end) into the row's own
-   * reusable fragment. NOTHING is destroyed — subscriptions, opcodes and DOM
-   * survive for later re-insertion.
-   */
-  private _retireRecycledRow(rec: RecycledRow<T>, end: Node): void {
-    const api = this.api;
-    const fragment = rec.fragment ?? (rec.fragment = api.fragment());
-    let node: Node | null = rec.marker;
-    let next: Node | null;
-    while (node !== null && node !== end) {
-      next = node.nextSibling;
-      api.insert(fragment, node);
-      node = next;
-    }
-  }
-
   updateItems(items: T[], amountOfKeys: number, removedCount: number) {
     const {
       indexMap,
@@ -1945,10 +1592,11 @@ export class SyncListComponent<
     // and corrupts it. Skip nested calls — the outer one is already applying
     // `items`, which is either the final desired state or `[]` (teardown).
     if (this._syncInProgress) return;
-    // Opt-in row recycling bypasses the keyed diff entirely (re-entry guard
-    // lives inside syncRecycle, shared with the async subclass).
-    if (this.recycleEnabled) {
-      this.syncRecycle(items);
+    // Opt-in row recycling bypasses the keyed diff entirely. The dispatch
+    // hook is installed by $_eachRecycled (list-recycle.ts); the re-entry
+    // guard lives inside the impl, shared with the async subclass.
+    if (this.recycleImpl !== undefined) {
+      this.recycleImpl(this, items);
       return;
     }
     this._syncInProgress = true;
@@ -2328,10 +1976,11 @@ export class AsyncListComponent<
       items = normalizeIterableValue<T>(items);
     }
     // Opt-in row recycling bypasses the keyed diff entirely (fully
-    // synchronous — no destroys in steady state, nothing to await; re-entry
-    // guard lives inside syncRecycle, shared with the sync subclass).
-    if (this.recycleEnabled) {
-      this.syncRecycle(items);
+    // synchronous — no destroys in steady state, nothing to await). The
+    // dispatch hook is installed by $_eachRecycled (list-recycle.ts); the
+    // re-entry guard lives inside the impl, shared with the sync subclass.
+    if (this.recycleImpl !== undefined) {
+      this.recycleImpl(this, items);
       return;
     }
     // Invalidate per-items-array duplicate-key cache (see SyncListComponent)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -17,6 +17,9 @@ export {
   type CachedCell,
 } from '@/core/reactive';
 
+// Keyed selector primitive (O(2) fan-out for `selected === key` bindings)
+export { keyedSelector, type KeyedSelector } from '@/core/selector';
+
 // Component class and types
 export { Component, type ComponentReturnType } from '@/core/component-class';
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,6 +20,15 @@ export {
 // Keyed selector primitive (O(2) fan-out for `selected === key` bindings)
 export { keyedSelector, type KeyedSelector } from '@/core/selector';
 
+// Opt-in row recycling ({{#each items key="@recycle"}}). The compiler emits
+// these entry points instead of $_each/$_eachSync when it sees the sentinel
+// key, so the recycle runtime stays tree-shakable for apps that never use it.
+export {
+  $_eachRecycled,
+  $_eachSyncRecycled,
+  RECYCLE_KEY,
+} from '@/core/control-flow/list-recycle';
+
 // Component class and types
 export { Component, type ComponentReturnType } from '@/core/component-class';
 

--- a/src/core/list-perf.bench.test.ts
+++ b/src/core/list-perf.bench.test.ts
@@ -1,69 +1,33 @@
 /**
  * @vitest-environment happy-dom
  *
- * List performance harness — shared measurement methodology for the
- * {{#each}} tracking-context experiments (see RESEARCH_LIST_TRACKING_OPTIMIZATION.md).
+ * List performance harness for the keyed {{#each}} hot paths (see
+ * RESEARCH_LIST_TRACKING_OPTIMIZATION.md for the cost analysis and measured
+ * history). Methodology — item shape, timing, root component, mount ritual —
+ * lives in __test-utils__/list-harness.ts and is shared with the recycle
+ * variant so comparisons stay apples-to-apples. Results print as one JSON
+ * line prefixed with PERF_RESULTS_JSON.
  *
- * IMPORTANT FOR EXPERIMENT BRANCHES: do NOT change the scenarios, item shape,
- * iteration counts, or timing methodology — only the framework internals (or,
- * for opt-in features, the template/flags marked EXPERIMENT-TUNABLE below).
- * The shared methodology helpers live in __test-utils__/list-harness.ts.
- * Results print as a single JSON line prefixed with PERF_RESULTS_JSON so they
- * can be collected mechanically.
- *
- * Caveat: happy-dom measures JS-side cost (which is what these experiments
- * target). Browser-level DOM wins (layout, native cloneNode) are NOT captured.
+ * Caveat: happy-dom measures JS-side cost only — browser-level effects
+ * (layout, native cloneNode) are not captured.
  *
  * Gated behind RUN_LIST_PERF=1: the full matrix takes ~40-90s, which would
  * blow the CI vitest job's 4-minute budget. Run locally with:
  *   RUN_LIST_PERF=1 npx vitest run src/core/list-perf.bench.test.ts
  */
 import { describe, test, beforeEach, afterEach } from 'vitest';
-import { Component } from './component';
-import { $template } from './shared';
 import { createDOMFixture, type DOMFixture } from './__test-utils__';
-import { cellFor } from './reactive';
-import { template } from '../../plugins/runtime-compiler';
 import {
   buildItems,
   settle,
   timed,
   median,
   mountRoot,
+  defineBenchRoot,
   setupRuntimeTemplateGlobals,
-  type HarnessItem,
 } from './__test-utils__/list-harness';
 
-// Each-body shape mirrors the Krausest Row: one static-ish <tr>, a reactive
-// text binding (per-item cell) and TWO bindings on the shared `selected`
-// cell (the select fan-out path). EXPERIMENT-TUNABLE: experiments may render
-// an alternative template variant ADDITIONALLY, never instead.
-const LIST_TEMPLATE = `
-  <table><tbody>
-    {{#each this.items key="id" as |item|}}
-      <tr class={{this.rowClass item.id}}>
-        <td>{{item.id}}</td>
-        <td><a class={{this.rowClass item.id}}>{{item.label}}</a></td>
-        <td><span>x</span></td>
-      </tr>
-    {{/each}}
-  </tbody></table>
-`;
-
-class BenchRoot extends Component {
-  _items: HarnessItem[] = [];
-  _selected = 0;
-  constructor(args: any) {
-    super(args);
-    cellFor(this as any, '_items');
-    cellFor(this as any, '_selected');
-  }
-  get items() {
-    return this._items;
-  }
-  rowClass = (id: number) => (this._selected === id ? 'danger' : '');
-  [$template] = template(LIST_TEMPLATE);
-}
+const BenchRoot = defineBenchRoot('id');
 
 describe('list-perf harness', () => {
   let fixture: DOMFixture;

--- a/src/core/list-perf.bench.test.ts
+++ b/src/core/list-perf.bench.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * List performance harness — shared measurement methodology for the
+ * {{#each}} tracking-context experiments (see RESEARCH_LIST_TRACKING_OPTIMIZATION.md).
+ *
+ * IMPORTANT FOR EXPERIMENT BRANCHES: do NOT change the scenarios, item shape,
+ * iteration counts, or timing methodology — only the framework internals (or,
+ * for opt-in features, the template/flags marked EXPERIMENT-TUNABLE below).
+ * The shared methodology helpers live in __test-utils__/list-harness.ts.
+ * Results print as a single JSON line prefixed with PERF_RESULTS_JSON so they
+ * can be collected mechanically.
+ *
+ * Caveat: happy-dom measures JS-side cost (which is what these experiments
+ * target). Browser-level DOM wins (layout, native cloneNode) are NOT captured.
+ *
+ * Gated behind RUN_LIST_PERF=1: the full matrix takes ~40-90s, which would
+ * blow the CI vitest job's 4-minute budget. Run locally with:
+ *   RUN_LIST_PERF=1 npx vitest run src/core/list-perf.bench.test.ts
+ */
+import { describe, test, beforeEach, afterEach } from 'vitest';
+import { Component } from './component';
+import { $template } from './shared';
+import { createDOMFixture, type DOMFixture } from './__test-utils__';
+import { cellFor } from './reactive';
+import { template } from '../../plugins/runtime-compiler';
+import {
+  buildItems,
+  settle,
+  timed,
+  median,
+  mountRoot,
+  setupRuntimeTemplateGlobals,
+  type HarnessItem,
+} from './__test-utils__/list-harness';
+
+// Each-body shape mirrors the Krausest Row: one static-ish <tr>, a reactive
+// text binding (per-item cell) and TWO bindings on the shared `selected`
+// cell (the select fan-out path). EXPERIMENT-TUNABLE: experiments may render
+// an alternative template variant ADDITIONALLY, never instead.
+const LIST_TEMPLATE = `
+  <table><tbody>
+    {{#each this.items key="id" as |item|}}
+      <tr class={{this.rowClass item.id}}>
+        <td>{{item.id}}</td>
+        <td><a class={{this.rowClass item.id}}>{{item.label}}</a></td>
+        <td><span>x</span></td>
+      </tr>
+    {{/each}}
+  </tbody></table>
+`;
+
+class BenchRoot extends Component {
+  _items: HarnessItem[] = [];
+  _selected = 0;
+  constructor(args: any) {
+    super(args);
+    cellFor(this as any, '_items');
+    cellFor(this as any, '_selected');
+  }
+  get items() {
+    return this._items;
+  }
+  rowClass = (id: number) => (this._selected === id ? 'danger' : '');
+  [$template] = template(LIST_TEMPLATE);
+}
+
+describe('list-perf harness', () => {
+  let fixture: DOMFixture;
+
+  beforeEach(() => {
+    fixture = createDOMFixture();
+    setupRuntimeTemplateGlobals();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test.runIf(process.env.RUN_LIST_PERF)(
+    'scenarios',
+    { timeout: 600_000 },
+    async () => {
+      const ROUNDS = 5;
+      const results: Record<string, number> = {};
+      const rows = () =>
+        fixture.container.querySelectorAll('tbody tr').length;
+      const assert = (cond: boolean, msg: string) => {
+        if (!cond) throw new Error(`harness sanity failed: ${msg}`);
+      };
+
+      const samples: Record<string, number[]> = {};
+      const record = (name: string, ms: number) => {
+        (samples[name] ??= []).push(ms);
+      };
+
+      for (let round = 0; round < ROUNDS; round++) {
+        const root = mountRoot(fixture, BenchRoot);
+
+        // create 1000
+        record('create1k', await timed(() => {
+          (root as any)._items = buildItems(1000);
+        }));
+        assert(rows() === 1000, `create1k rows=${rows()}`);
+
+        // update every 10th label (per-item cell push path)
+        record('update10th', await timed(() => {
+          const items = root._items;
+          for (let i = 0; i < items.length; i += 10) {
+            items[i].label = items[i].label + ' !!!';
+          }
+        }));
+
+        // select: 20 consecutive selections (shared-cell fan-out)
+        record('select20', await timed(async () => {
+          const items = root._items;
+          for (let s = 1; s <= 20; s++) {
+            (root as any)._selected = items[s * 37].id;
+            await settle();
+          }
+        }));
+        assert(
+          fixture.container.querySelectorAll('tr.danger').length === 1,
+          'select applied',
+        );
+
+        // swap rows 1 and 998
+        record('swap', await timed(() => {
+          const newData = [...root._items];
+          const t = newData[1];
+          newData[1] = newData[998];
+          newData[998] = t;
+          (root as any)._items = newData;
+        }));
+
+        // append 1000
+        record('append1k', await timed(() => {
+          (root as any)._items = [...root._items, ...buildItems(1000)];
+        }));
+        assert(rows() === 2000, `append1k rows=${rows()}`);
+
+        // replace all with fresh 1000 (disjoint keys)
+        record('replace1k', await timed(() => {
+          (root as any)._items = buildItems(1000);
+        }));
+        assert(rows() === 1000, `replace1k rows=${rows()}`);
+
+        // clear
+        record('clear1k', await timed(() => {
+          (root as any)._items = [];
+        }));
+        assert(rows() === 0, `clear rows=${rows()}`);
+
+        // create 5000
+        record('create5k', await timed(() => {
+          (root as any)._items = buildItems(5000);
+        }));
+        assert(rows() === 5000, `create5k rows=${rows()}`);
+
+        record('clear5k', await timed(() => {
+          (root as any)._items = [];
+        }));
+
+        fixture.cleanup();
+        fixture = createDOMFixture();
+      }
+
+      for (const [name, xs] of Object.entries(samples)) {
+        results[name] = Math.round(median(xs) * 100) / 100;
+      }
+      // eslint-disable-next-line no-console
+      console.log('PERF_RESULTS_JSON ' + JSON.stringify(results));
+    },
+  );
+});

--- a/src/core/list-perf.recycle.bench.test.ts
+++ b/src/core/list-perf.recycle.bench.test.ts
@@ -4,10 +4,10 @@
  * Perf bench: opt-in row recycling — "sliding window of references"
  * (reference-swap variant, RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A2).
  *
- * Methodology (timed/settle/median, ROUNDS=5, happy-dom, item shape) is
- * shared with src/core/list-perf.bench.test.ts via
+ * Methodology (timed/settle/median, ROUNDS=5, happy-dom, item shape, root
+ * component) is shared with src/core/list-perf.bench.test.ts via
  * __test-utils__/list-harness.ts — the comparison stays apples-to-apples by
- * construction. The ONLY template difference is the opt-in `key="@recycle"`.
+ * construction. The ONLY difference is the opt-in `key="@recycle"`.
  *
  * Headline comparison: `replaceAll1k` here vs the standard harness's
  * `replace1k` (destroy+create). Correctness-with-reactivity is proven by
@@ -27,49 +27,21 @@
  * recycling runs ungated in src/core/control-flow/list.recycle.test.ts.
  */
 import { describe, test, beforeEach, afterEach } from 'vitest';
-import { Component } from './component';
-import { $template } from './shared';
 import { createDOMFixture, type DOMFixture } from './__test-utils__';
-import { cellFor } from './reactive';
-import { template } from '../../plugins/runtime-compiler';
 import {
   buildItems,
   settle,
   timed,
   median,
   mountRoot,
+  defineBenchRoot,
   setupRuntimeTemplateGlobals,
   type HarnessItem,
 } from './__test-utils__/list-harness';
 
-// Identical body shape to the shared harness; the ONLY change is the opt-in
-// recycle sentinel key (rows are reused by position, never destroyed).
-const LIST_TEMPLATE = `
-  <table><tbody>
-    {{#each this.items key="@recycle" as |item|}}
-      <tr class={{this.rowClass item.id}}>
-        <td>{{item.id}}</td>
-        <td><a class={{this.rowClass item.id}}>{{item.label}}</a></td>
-        <td><span>x</span></td>
-      </tr>
-    {{/each}}
-  </tbody></table>
-`;
-
-class BenchRoot extends Component {
-  _items: HarnessItem[] = [];
-  _selected = 0;
-  constructor(args: any) {
-    super(args);
-    cellFor(this as any, '_items');
-    cellFor(this as any, '_selected');
-  }
-  get items() {
-    return this._items;
-  }
-  rowClass = (id: number) => (this._selected === id ? 'danger' : '');
-  [$template] = template(LIST_TEMPLATE);
-}
+// Identical root/body shape to the keyed harness; the ONLY difference is the
+// opt-in recycle sentinel key (rows are reused by position, never destroyed).
+const BenchRoot = defineBenchRoot('@recycle');
 
 describe('list-perf recycle harness', () => {
   let fixture: DOMFixture;

--- a/src/core/list-perf.recycle.bench.test.ts
+++ b/src/core/list-perf.recycle.bench.test.ts
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Perf bench: opt-in row recycling — "sliding window of references"
+ * (reference-swap variant, RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A2).
+ *
+ * Methodology (timed/settle/median, ROUNDS=5, happy-dom, item shape) is
+ * shared with src/core/list-perf.bench.test.ts via
+ * __test-utils__/list-harness.ts — the comparison stays apples-to-apples by
+ * construction. The ONLY template difference is the opt-in `key="@recycle"`.
+ *
+ * Headline comparison: `replaceAll1k` here vs the standard harness's
+ * `replace1k` (destroy+create). Correctness-with-reactivity is proven by
+ * `update10th` (per-item cellFor push through the recycled state objects)
+ * and `select20` (shared-cell fan-out), plus full DOM-content scans after
+ * every structural mutation (ids/labels actually correct after replace /
+ * shrink / grow-from-pool — the easy thing to get wrong).
+ *
+ * Note on shrink/grow numbers: the retire pool is capped (RECYCLE_POOL_LIMIT
+ * in list.ts), so shrinking by more than the cap destroys the overflow rows
+ * for real, and the following growth mixes pool reuse with fresh builds —
+ * the numbers measure the shipped behavior, not an unbounded pool.
+ *
+ * Results print as a single JSON line prefixed with PERF_RESULTS_JSON.
+ *
+ * Gated behind RUN_LIST_PERF=1 (CI vitest budget); functional coverage for
+ * recycling runs ungated in src/core/control-flow/list.recycle.test.ts.
+ */
+import { describe, test, beforeEach, afterEach } from 'vitest';
+import { Component } from './component';
+import { $template } from './shared';
+import { createDOMFixture, type DOMFixture } from './__test-utils__';
+import { cellFor } from './reactive';
+import { template } from '../../plugins/runtime-compiler';
+import {
+  buildItems,
+  settle,
+  timed,
+  median,
+  mountRoot,
+  setupRuntimeTemplateGlobals,
+  type HarnessItem,
+} from './__test-utils__/list-harness';
+
+// Identical body shape to the shared harness; the ONLY change is the opt-in
+// recycle sentinel key (rows are reused by position, never destroyed).
+const LIST_TEMPLATE = `
+  <table><tbody>
+    {{#each this.items key="@recycle" as |item|}}
+      <tr class={{this.rowClass item.id}}>
+        <td>{{item.id}}</td>
+        <td><a class={{this.rowClass item.id}}>{{item.label}}</a></td>
+        <td><span>x</span></td>
+      </tr>
+    {{/each}}
+  </tbody></table>
+`;
+
+class BenchRoot extends Component {
+  _items: HarnessItem[] = [];
+  _selected = 0;
+  constructor(args: any) {
+    super(args);
+    cellFor(this as any, '_items');
+    cellFor(this as any, '_selected');
+  }
+  get items() {
+    return this._items;
+  }
+  rowClass = (id: number) => (this._selected === id ? 'danger' : '');
+  [$template] = template(LIST_TEMPLATE);
+}
+
+describe('list-perf recycle harness', () => {
+  let fixture: DOMFixture;
+
+  beforeEach(() => {
+    fixture = createDOMFixture();
+    setupRuntimeTemplateGlobals();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test.runIf(process.env.RUN_LIST_PERF)(
+    'scenarios',
+    { timeout: 600_000 },
+    async () => {
+      const ROUNDS = 5;
+      const results: Record<string, number> = {};
+      const trs = () => fixture.container.querySelectorAll('tbody tr');
+      const rows = () => trs().length;
+      const assert = (cond: boolean, msg: string) => {
+        if (!cond) throw new Error(`recycle harness failed: ${msg}`);
+      };
+
+      // DOM-content assertion: every rendered row's id/label cells must match
+      // the items array, position by position. This is the recycle-mode
+      // correctness contract (stale bindings after a reference swap are the
+      // easy thing to get wrong).
+      const assertContent = (items: HarnessItem[], where: string) => {
+        const rendered = trs();
+        assert(
+          rendered.length === items.length,
+          `${where}: rows=${rendered.length} expected=${items.length}`,
+        );
+        for (let i = 0; i < items.length; i++) {
+          const tr = rendered[i];
+          const idText = tr.children[0]!.textContent;
+          const labelText = tr.children[1]!.querySelector('a')!.textContent;
+          assert(
+            idText === String(items[i].id),
+            `${where}: row ${i} id="${idText}" expected="${items[i].id}"`,
+          );
+          assert(
+            labelText === items[i].label,
+            `${where}: row ${i} label="${labelText}" expected="${items[i].label}"`,
+          );
+        }
+      };
+
+      const samples: Record<string, number[]> = {};
+      const record = (name: string, ms: number) => {
+        (samples[name] ??= []).push(ms);
+      };
+
+      for (let round = 0; round < ROUNDS; round++) {
+        const root = mountRoot(fixture, BenchRoot);
+
+        // create 1000 against a COLD pool (all rows freshly built)
+        const first = buildItems(1000);
+        record('createInitial1k', await timed(() => {
+          (root as any)._items = first;
+        }));
+        assertContent(first, 'createInitial1k');
+
+        // update every 10th label — the per-item cellFor push path must reach
+        // the DOM THROUGH the recycled state objects (holder + item cell).
+        record('update10th', await timed(() => {
+          const items = root._items;
+          for (let i = 0; i < items.length; i += 10) {
+            items[i].label = items[i].label + ' !!!';
+          }
+        }));
+        assertContent(first, 'update10th'); // first[] labels mutated in place
+        assert(
+          trs()[0].children[1]!.textContent!.endsWith(' !!!'),
+          'update10th: row 0 label not updated in DOM',
+        );
+        assert(
+          !trs()[1].children[1]!.textContent!.endsWith(' !!!'),
+          'update10th: row 1 label must be untouched',
+        );
+
+        // select: 20 consecutive selections (shared-cell fan-out)
+        record('select20', await timed(async () => {
+          const items = root._items;
+          for (let s = 1; s <= 20; s++) {
+            (root as any)._selected = items[s * 37].id;
+            await settle();
+          }
+        }));
+        assert(
+          fixture.container.querySelectorAll('tr.danger').length === 1,
+          'select applied',
+        );
+        assert(
+          fixture.container.querySelector('tr.danger')!.children[0]!
+            .textContent === String(first[20 * 37].id),
+          'select20: danger row id mismatch',
+        );
+
+        // replace all with fresh 1000 (disjoint ids) — THE HEADLINE: pure
+        // reference swap, zero destroy/create.
+        const fresh = buildItems(1000);
+        record('replaceAll1k', await timed(() => {
+          (root as any)._items = fresh;
+        }));
+        assertContent(fresh, 'replaceAll1k');
+
+        // correctness-after-swap: per-item push must target the NEW items
+        fresh[5].label = fresh[5].label + ' post-swap';
+        await settle();
+        assert(
+          trs()[5].children[1]!.textContent === fresh[5].label,
+          'post-swap update: row 5 label not updated through new item cell',
+        );
+        // correctness-after-swap: select must resolve against NEW ids
+        (root as any)._selected = fresh[123].id;
+        await settle();
+        assert(
+          fixture.container.querySelectorAll('tr.danger').length === 1 &&
+            fixture.container.querySelector('tr.danger')!.children[0]!
+              .textContent === String(fresh[123].id),
+          'post-swap select: danger row mismatch',
+        );
+
+        // shrink to half: trailing rows retire (pool-capped; overflow rows
+        // are destroyed for real)
+        record('shrinkToHalf', await timed(() => {
+          (root as any)._items = fresh.slice(0, 500);
+        }));
+        assertContent(fresh.slice(0, 500), 'shrinkToHalf');
+
+        // grow back: pooled rows return first (re-insert + re-bind), the
+        // overflow remainder is built fresh
+        record('growBack', await timed(() => {
+          (root as any)._items = fresh;
+        }));
+        assertContent(fresh, 'growBack');
+
+        // clear: rows retire into the pool up to the cap
+        record('clear1k', await timed(() => {
+          (root as any)._items = [];
+        }));
+        assert(rows() === 0, `clear rows=${rows()}`);
+
+        // create 1000 against a WARM (cap-bounded) pool
+        const reborn = buildItems(1000);
+        record('recreateFromPool1k', await timed(() => {
+          (root as any)._items = reborn;
+        }));
+        assertContent(reborn, 'recreateFromPool1k');
+
+        fixture.cleanup();
+        fixture = createDOMFixture();
+      }
+
+      for (const [name, xs] of Object.entries(samples)) {
+        results[name] = Math.round(median(xs) * 100) / 100;
+      }
+      // eslint-disable-next-line no-console
+      console.log('PERF_RESULTS_JSON ' + JSON.stringify(results));
+    },
+  );
+});

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -292,12 +292,20 @@ export function relatedTagsForCell(cell: Cell) {
  * error is surfaced to the host via the opcode-error reporter (NOT swallowed).
  */
 export function flushCellOpcodes(cell: Cell | MergedCell): void {
-  try {
-    executeTagSync(cell);
-  } catch (e) {
-    // Don't abort the flush, but report to the host (mirrors the normal drain's
-    // handleOpcodeError reporter path) rather than silently swallowing.
-    reportOpcodeError(e, cell);
+  // Only execute the cell's own opcodes when it actually has some — for cells
+  // that exist purely as subscription targets (selector key cells, recycle
+  // holder cells) an unguarded executeTagSync would MATERIALIZE an empty
+  // pooled ops array into the global opsForTag map per flush.
+  const ownOps = opsForTag.get((cell as Cell).id);
+  if (ownOps !== undefined && ownOps.length > 0) {
+    try {
+      executeTagSync(cell);
+    } catch (e) {
+      // Don't abort the flush, but report to the host (mirrors the normal
+      // drain's handleOpcodeError reporter path) rather than silently
+      // swallowing.
+      reportOpcodeError(e, cell);
+    }
   }
   const subTags = relatedTags.get((cell as Cell).id);
   if (subTags === undefined) {
@@ -315,6 +323,42 @@ export function flushCellOpcodes(cell: Cell | MergedCell): void {
     } catch (e) {
       reportOpcodeError(e, tag);
     }
+  }
+}
+
+/**
+ * Apply a cell update synchronously and deliver it to subscribers NOW.
+ *
+ * The drain-safe sibling of `Cell.update()`: a plain `update()` issued from
+ * inside an active `syncDomSync` lands in `tagsToRevalidate` after the drain
+ * snapshotted its work list, so the terminal clear silently drops it. This
+ * helper instead:
+ *   - mutates `_value`/`_revision` directly, BYPASSING the host
+ *     `_cellUpdateDeferralHook` (a deferred apply would leave `_value` stale
+ *     while the caller immediately re-executes subscribers against it);
+ *   - removes the cell from `tagsToRevalidate` so an in-flight drain doesn't
+ *     double-execute it;
+ *   - flushes its opcodes + subscriber formulas via `flushCellOpcodes` under
+ *     `_isRendering` — REQUIRED: `MergedCell.value` only re-collects deps on
+ *     the tracking path, so flushing while not rendering would permanently
+ *     unsubscribe every re-executed formula.
+ *
+ * Used by `keyedSelector` key-cell flips and the recycle-mode holder swap in
+ * the list control flow. No-op when the value is reference-equal.
+ */
+export function applyCellUpdateSync<T>(cell: Cell<T>, value: T): void {
+  if (cell._value === value) {
+    return;
+  }
+  cell._value = value;
+  cell._revision = bumpGlobalRevision();
+  tagsToRevalidate.delete(cell as Cell<unknown>);
+  const wasRendering = _isRendering;
+  if (!wasRendering) setIsRendering(true);
+  try {
+    flushCellOpcodes(cell);
+  } finally {
+    if (!wasRendering) setIsRendering(false);
   }
 }
 

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the keyedSelector primitive (src/core/selector.ts).
+ *
+ * Verifies the O(2) fan-out contract: when the source key changes, ONLY the
+ * formulas subscribed to the previous key's cell and the next key's cell
+ * re-execute — every other key's subscriber stays untouched. Also covers lazy
+ * per-key cell creation/reuse, initial truth for the currently-selected key,
+ * function sources, in-drain batching (snapshotted drain work list), and
+ * destroy/owner cleanup.
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import {
+  cell,
+  formula,
+  tagsToRevalidate,
+  opsForTag,
+  relatedTags,
+  setTracker,
+  setIsRendering,
+} from './reactive';
+import { opcodeFor } from './vm';
+import { keyedSelector } from './selector';
+import { destroySync } from './glimmer/destroyable';
+
+// drain the microtask-scheduled syncDom
+const settle = () => new Promise<void>((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  tagsToRevalidate.clear();
+  opsForTag.clear();
+  relatedTags.clear();
+  setTracker(null);
+  setIsRendering(false);
+});
+
+/**
+ * Subscribe one formula per key to `select` and count opcode executions.
+ * Mirrors how a row's class-binding formula subscribes in real templates.
+ */
+function subscribeKeys<K>(
+  select: (key: K) => boolean,
+  keys: K[],
+): {
+  counts: Map<K, number>;
+  values: Map<K, boolean>;
+  destructors: Array<() => void>;
+} {
+  const counts = new Map<K, number>();
+  const values = new Map<K, boolean>();
+  const destructors: Array<() => void> = [];
+  for (const key of keys) {
+    const f = formula(() => select(key), `selector-test-${String(key)}`);
+    destructors.push(
+      opcodeFor(f, (value: unknown) => {
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+        values.set(key, value as boolean);
+      }),
+    );
+  }
+  return { counts, values, destructors };
+}
+
+describe('keyedSelector', () => {
+  test('initial read is true for the currently-selected key, false otherwise', () => {
+    const source = cell(2);
+    const select = keyedSelector(source);
+
+    expect(select(2)).toBe(true);
+    expect(select(1)).toBe(false);
+    expect(select(999)).toBe(false);
+
+    select.destroy();
+  });
+
+  test('per-key cells are created lazily and reused for repeated reads', () => {
+    const source = cell(1);
+    const select = keyedSelector(source);
+
+    expect(select.size).toBe(0); // nothing materialized before any read
+
+    select(7);
+    expect(select.size).toBe(1);
+
+    select(7); // repeated read of the same key reuses the one cell
+    select(7);
+    expect(select.size).toBe(1);
+
+    select(8);
+    expect(select.size).toBe(2);
+
+    select.destroy();
+  });
+
+  test('only old and new key subscribers re-execute on change (O(2) fan-out)', async () => {
+    const source = cell(1);
+    const select = keyedSelector(source);
+    const keys = [1, 2, 3, 4, 5];
+    const { counts, values, destructors } = subscribeKeys(select, keys);
+
+    // initial evaluation: each subscriber ran exactly once
+    for (const k of keys) expect(counts.get(k)).toBe(1);
+    expect(values.get(1)).toBe(true);
+    for (const k of [2, 3, 4, 5]) expect(values.get(k)).toBe(false);
+
+    source.update(3);
+    await settle();
+
+    // ONLY key 1 (deselected) and key 3 (selected) re-ran
+    expect(counts.get(1)).toBe(2);
+    expect(counts.get(3)).toBe(2);
+    expect(counts.get(2)).toBe(1);
+    expect(counts.get(4)).toBe(1);
+    expect(counts.get(5)).toBe(1);
+    expect(values.get(1)).toBe(false);
+    expect(values.get(3)).toBe(true);
+
+    // second change: 3 → 5; keys 1/2/4 still untouched
+    source.update(5);
+    await settle();
+    expect(counts.get(3)).toBe(3);
+    expect(counts.get(5)).toBe(2);
+    expect(counts.get(1)).toBe(2);
+    expect(counts.get(2)).toBe(1);
+    expect(counts.get(4)).toBe(1);
+    expect(values.get(3)).toBe(false);
+    expect(values.get(5)).toBe(true);
+
+    destructors.forEach((d) => d());
+    select.destroy();
+  });
+
+  test('re-setting the same key is a no-op (no subscriber re-runs)', async () => {
+    const source = cell(1);
+    const select = keyedSelector(source);
+    const { counts, destructors } = subscribeKeys(select, [1, 2]);
+
+    source.update(1);
+    await settle();
+
+    expect(counts.get(1)).toBe(1);
+    expect(counts.get(2)).toBe(1);
+
+    destructors.forEach((d) => d());
+    select.destroy();
+  });
+
+  test('selecting a key with no materialized cell still deselects the old one', async () => {
+    const source = cell(1);
+    const select = keyedSelector(source);
+    const { counts, values, destructors } = subscribeKeys(select, [1]);
+
+    source.update(42); // nobody ever read key 42
+    await settle();
+
+    expect(counts.get(1)).toBe(2);
+    expect(values.get(1)).toBe(false);
+    // a later read of the new key materializes its cell with the right value
+    expect(select(42)).toBe(true);
+
+    destructors.forEach((d) => d());
+    select.destroy();
+  });
+
+  test('function source: wraps in a formula and tracks its dependencies', async () => {
+    const source = cell(10);
+    const select = keyedSelector(() => source.value);
+    const { counts, values, destructors } = subscribeKeys(select, [10, 20]);
+
+    expect(values.get(10)).toBe(true);
+    expect(values.get(20)).toBe(false);
+
+    source.update(20);
+    await settle();
+
+    expect(counts.get(10)).toBe(2);
+    expect(counts.get(20)).toBe(2);
+    expect(values.get(10)).toBe(false);
+    expect(values.get(20)).toBe(true);
+
+    destructors.forEach((d) => d());
+    select.destroy();
+  });
+
+  test('flips apply even when the drain work list was snapshotted (multi-cell batch)', async () => {
+    // When >1 cell is dirty, syncDomSync iterates a SNAPSHOT of
+    // tagsToRevalidate — cells dirtied mid-drain would be cleared without
+    // executing. The selector must therefore flush flips synchronously.
+    const source = cell(1);
+    const unrelated = cell(0);
+    let unrelatedRuns = 0;
+    const dropUnrelated = opcodeFor(unrelated, () => {
+      unrelatedRuns++;
+    });
+    const select = keyedSelector(source);
+    const { counts, values, destructors } = subscribeKeys(select, [1, 2, 3]);
+
+    // dirty BOTH cells in the same tick → snapshot path in the drain
+    unrelated.update(99);
+    source.update(3);
+    await settle();
+
+    expect(unrelatedRuns).toBe(2); // initial + batch
+    expect(counts.get(1)).toBe(2);
+    expect(counts.get(3)).toBe(2);
+    expect(counts.get(2)).toBe(1);
+    expect(values.get(1)).toBe(false);
+    expect(values.get(3)).toBe(true);
+
+    dropUnrelated();
+    destructors.forEach((d) => d());
+    select.destroy();
+  });
+
+  test('destroy unsubscribes from the source and clears the key map', async () => {
+    const source = cell(1);
+    const select = keyedSelector(source);
+    const { counts, destructors } = subscribeKeys(select, [1, 2]);
+    expect(select.size).toBe(2);
+
+    select.destroy();
+
+    expect(select.size).toBe(0);
+    // source opcode fully removed (ops array drained + released)
+    expect(opsForTag.has(source.id)).toBe(false);
+
+    source.update(2);
+    await settle();
+
+    // no subscriber re-ran — the selector is disconnected
+    expect(counts.get(1)).toBe(1);
+    expect(counts.get(2)).toBe(1);
+
+    // post-destroy reads: frozen plain comparison, no new cells materialized
+    expect(select(1)).toBe(true);
+    expect(select(2)).toBe(false);
+    expect(select.size).toBe(0);
+
+    // idempotent
+    select.destroy();
+
+    destructors.forEach((d) => d());
+  });
+
+  test('dead keys are pruned on source change once the map grows (destroyed rows)', async () => {
+    const source = cell(0);
+    const select = keyedSelector(source, undefined, 'prune-test');
+    // Cross the sweep threshold (PRUNE_MIN_SIZE = 64) with 70 subscribed keys.
+    const keys = Array.from({ length: 70 }, (_, i) => i + 1);
+    const { counts, destructors } = subscribeKeys(select, keys);
+    expect(select.size).toBe(70);
+
+    // Destroy all but 5 subscribers — simulates rows leaving the list. Their
+    // formulas remove themselves from the key cells' relatedTags sets.
+    destructors.slice(5).forEach((d) => d());
+
+    source.update(3);
+    await settle();
+
+    // Swept down to the live keys (the active key's cell is always kept).
+    expect(select.size).toBeLessThanOrEqual(6);
+    expect(select(3)).toBe(true);
+    expect(select(4)).toBe(false);
+    // Surviving subscriber for key 3 saw the flip.
+    expect(counts.get(3)).toBe(2);
+
+    destructors.slice(0, 5).forEach((d) => d());
+    select.destroy();
+  });
+
+  test('destroy is registered on the owner when one is passed', async () => {
+    const owner = {};
+    const source = cell(1);
+    const select = keyedSelector(source, owner);
+    const { counts, destructors } = subscribeKeys(select, [1, 2]);
+
+    destroySync(owner);
+
+    expect(select.size).toBe(0);
+    source.update(2);
+    await settle();
+    expect(counts.get(1)).toBe(1);
+    expect(counts.get(2)).toBe(1);
+
+    destructors.forEach((d) => d());
+  });
+});

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -1,0 +1,192 @@
+/**
+ * `keyedSelector` — O(2) fan-out for `selected === key` style bindings.
+ *
+ * Problem (see RESEARCH_LIST_TRACKING_OPTIMIZATION.md §1.2 / §4.2): a binding
+ * like `class={{if (eq this.selected item.id) "danger"}}` makes EVERY row's
+ * formula subscribe to the single shared `selected` cell. Changing selection
+ * then re-executes O(N) formulas even though only two rows visually change.
+ *
+ * Solution (SolidJS `createSelector` shape): keep ONE subscription on the
+ * source and a `Map<key, Cell<boolean>>`. Row formulas call the selector with
+ * their key inside their tracking frame, so each row subscribes to ITS OWN
+ * per-key boolean cell. When the source changes, only the previous key's cell
+ * and the next key's cell flip → exactly ≤2 cell notifications, regardless of
+ * list size. Per-key cells are created lazily on first read and reused for
+ * repeated reads of the same key.
+ *
+ * Flip mechanics: the selector's source opcode runs INSIDE the `syncDomSync`
+ * drain (it is executed as one of the dirty source cell's ops), where a plain
+ * `Cell.update()` would be silently discarded by the drain's terminal
+ * `tagsToRevalidate.clear()`. Flips go through `applyCellUpdateSync` — the
+ * drain-safe update path (direct mutate + synchronous subscriber flush under
+ * `_isRendering`, bypassing the host deferral hook).
+ *
+ * Lifecycle: `selector.destroy()` removes the source subscription (destroying
+ * the internal formula when the source was a function), releases per-key
+ * bookkeeping (`opsForTag` arrays, `relatedTags` entries) and clears the map.
+ * Pass an `owner` to auto-destroy via `registerDestructor` when the owner
+ * (e.g. a component) is destroyed. After destroy, reads return a plain
+ * comparison against the last-known key and no longer materialize cells.
+ *
+ * Memory: key cells whose subscribers are all gone (their rows were destroyed)
+ * are swept on every source change (interaction-rate, immediate reclaim) and,
+ * watermark-gated, on new-key materialization (so churning data prunes even
+ * while the selection never moves). The sweep can only collect keys whose
+ * subscriber formulas were DESTROYED; a formula that merely stopped reading a
+ * key stays subscribed until it is destroyed (GXT formulas never unbind
+ * dropped deps), so pair long-lived selectors with row teardown, not row
+ * recycling.
+ */
+import {
+  type Cell,
+  type AnyCell,
+  cell as createCell,
+  formula,
+  applyCellUpdateSync,
+  opsForTag,
+  relatedTags,
+  releaseOpArray,
+} from '@/core/reactive';
+import { opcodeFor } from '@/core/vm';
+import { registerDestructor } from '@/core/glimmer/destroyable';
+import { isFn } from '@/core/shared';
+
+export interface KeyedSelector<K> {
+  (key: K): boolean;
+  /** Number of materialized per-key cells (introspection / tests). */
+  readonly size: number;
+  /** Unsubscribe from the source and drop all per-key cells. Idempotent. */
+  destroy(): void;
+}
+
+// A key cell with no remaining subscribers is dead weight: its row formulas
+// were destroyed (row removed / list cleared) and removed themselves from the
+// cell's relatedTags set. Ops-array emptiness — not absence — is the liveness
+// signal on the ops side (pooled arrays may linger empty).
+function isKeyCellUnused(keyCell: Cell<boolean>): boolean {
+  const subs = relatedTags.get(keyCell.id);
+  if (subs !== undefined && subs.size > 0) {
+    return false;
+  }
+  const ops = opsForTag.get(keyCell.id);
+  return ops === undefined || ops.length === 0;
+}
+
+function releaseKeyCell(keyCell: Cell<boolean>): void {
+  const ops = opsForTag.get(keyCell.id);
+  if (ops !== undefined) {
+    opsForTag.delete(keyCell.id);
+    releaseOpArray(ops);
+  }
+  relatedTags.delete(keyCell.id);
+}
+
+// Don't sweep tiny maps — the walk costs more than the memory it frees.
+const PRUNE_MIN_SIZE = 64;
+
+export function keyedSelector<K>(
+  source: Cell<K> | (() => K),
+  owner?: object,
+  debugName?: string,
+): KeyedSelector<K> {
+  const cells = new Map<K, Cell<boolean>>();
+  // One subscription on the source for the whole selector: a raw Cell is
+  // subscribed directly (its ops run when it dirties); a function source is
+  // wrapped in a formula so it tracks whatever cells it reads.
+  const tag: AnyCell = isFn(source)
+    ? formula(source, debugName ?? 'keyedSelector.source')
+    : source;
+  let isDestroyed = false;
+  // Established synchronously below: opcodeFor runs the source op once during
+  // construction, before any external read can happen.
+  let currentKey!: K;
+
+  // Dead-key sweep: rows that are destroyed leave their key cells
+  // subscriber-less but still in the map, so a long-lived selector over
+  // churning data (replace-all every tick) would grow without bound.
+  // Two triggers with different gating:
+  //   - source change (user-interaction rate): full sweep whenever the map is
+  //     non-trivial — a selection change after mass row teardown reclaims
+  //     everything immediately;
+  //   - new-key materialization (render rate): watermark-gated — sweep only
+  //     once the map doubles past the last sweep, so churn under a
+  //     never-moving selection still prunes without an O(size) walk per read.
+  let pruneThreshold = PRUNE_MIN_SIZE;
+  function pruneUnusedKeys(): void {
+    for (const [key, keyCell] of cells) {
+      // Never drop the active key's cell — the next flip needs it.
+      if (key === currentKey) continue;
+      if (isKeyCellUnused(keyCell)) {
+        releaseKeyCell(keyCell);
+        cells.delete(key);
+      }
+    }
+    pruneThreshold = Math.max(PRUNE_MIN_SIZE, cells.size * 2);
+  }
+
+  const removeSourceOpcode = opcodeFor(tag, (next: unknown) => {
+    const nextKey = next as K;
+    const prevKey = currentKey;
+    if (nextKey === prevKey) {
+      return;
+    }
+    // Commit the new key BEFORE flipping so key cells materialized lazily by
+    // re-executing subscriber formulas initialize against the new key.
+    currentKey = nextKey;
+    const prevCell = cells.get(prevKey);
+    if (prevCell !== undefined) {
+      applyCellUpdateSync(prevCell, false);
+    }
+    const nextCell = cells.get(nextKey);
+    if (nextCell !== undefined) {
+      applyCellUpdateSync(nextCell, true);
+    }
+    if (cells.size >= PRUNE_MIN_SIZE) {
+      pruneUnusedKeys();
+    }
+  });
+
+  const select = ((key: K): boolean => {
+    let keyCell = cells.get(key);
+    if (keyCell === undefined) {
+      if (isDestroyed) {
+        // Frozen post-destroy semantics: plain comparison, no new cells.
+        return key === currentKey;
+      }
+      // Sweep BEFORE inserting: the cell being materialized has no
+      // subscribers until its reader's tracking frame closes, so a
+      // post-insert sweep would reclaim it and orphan that subscription.
+      if (cells.size >= pruneThreshold) {
+        pruneUnusedKeys();
+      }
+      keyCell = createCell(
+        key === currentKey,
+        IS_DEV_MODE ? `keyedSelector(${String(key)})` : undefined,
+      );
+      cells.set(key, keyCell);
+    }
+    // Tracked read: a formula evaluating this subscribes to THIS key's cell,
+    // not to the selector source.
+    return keyCell.value;
+  }) as KeyedSelector<K>;
+
+  const destroy = () => {
+    if (isDestroyed) {
+      return;
+    }
+    isDestroyed = true;
+    removeSourceOpcode();
+    cells.forEach(releaseKeyCell);
+    cells.clear();
+  };
+  select.destroy = destroy;
+  Object.defineProperty(select, 'size', {
+    get: () => cells.size,
+  });
+
+  if (owner !== undefined) {
+    registerDestructor(owner, destroy);
+  }
+
+  return select;
+}


### PR DESCRIPTION
## What

Consolidated landing of the `{{#each}}` tracking-context research (`RESEARCH_LIST_TRACKING_OPTIMIZATION.md` included — six prototypes built and measured on `exp/*` branches; this PR lands the two production-shaped ones plus the shared measurement harness).

### 1. `keyedSelector` — O(2) selection fan-out (`src/core/selector.ts`)

`selected === id` bindings subscribe every row's formula to one shared cell → selection change re-executes O(N) formulas. `keyedSelector(source)` keeps ONE subscription on the source and a lazy `Map<key, Cell<boolean>>`; rows subscribe to their own key cell; a change flips exactly prev/next. Dead keys are swept on source change + watermark-gated on reads (bounded by live key count). Built on the new `applyCellUpdateSync` primitive in `reactive.ts` — the single home for drain-safe cell updates (direct mutate bypassing the host deferral hook + synchronous flush under `_isRendering`).

**Wired into the benchmark app** (`Row.gts`/`Benchmark.gts`, keyed `{{#each}}` untouched — same pattern as SolidJS's js-framework-benchmark entry). Tracerbench vs master: **selectFirstRow −97%, selectSecondRow −98%, total duration −2.8%**; trade: +2-4% on render phases (per-key cell materialization).

### 2. Opt-in row recycling — `{{#each items key="@recycle"}}` (tree-shakable)

Positional reference-swap fast path: rows render against a stable state object forwarding through a re-pointable holder `Cell`; replace = swap N references. Shrink retires rows into a capped pool (`RECYCLE_POOL_LIMIT=256`, overflow torn down for real); growth reuses the pool. **Intentionally breaks keyed semantics** (row DOM identity does not follow items; block param is the state object) — strictly opt-in, default `{{#each}}` untouched.

**Tree-shakable by construction**: all recycle logic lives in `list-recycle.ts`; the compiler resolves the `@recycle` sentinel at build time and emits `$_eachRecycled` instead of `$_each`. Apps that never use it ship **zero recycle bytes** (verified: `import { cell }` esbuild probe contains no `@recycle`; the always-shipped dom chunk is 38,494 B — *below* master's 39,304 B).

Measured (happy-dom, median of 5, idle): **replaceAll1k 16.25ms vs keyed 596.92ms (35.7×)**, recreate-after-clear −14%, per-item update parity, select +24% (holder entanglement, documented), clear ≈ keyed (price of the bounded pool).

### 3. Perf harness (`RUN_LIST_PERF=1`-gated) + research doc

Krausest-shaped `{{#each}}` via the runtime compiler; methodology (item shape, timing, root component, mount ritual) shared via `__test-utils__/list-harness.ts`. Gated to stay out of the CI vitest budget. Note: happy-dom's `insertBefore` is O(n) (array-backed childNodes), so create timings are not comparable across row counts.

## Compatibility

No breaking changes for existing apps. Three theoretical edges: (1) a template using the literal string `@recycle` as a *property-name* key changes meaning (the `@` namespace was already reserved for `@identity`/`@index`); (2) `flushCellOpcodes` now skips the own-ops phase for cells with zero opcodes (observably identical for all in-repo callers); (3) constructing list classes directly (no compiler) with `key='@recycle'` reads it as a property key — dev mode surfaces it.

## Testing

3,813 vitest tests green (12 selector + 7 recycle functional tests incl. DOM-identity contract, prototype-accessor `@tracked` items, pool cap, inverse blocks); `tsc --noEmit` clean; QUnit-in-Chromium green; select/deselect verified against the production deploy preview. Multi-angle review applied (deferral-hook stale-flush, re-entry guards, host marker registry, pool cap, prune-orphan fix).

## Follow-ups (measured on exp/* branches, not in this PR)

Static-block fast path (#221, stacked), frames v2 (verified create −49%/clear −73%, `exp/d2-frames`), drain-overhead diet (`exp/d1-drain`), same-module component inlining (`exp/d3-inline`), `sideEffects` audit (`exp/d4-hygiene`, consumer bundle −81%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)