### PR TITLE
fix(pkg): extend sideEffects — exempt first-party src/plugins from app-build shaking, keep consumer tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
     "compiler.d.ts"
   ],
   "sideEffects": [
-    "./dist/gxt.ember-inspector.es.js"
+    "./dist/gxt.ember-inspector.es.js",
+    "./src/**",
+    "./plugins/**",
+    "**/*.css"
   ],
   "module": "./dist/gxt.index.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What

Extends the existing `sideEffects` field (landed dist-only in 928cbc3) to:

```json
"sideEffects": ["./dist/gxt.ember-inspector.es.js", "./src/**", "./plugins/**", "**/*.css"]
```

## Why

Two things at once:

1. **Fixes a live app-build deviation on master**: the current dist-only field makes Vite apply aggressive shaking to the repo's own app build — it currently **drops chunks** (NestedRouter, StyleSheet; 24 emitted files vs 27 without the field). The `src/**`/`plugins/**` exemptions restore the app build to byte-identical with no-field behavior (verified by hashing all outputs); these paths are unpublished, so consumers lose nothing.
2. **Keeps the consumer tree-shaking win**: `import { cell }` esbuild probe against master's own lib dist: **25,138 B → 4,786 B (−81%)** with the field. The Ember Inspector entry (a bare side-effect module — `window.define`/`window.requireModule`) is explicitly preserved and verified to survive bundling and execute. `"sideEffects": false` was tested and proven unsafe (both webpack 5 and esbuild silently drop the inspector).

Audit basis: AST scan of all 98 src modules + all built dist chunks (dev-gated `window.*` hooks are compiled out of the lib dist; the inspector entry is the only load-bearing side effect).

## Testing

`tsc --noEmit` clean; vitest 3,806 passed; QUnit-in-Chromium 1,219/1,219 (the globals-sensitive check); lib dist byte-identical with/without the field; app build byte-identical with the extended field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)