### PR TITLE
feat(host): registerHostHooks() + registerHostManagers() formal host-integration APIs

### DIFF
--- a/plugins/__tests__/hbs-sniff.test.ts
+++ b/plugins/__tests__/hbs-sniff.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { hasHbsTaggedTemplate } from '../compiler';
+
+describe('hasHbsTaggedTemplate', () => {
+  it('matches genuine tagged templates', () => {
+    expect(hasHbsTaggedTemplate('const t = hbs`<div></div>`;')).toBe(true);
+    expect(hasHbsTaggedTemplate('return hbs `{{x}}`;')).toBe(true);
+    expect(hasHbsTaggedTemplate('fn(hbs`{{x}}`)')).toBe(true);
+    expect(hasHbsTaggedTemplate('hbs`top of file`')).toBe(true);
+  });
+
+  it('ignores file-extension and inline-code prose', () => {
+    // The emberjs/ember.js#21340 docs sentence: closing backtick of an
+    // inline-code span directly after "hbs".
+    expect(
+      hasHbsTaggedTemplate('// components were authored in paired `.hbs` and `.js` files')
+    ).toBe(false);
+    expect(hasHbsTaggedTemplate("// rename 'template.hbs' to `template.gjs`")).toBe(false);
+    expect(hasHbsTaggedTemplate('/** see `hbs` for details */')).toBe(false);
+    expect(hasHbsTaggedTemplate('// "hbs" files')).toBe(false);
+    expect(hasHbsTaggedTemplate('const stubhbs = stubhbs`x`;')).toBe(false);
+  });
+});

--- a/plugins/compiler.ts
+++ b/plugins/compiler.ts
@@ -15,6 +15,21 @@ function toViteResult(result: ReturnType<typeof transform>): ViteTransformResult
 
 const p = new Preprocessor();
 
+/**
+ * Detect a genuine `hbs\`...\`` tagged template in a .ts/.js module.
+ *
+ * The negative lookbehind excludes file-extension / inline-code PROSE in doc
+ * comments — `.hbs`, 'hbs', "hbs", \`hbs — which would otherwise route the
+ * whole module through the template transform and mangle its exports. A docs
+ * sentence like "components were authored in paired \`.hbs\` files" hit
+ * exactly this in emberjs/ember.js#21340 (the closing backtick of the
+ * inline-code span follows "hbs" directly). Genuine tags are preceded by
+ * whitespace, `=`, `(`, `,`, `return`, start-of-file, etc.
+ */
+export function hasHbsTaggedTemplate(code: string): boolean {
+  return /(?<![.\w'"`])hbs\s*`/.test(code);
+}
+
 const extensionsToResolve = [
   '.mjs',
   '.js',
@@ -110,7 +125,7 @@ export function compiler(mode: string, options: Options = {}): Plugin {
       // Only process .ts/.js files that use hbs tagged templates.
       // Files that merely import from @lifeart/gxt don't need the babel transform
       // (which injects symbol imports that may conflict with existing declarations).
-      const hasHbsTemplate = /hbs\s*`/.test(code);
+      const hasHbsTemplate = hasHbsTaggedTemplate(code);
       if (!hasHbsTemplate) {
         return;
       }

--- a/src/core/control-flow/if.ts
+++ b/src/core/control-flow/if.ts
@@ -29,6 +29,7 @@ import { cId, addToTree } from '@/core/tree';
 import { opcodeFor } from '@/core/vm';
 import { initDOM } from '@/core/context';
 import { setParentContext, getParentContext } from '../tracking';
+import { HOST_HOOKS } from '@/core/host-hooks';
 
 export type IfFunction = () => boolean;
 
@@ -456,7 +457,8 @@ export class IfCondition {
       this.condition = formula(() => {
         const v = maybeCondition();
         // Allow external truthiness override (e.g., Ember's special rules)
-        const externalToBool = (globalThis as any).__gxtToBool;
+        const externalToBool =
+          HOST_HOOKS.toBool ?? (globalThis as any).__gxtToBool;
         if (externalToBool) {
           return externalToBool(v);
         }

--- a/src/core/control-flow/list.ts
+++ b/src/core/control-flow/list.ts
@@ -44,6 +44,7 @@ import {
   destroySync,
 } from '../glimmer/destroyable';
 import { setParentContext, getParentContext } from '../tracking';
+import { HOST_HOOKS } from '@/core/host-hooks';
 
 // Re-export getFirstNode for backward compatibility
 export { getFirstNode };
@@ -578,11 +579,13 @@ export class BasicListComponent<T extends { id: number }> {
       // gxt-backend artifact stripper) skip our list-marker comments when
       // pruning empty comments from rendered output. See registration sites
       // in the constructor and updateItems.
-      const _unreg = (
-        globalThis as {
-          __gxtUnregisterListMarker?: (m: Comment) => void;
-        }
-      ).__gxtUnregisterListMarker;
+      const _unreg =
+        HOST_HOOKS.unregisterListMarker ??
+        (
+          globalThis as {
+            __gxtUnregisterListMarker?: (m: Comment) => void;
+          }
+        ).__gxtUnregisterListMarker;
       if (_unreg) {
         for (const marker of this.markerSet) {
           _unreg(marker);
@@ -627,9 +630,10 @@ export class BasicListComponent<T extends { id: number }> {
     // passes (e.g. ember.js's removeGxtArtifacts). The hook is a no-op when
     // no consumer has installed it.
     {
-      const _reg = (
-        globalThis as { __gxtRegisterListMarker?: (m: Comment) => void }
-      ).__gxtRegisterListMarker;
+      const _reg =
+        HOST_HOOKS.registerListMarker ??
+        (globalThis as { __gxtRegisterListMarker?: (m: Comment) => void })
+          .__gxtRegisterListMarker;
       if (_reg) {
         _reg(this.topMarker);
         _reg(this.bottomMarker);
@@ -1023,6 +1027,7 @@ export class BasicListComponent<T extends { id: number }> {
       // read if invoked out of band.
       const _reg =
         this._registerMarkerHook ??
+        HOST_HOOKS.registerListMarker ??
         (globalThis as { __gxtRegisterListMarker?: (m: Comment) => void })
           .__gxtRegisterListMarker;
       if (_reg) _reg(marker);
@@ -1112,9 +1117,10 @@ export class BasicListComponent<T extends { id: number }> {
     // reading it once per updateItems (instead of once per new marker) removes a
     // global-property lookup per row on the create/append path. Stashed on the
     // instance so `_buildAndInsertRow` (the append fast-path) reuses it too.
-    this._registerMarkerHook = (
-      globalThis as { __gxtRegisterListMarker?: (m: Comment) => void }
-    ).__gxtRegisterListMarker;
+    this._registerMarkerHook =
+      HOST_HOOKS.registerListMarker ??
+      (globalThis as { __gxtRegisterListMarker?: (m: Comment) => void })
+        .__gxtRegisterListMarker;
     const _registerMarker = this._registerMarkerHook;
     existKeys.length = 0;
     existNewIdx.length = 0;
@@ -1320,7 +1326,9 @@ export class BasicListComponent<T extends { id: number }> {
         if (this.boundItemMap !== null) {
           const boundItem = this.boundItemMap.get(key);
           if (boundItem !== item) {
-            const rebind = (globalThis as any).__gxtRebindEachItem;
+            const rebind =
+              HOST_HOOKS.rebindEachItem ??
+              (globalThis as any).__gxtRebindEachItem;
             if (typeof rebind === 'function') {
               rebind(boundItem, item);
             }

--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -76,6 +76,11 @@ import {
   setParentContext,
   getParentContext,
 } from './tracking';
+import {
+  HOST_HOOKS,
+  isHostFunctionalHelper,
+  markHostFunctionalHelper,
+} from '@/core/host-hooks';
 export { pushParentContext, popParentContext, setParentContext, getParentContext };
 
 
@@ -227,16 +232,14 @@ export function $_helperHelper(params: any[], hash: Record<string, unknown>) {
     }
   }
 
-  // @ts-expect-error EmberFunctionalHelpers global
-  if (typeof EmberFunctionalHelpers !== 'undefined' && EmberFunctionalHelpers.has(helperFn)) {
+  if (isHostFunctionalHelper(helperFn)) {
     function wrappedHelper(_params: any[], _hash: Record<string, unknown>) {
       return $_maybeHelper(helperFn, [...boundParams, ..._params], {
         ...hash,
         ..._hash,
       });
     }
-    // @ts-expect-error EmberFunctionalHelpers global
-    EmberFunctionalHelpers.add(wrappedHelper);
+    markHostFunctionalHelper(wrappedHelper);
     return wrappedHelper;
   }
 
@@ -1126,8 +1129,7 @@ export const $_maybeHelper = (
         return helper.compute.call(helper, $_unwrapArgs(runtimeArgs), hash);
       };
     }
-    // @ts-expect-error EmberFunctionalHelpers global
-    if (typeof EmberFunctionalHelpers !== 'undefined' && EmberFunctionalHelpers.has(value)) {
+    if (isHostFunctionalHelper(value)) {
       // @ts-expect-error amount of args
       const hash = $_args(_hash, false);
       return (...runtimeArgs: any[]) => {
@@ -1183,9 +1185,9 @@ export const $_maybeHelper = (
     if (WITH_DYNAMIC_EVAL) {
       // The outer getter from compiled code handles reactivity
       // Check ctx.$_eval first (passed directly, avoids closure overhead)
-      // Then fall back to globalThis.$_eval for initial render
+      // Then fall back to the host hook / globalThis.$_eval for initial render
       // @ts-expect-error $_eval may exist on ctx
-      const evalFn = _ctx?.$_eval ?? globalThis.$_eval;
+      const evalFn = _ctx?.$_eval ?? HOST_HOOKS.dynamicEval ?? globalThis.$_eval;
       if (typeof evalFn === 'function') {
         try {
           const result = evalFn(value);
@@ -1598,8 +1600,10 @@ function ifCond(
   {
     const cond = instance.condition as { isConst?: boolean };
     if (cond && cond.isConst !== true) {
-      const _reg = (globalThis as { __gxtRegisterListMarker?: (m: Comment) => void })
-        .__gxtRegisterListMarker;
+      const _reg =
+        HOST_HOOKS.registerListMarker ??
+        (globalThis as { __gxtRegisterListMarker?: (m: Comment) => void })
+          .__gxtRegisterListMarker;
       if (_reg) {
         _reg(placeholder);
       }

--- a/src/core/host-hooks.test.ts
+++ b/src/core/host-hooks.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  HOST_HOOKS,
+  registerHostHooks,
+  isHostFunctionalHelper,
+  markHostFunctionalHelper,
+  type HostHooks,
+} from './host-hooks';
+
+function resetHooks() {
+  for (const key of Object.keys(HOST_HOOKS)) {
+    delete (HOST_HOOKS as Record<string, unknown>)[key];
+  }
+}
+
+describe('registerHostHooks', () => {
+  afterEach(() => {
+    resetHooks();
+    delete (globalThis as Record<string, unknown>)['EmberFunctionalHelpers'];
+  });
+
+  it('merges registered hooks into the slot table', () => {
+    const toBool = (v: unknown) => v === 'yes';
+    registerHostHooks({ toBool });
+    expect(HOST_HOOKS.toBool).toBe(toBool);
+  });
+
+  it('later registrations override per-key and keep other keys', () => {
+    const first: HostHooks = {
+      toBool: () => true,
+      scheduleRevalidate: () => {},
+    };
+    registerHostHooks(first);
+    const secondToBool = () => false;
+    registerHostHooks({ toBool: secondToBool });
+    expect(HOST_HOOKS.toBool).toBe(secondToBool);
+    expect(HOST_HOOKS.scheduleRevalidate).toBe(first.scheduleRevalidate);
+  });
+
+  it('ignores undefined values instead of clearing a slot', () => {
+    const toBool = () => true;
+    registerHostHooks({ toBool });
+    registerHostHooks({ toBool: undefined });
+    expect(HOST_HOOKS.toBool).toBe(toBool);
+  });
+
+  describe('functional-helper brand', () => {
+    it('prefers the registered hook pair', () => {
+      const branded = new WeakSet<object>();
+      registerHostHooks({
+        isFunctionalHelper: (fn) => branded.has(fn as object),
+        markFunctionalHelper: (fn) => void branded.add(fn as object),
+      });
+      const helper = () => {};
+      expect(isHostFunctionalHelper(helper)).toBe(false);
+      markHostFunctionalHelper(helper);
+      expect(isHostFunctionalHelper(helper)).toBe(true);
+    });
+
+    it('falls back to the legacy EmberFunctionalHelpers global Set', () => {
+      const legacy = new Set<unknown>();
+      (globalThis as Record<string, unknown>)['EmberFunctionalHelpers'] =
+        legacy;
+      const helper = () => {};
+      expect(isHostFunctionalHelper(helper)).toBe(false);
+      markHostFunctionalHelper(helper);
+      expect(legacy.has(helper)).toBe(true);
+      expect(isHostFunctionalHelper(helper)).toBe(true);
+    });
+
+    it('is inert when neither hook nor legacy global exists', () => {
+      const helper = () => {};
+      expect(isHostFunctionalHelper(helper)).toBe(false);
+      expect(() => markHostFunctionalHelper(helper)).not.toThrow();
+    });
+  });
+});

--- a/src/core/host-hooks.ts
+++ b/src/core/host-hooks.ts
@@ -1,0 +1,132 @@
+/**
+ * Host-integration hooks.
+ *
+ * A host renderer embedding GXT (e.g. the Ember dual-backend integration)
+ * historically extended the runtime through optional `globalThis.__gxt*`
+ * slots — mutable cross-realm state that masks dual-module-copy bugs and is
+ * invisible to bundlers. The hooks live here as module-local slots behind an
+ * explicit registration API instead. Every runtime call site reads the hook
+ * slot FIRST and falls back to the historical global, so hosts running the
+ * legacy wiring keep working unchanged.
+ *
+ * Register once at host module init:
+ *
+ * ```ts
+ * import { registerHostHooks } from '@lifeart/gxt';
+ * registerHostHooks({ toBool: emberToBool, scheduleRevalidate: syncNow });
+ * ```
+ */
+export interface HostHooks {
+  /**
+   * Truthiness override for `{{#if}}`-style conditionals (e.g. Ember's
+   * toBool semantics: `[]` is falsy, `isHTMLSafe('')` is truthy, …).
+   * Replaces `globalThis.__gxtToBool`.
+   */
+  toBool?: (value: unknown) => boolean;
+  /**
+   * When installed, the runtime delegates revalidation scheduling to the
+   * host, which becomes responsible for calling `syncDom()` at the right
+   * time; the built-in async scheduler is bypassed. Replaces
+   * `globalThis.__gxtExternalSchedule` (see also `takeRenderingControl`).
+   */
+  scheduleRevalidate?: () => void;
+  /**
+   * Observe keyed-list / const-if anchor markers as they are created so the
+   * host can re-associate row state across re-renders. Replaces
+   * `globalThis.__gxtRegisterListMarker`.
+   */
+  registerListMarker?: (marker: Comment) => void;
+  /**
+   * Unregister keyed-list anchor markers on list teardown (the converse of
+   * `registerListMarker`). Replaces `globalThis.__gxtUnregisterListMarker`.
+   */
+  unregisterListMarker?: (marker: Comment) => void;
+  /**
+   * Re-bind a keyed row's block param to a NEW object in place when a
+   * ref-swap reused the row by a stale key — preserves DOM identity.
+   * Replaces `globalThis.__gxtRebindEachItem`.
+   */
+  rebindEachItem?: (oldItem: unknown, newItem: unknown) => void;
+  /**
+   * Register a leaf object held by a tracked cell as a value-owner of that
+   * cell (host reverse-lookup so `set(leafObj, key, …)` can reach the
+   * cell). Replaces `globalThis.__gxtRegisterObjectValueOwner`.
+   */
+  registerObjectValueOwner?: (
+    value: object,
+    relatedObj: object,
+    relatedKey: string,
+  ) => void;
+  /**
+   * The `this` of the currently-evaluating runtime-compiled template, used
+   * to materialize absent-path cells. Replaces
+   * `globalThis.__gxtCurrentTemplateThis` (which the host had to mutate
+   * around every template evaluation — with the hook the host keeps that
+   * state module-local).
+   */
+  getCurrentTemplateThis?: () => unknown;
+  /**
+   * Brand check / brand mark for host "functional helpers" — plain
+   * functions invoked as `(positional, named) => value` rather than
+   * spread-args. Replaces the `EmberFunctionalHelpers` global Set.
+   */
+  isFunctionalHelper?: (fn: unknown) => boolean;
+  markFunctionalHelper?: (fn: unknown) => void;
+  /**
+   * Dynamic-eval fallback for compiled-template identifier resolution when
+   * the render context doesn't carry `$_eval` (initial render). Replaces
+   * the `globalThis.$_eval` fallback read.
+   */
+  dynamicEval?: (value: unknown) => unknown;
+}
+
+/**
+ * Internal read path for runtime call sites. Intentionally a plain mutable
+ * object (not getters) — these slots sit on hot paths (per-row list-marker
+ * registration, per-conditional toBool).
+ */
+export const HOST_HOOKS: HostHooks = {};
+
+/**
+ * Merge the given hooks into the active slot table. Later registrations
+ * override earlier ones per-key; passing `undefined` for a key is ignored
+ * (use an explicit no-op function to disable a default the host set
+ * earlier).
+ */
+export function registerHostHooks(hooks: HostHooks): void {
+  for (const key of Object.keys(hooks) as Array<keyof HostHooks>) {
+    const value = hooks[key];
+    if (value !== undefined) {
+      (HOST_HOOKS as Record<string, unknown>)[key] = value;
+    }
+  }
+}
+
+/**
+ * Functional-helper brand check, hook-first with the legacy
+ * `EmberFunctionalHelpers` bare-global Set as fallback. Hosts should
+ * register `isFunctionalHelper` and `markFunctionalHelper` together.
+ */
+export function isHostFunctionalHelper(fn: unknown): boolean {
+  if (HOST_HOOKS.isFunctionalHelper) {
+    return HOST_HOOKS.isFunctionalHelper(fn);
+  }
+  return (
+    // @ts-expect-error EmberFunctionalHelpers legacy global
+    typeof EmberFunctionalHelpers !== 'undefined' &&
+    // @ts-expect-error EmberFunctionalHelpers legacy global
+    EmberFunctionalHelpers.has(fn)
+  );
+}
+
+export function markHostFunctionalHelper(fn: unknown): void {
+  if (HOST_HOOKS.markFunctionalHelper) {
+    HOST_HOOKS.markFunctionalHelper(fn);
+    return;
+  }
+  // @ts-expect-error EmberFunctionalHelpers legacy global
+  if (typeof EmberFunctionalHelpers !== 'undefined') {
+    // @ts-expect-error EmberFunctionalHelpers legacy global
+    EmberFunctionalHelpers.add(fn);
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -54,6 +54,7 @@ export {
 export * from '@/core/helpers/index';
 export { $template, $args, $fwProp } from '@/core/shared';
 export { syncDom, takeRenderingControl } from '@/core/runtime';
+export { registerHostHooks, type HostHooks } from '@/core/host-hooks';
 export { setIsRendering, isRendering } from '@/core/reactive';
 export { flushCellOpcodes } from '@/core/reactive';
 export { setOpcodeErrorReporter, type OpcodeErrorReporter } from '@/core/reactive';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -55,6 +55,10 @@ export * from '@/core/helpers/index';
 export { $template, $args, $fwProp } from '@/core/shared';
 export { syncDom, takeRenderingControl } from '@/core/runtime';
 export { registerHostHooks, type HostHooks } from '@/core/host-hooks';
+export {
+  registerHostManagers,
+  type HostManagers,
+} from '@/core/manager-integration';
 export { setIsRendering, isRendering } from '@/core/reactive';
 export { flushCellOpcodes } from '@/core/reactive';
 export { setOpcodeErrorReporter, type OpcodeErrorReporter } from '@/core/reactive';

--- a/src/core/manager-integration.ts
+++ b/src/core/manager-integration.ts
@@ -93,6 +93,44 @@ export const $_MANAGERS = {
 };
 
 /**
+ * The host-manager table shape accepted by `registerHostManagers`. Each entry
+ * replaces the corresponding `$_MANAGERS` slot wholesale (hosts typically
+ * carry extra private state on their manager objects, e.g. builtin-modifier
+ * registries), so the table is typed by the slots' own shapes.
+ */
+export interface HostManagers {
+  component?: (typeof $_MANAGERS)['component'];
+  modifier?: (typeof $_MANAGERS)['modifier'];
+  helper?: (typeof $_MANAGERS)['helper'];
+}
+
+/**
+ * Formal registration API for host managers (the companion of
+ * `registerHostHooks` in host-hooks.ts). Replaces the legacy contract of
+ * hunting down the module-original `$_MANAGERS` object reference and
+ * mutating it from outside — this function lives in the same module
+ * instance the runtime call sites close over, so registration always
+ * reaches the canonical table regardless of how the host resolved the
+ * package (no object-identity hazards, no deferred-retry dance).
+ *
+ * ```ts
+ * import { registerHostManagers } from '@lifeart/gxt';
+ * registerHostManagers({ component: myComponentManager });
+ * ```
+ */
+export function registerHostManagers(managers: HostManagers): void {
+  if (managers.component !== undefined) {
+    $_MANAGERS.component = managers.component;
+  }
+  if (managers.modifier !== undefined) {
+    $_MANAGERS.modifier = managers.modifier;
+  }
+  if (managers.helper !== undefined) {
+    $_MANAGERS.helper = managers.helper;
+  }
+}
+
+/**
  * Result of attempting to handle via a custom manager.
  * If `handled` is true, `result` contains the manager's output.
  * If `handled` is false, the caller should use default behavior.

--- a/src/core/managers.test.ts
+++ b/src/core/managers.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { Window } from 'happy-dom';
 import {
   $_MANAGERS,
+  registerHostManagers,
   tryComponentManager,
   tryHelperManager,
   tryModifierManager,
@@ -1019,5 +1020,41 @@ describe('$_MANAGERS re-export from dom.ts', () => {
 
     expect(managerModule.$_MANAGERS.helper.canHandle).toBe(customCanHandle);
     // Cleanup handled by afterEach
+  });
+});
+
+describe('registerHostManagers', () => {
+  const savedComponent = $_MANAGERS.component;
+  const savedHelper = $_MANAGERS.helper;
+  const savedModifier = $_MANAGERS.modifier;
+  afterEach(() => {
+    $_MANAGERS.component = savedComponent;
+    $_MANAGERS.helper = savedHelper;
+    $_MANAGERS.modifier = savedModifier;
+  });
+
+  test('replaces only the given slots', () => {
+    const componentManager = {
+      canHandle: (c: unknown) => c === 'mine',
+      handle: () => undefined,
+    };
+    registerHostManagers({ component: componentManager });
+    expect($_MANAGERS.component).toBe(componentManager);
+    expect($_MANAGERS.helper).toBe(savedHelper);
+    expect($_MANAGERS.modifier).toBe(savedModifier);
+  });
+
+  test('runtime try* paths route through a registered manager', () => {
+    registerHostManagers({
+      helper: {
+        canHandle: (h: unknown) => h === 'host-helper',
+        handle: (_h: unknown, params: unknown[]) => `handled:${params.length}`,
+      },
+    });
+    expect(tryHelperManager('host-helper', [1, 2], {})).toEqual({
+      handled: true,
+      result: 'handled:2',
+    });
+    expect(tryHelperManager('other', [], {})).toEqual({ handled: false });
   });
 });

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -6,6 +6,7 @@
 import { scheduleRevalidate } from '@/core/runtime';
 import { isFn, isTag, isTagLike, debugContext } from '@/core/shared';
 import { AdaptivePool, config } from '@/core/config';
+import { HOST_HOOKS } from '@/core/host-hooks';
 
 // Async opcode support — tree-shaken when ASYNC_COMPILE_TRANSFORMS is false
 const asyncOpcodes = new WeakSet<tagOp>();
@@ -870,7 +871,9 @@ export function cell<T>(value: T, debugName?: string) {
 // the formula tracked no object-valued cells.
 export function registerLeafOwnersForFormula(f: MergedCell): void {
   try {
-    const hook = (globalThis as any).__gxtRegisterObjectValueOwner;
+    const hook =
+      HOST_HOOKS.registerObjectValueOwner ??
+      (globalThis as any).__gxtRegisterObjectValueOwner;
     if (typeof hook !== 'function') return;
     const cells = (f as any).relatedCells as Set<Cell> | undefined;
     if (!cells || cells.size === 0) return;
@@ -933,7 +936,9 @@ export function materializeAbsentPathCell(child: Function): boolean {
       path = str.slice(idx + marker.length, end);
     }
     if (!path) return false;
-    const ctx = (globalThis as any).__gxtCurrentTemplateThis;
+    const ctx = HOST_HOOKS.getCurrentTemplateThis
+      ? HOST_HOOKS.getCurrentTemplateThis()
+      : (globalThis as any).__gxtCurrentTemplateThis;
     if (!ctx || typeof ctx !== 'object') return false;
     let cur: any = ctx;
     let materialized = false;

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -7,6 +7,7 @@ import {
   relatedTags,
 } from '@/core/reactive';
 import { isRehydrationScheduled } from './ssr/rehydration-state';
+import { HOST_HOOKS } from '@/core/host-hooks';
 
 let revalidateScheduled = false;
 let hasExternalUpdate = false;
@@ -45,8 +46,11 @@ export function takeRenderingControl() {
 export function scheduleRevalidate() {
   // External sync hook: allows Ember integration to bypass async scheduling
   // When set, the hook is responsible for calling syncDom() at the right time
-  if ((globalThis as any).__gxtExternalSchedule) {
-    (globalThis as any).__gxtExternalSchedule();
+  const externalSchedule =
+    HOST_HOOKS.scheduleRevalidate ??
+    (globalThis as any).__gxtExternalSchedule;
+  if (externalSchedule) {
+    externalSchedule();
     return;
   }
   if (hasExternalUpdate) {


### PR DESCRIPTION
## Summary

Two formal host-integration APIs replacing the legacy mutate-a-global contracts (asks (a) and (c) of the Ember dual-backend integration's globalThis-retirement plan, emberjs/ember.js#21340).

### 1. `registerHostHooks()` — module-local hook slots

```ts
import { registerHostHooks } from '@lifeart/gxt';
registerHostHooks({ toBool: emberToBool, scheduleRevalidate: syncNow });
```

| Hook | Replaces |
| --- | --- |
| `toBool` | `__gxtToBool` |
| `scheduleRevalidate` | `__gxtExternalSchedule` |
| `registerListMarker` / `unregisterListMarker` | `__gxtRegisterListMarker` / `__gxtUnregisterListMarker` |
| `rebindEachItem` | `__gxtRebindEachItem` |
| `registerObjectValueOwner` | `__gxtRegisterObjectValueOwner` |
| `getCurrentTemplateThis` | `__gxtCurrentTemplateThis` |
| `isFunctionalHelper` / `markFunctionalHelper` | the `EmberFunctionalHelpers` global Set |
| `dynamicEval` | the `globalThis.$_eval` fallback read |

Every runtime call site reads the hook slot FIRST and falls back to the historical global, so hosts running the legacy wiring keep working unchanged. `HOST_HOOKS` is a plain mutable table (no getters) since several slots sit on hot paths (per-row list-marker registration, per-conditional toBool).

### 2. `registerHostManagers()` — canonical `$_MANAGERS` registration

```ts
import { registerHostManagers } from '@lifeart/gxt';
registerHostManagers({ component, modifier, helper });
```

Replaces the legacy contract of hunting down the module-original `$_MANAGERS` object reference and mutating it from outside (the ember side needed bridge accessors plus deferred microtask retries for this). The function lives in the same module instance the runtime call sites close over, so registration always reaches the canonical table — no object-identity hazards. Slots are replaced wholesale (hosts carry extra private state on their manager objects).

## Compatibility

No lockstep upgrade: both APIs are additive; all legacy global slots keep working as fallbacks. The ember side already adopts both behind capability detection (namespace-import probe), validated against this branch's dist: full Ember GXT suite green in both hook mode and legacy-fallback mode.

## Gates

- `tsc --noEmit` clean
- vitest 3819/3819 (includes new `host-hooks.test.ts` + `registerHostManagers` tests)
- playwright qunit 1219/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)