### PR TITLE
fix(reactive): cached() loses its subscriptions after a consumed drain with a clean cache

### DIFF
--- a/src/core/cached.test.ts
+++ b/src/core/cached.test.ts
@@ -13,7 +13,16 @@
  *     uses) does not re-run the user getter an extra time.
  */
 import { describe, test, expect } from 'vitest';
-import { cached, cell, formula, executeTag } from './reactive';
+import {
+  cached,
+  cell,
+  formula,
+  executeTag,
+  flushCellOpcodes,
+  setIsRendering,
+} from './reactive';
+import { opcodeFor } from './vm';
+import { syncDom } from './runtime';
 
 describe('cached() primitive', () => {
   test('memoizes while deps are unchanged: getter runs exactly once across multiple reads', () => {
@@ -192,5 +201,109 @@ describe('cached() primitive', () => {
     expect(runs).toBe(2);
     expect(memo.value).toBe(9);
     expect(runs).toBe(2);
+  });
+});
+
+describe('cached() subscription survives a consume + clean read (regression)', () => {
+  // Root cause: the drain (and flushCellOpcodes) CONSUMES a dirty cell's
+  // subscriber set before re-executing the subscribed tags. A plain formula
+  // re-collects its deps on re-execution and re-adds itself to each dep
+  // cell's subscriber set. But a cached() tag whose readCached() clean path
+  // hits (isClean() === true — e.g. after a same-value cell.update(), which
+  // schedules a drain WITHOUT bumping any revision) returns the memoized
+  // value WITHOUT touching its dep cells, so the tag is never re-added to
+  // the consumed subscriber sets — it is permanently unsubscribed and later
+  // REAL dep updates never reach its opcodes.
+
+  test('same-value update() drain must not permanently unsubscribe the cached tag', async () => {
+    const c = cell(1);
+    let runs = 0;
+    const memo = cached(() => {
+      runs++;
+      return c.value * 10;
+    }, 'memo-sub-drop-drain');
+
+    const seen: number[] = [];
+    const destroy = opcodeFor(memo.tag, (value) => {
+      seen.push(value as number);
+    });
+    expect(seen).toEqual([10]);
+    expect(runs).toBe(1);
+
+    // Same-value update: enqueues the cell for revalidation (observable
+    // side-effect semantics) but does NOT bump _revision, so the cached
+    // read in the drain is CLEAN. The drain consumes c's subscriber set;
+    // the clean read must re-establish the subscription.
+    c.update(1);
+    await syncDom();
+    expect(runs).toBe(1); // cache stayed clean — no recompute
+
+    // REAL change: must reach the opcode through the (re-established)
+    // subscription.
+    c.update(2);
+    await syncDom();
+    expect(seen[seen.length - 1]).toBe(20);
+    expect(runs).toBe(2);
+
+    destroy();
+  });
+
+  test('cache seeded via memo.value (not tag.value) survives the same-value drain too', async () => {
+    const c = cell(1);
+    const memo = cached(() => c.value * 3, 'memo-sub-drop-self-seeded');
+    // Seed through the PUBLIC getter first — this exercises the recompute
+    // path where the cache's dep bookkeeping and tag.relatedCells could
+    // alias the same Set object (and be wiped by the tag's re-tracking).
+    expect(memo.value).toBe(3);
+
+    const seen: number[] = [];
+    const destroy = opcodeFor(memo.tag, (value) => {
+      seen.push(value as number);
+    });
+    expect(seen).toEqual([3]);
+
+    c.update(1); // same value — drain consumes, cache stays clean
+    await syncDom();
+
+    c.update(2); // real change — must still reach the opcode
+    await syncDom();
+    expect(seen[seen.length - 1]).toBe(6);
+
+    destroy();
+  });
+
+  test('flushCellOpcodes consume path also re-subscribes a clean cached tag', async () => {
+    const c = cell(5);
+    let runs = 0;
+    const memo = cached(() => {
+      runs++;
+      return c.value + 1;
+    }, 'memo-sub-drop-flush');
+
+    const seen: number[] = [];
+    const destroy = opcodeFor(memo.tag, (value) => {
+      seen.push(value as number);
+    });
+    expect(seen).toEqual([6]);
+    expect(runs).toBe(1);
+
+    // Host-style synchronous flush (Ember integration path): consumes c's
+    // subscriber set and re-executes the cached tag while its cache is
+    // still clean (no revision bump happened).
+    setIsRendering(true);
+    try {
+      flushCellOpcodes(c);
+    } finally {
+      setIsRendering(false);
+    }
+    expect(runs).toBe(1); // clean — memoized value served
+
+    // Later REAL dep update must still reach the opcode.
+    c.update(7);
+    await syncDom();
+    expect(seen[seen.length - 1]).toBe(8);
+    expect(runs).toBe(2);
+
+    destroy();
   });
 });

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -743,9 +743,14 @@ export interface CachedCell<T = unknown> {
 export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
   let hasValue = false;
   let lastValue: T;
-  let lastDeps: Set<Cell> | null = null;
-  // Per-dep revision snapshot taken when we last ran fn().
-  let lastDepRevisions: Map<number, number> | null = null;
+  // Per-dep revision snapshot taken when we last ran fn(), keyed by the dep
+  // CELL OBJECT (not cell.id): the map doubles as the cache's own dep set for
+  // the clean-read resubscription below and the parent-tracker replay in
+  // `self.value`. Deliberately a SEPARATE container from `tag.relatedCells` —
+  // MergedCell.value reuses/clears `relatedCells` in place as its tracker
+  // buffer, so sharing one Set would wipe the cache's dep bookkeeping right
+  // before a clean read needs it.
+  let lastDepRevisions: Map<Cell, number> | null = null;
   // Global revision at time of last compute. If the global has advanced,
   // SOMETHING has changed (not necessarily a dep we captured). For pure
   // getters that read through non-tracked paths (arrays, plain objects),
@@ -762,16 +767,15 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
   const tag = new MergedCell(() => readThunk(), IS_DEV_MODE ? `cached:${debugName ?? 'unknown'}` : undefined);
 
   function isClean(): boolean {
-    if (!hasValue || lastDeps === null || lastDepRevisions === null) return false;
+    if (!hasValue || lastDepRevisions === null) return false;
     // Fast path: nothing in the whole system has updated since compute.
     if (_globalRevision === lastGlobalRevisionAtCompute) return true;
     // Something moved — if any captured dep's per-cell revision has advanced,
     // the cached value may be stale. Treating zero-dep captures as stale is
     // a safety net for getters that read raw (non-tracked) state.
-    if (lastDeps.size === 0) return false;
-    for (const cell of lastDeps) {
-      const prev = lastDepRevisions.get(cell.id);
-      if (prev === undefined || cell._revision !== prev) return false;
+    if (lastDepRevisions.size === 0) return false;
+    for (const [cell, prev] of lastDepRevisions) {
+      if (cell._revision !== prev) return false;
     }
     return true;
   }
@@ -802,9 +806,8 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
     tag.isConst = localTracker.size === 0;
     tag.relatedCells = localTracker;
     // Snapshot revisions so we can detect staleness cheaply on next read.
-    const snapshot = new Map<number, number>();
-    localTracker.forEach((cell) => snapshot.set(cell.id, cell._revision));
-    lastDeps = localTracker;
+    const snapshot = new Map<Cell, number>();
+    localTracker.forEach((cell) => snapshot.set(cell, cell._revision));
     lastDepRevisions = snapshot;
     lastGlobalRevisionAtCompute = _globalRevision;
     lastValue = value;
@@ -817,7 +820,30 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
   // a single cache-first function prevents the user getter from running
   // an extra time when the sync path invokes tag.value directly.
   function readCached(): T {
-    if (isClean()) return lastValue;
+    if (isClean()) {
+      // Re-establish subscriptions before serving the memoized value. The
+      // drain and flushCellOpcodes CONSUME (clear) a dirty cell's subscriber
+      // set and then re-execute the subscribed tags; a plain formula re-adds
+      // itself via its tracking frame, but this clean path used to return
+      // without touching the dep cells — leaving the tag PERMANENTLY
+      // unsubscribed (a same-value cell.update() triggers exactly that: the
+      // set is consumed, yet no revision moved, so the cache stays clean).
+      // Mirrors bindAllCellsToTag; Set.add is idempotent, so when the sets
+      // were not consumed this is the same hash cost as a membership check.
+      if (lastDepRevisions !== null && lastDepRevisions.size > 0) {
+        lastDepRevisions.forEach((_revision, cell) => {
+          relatedTagsForCell(cell).add(tag);
+          // Keep the inner MergedCell's tracking frame consistent when this
+          // read came through tag.value (executeTag during a drain): forward
+          // the deps so its `finally` re-binds them, keeps isConst false and
+          // leaves tag.relatedCells accurate (destroy() unbinds through it).
+          if (currentTracker !== null) {
+            currentTracker.add(cell);
+          }
+        });
+      }
+      return lastValue;
+    }
     return recompute();
   }
   readThunk = readCached;
@@ -830,15 +856,20 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
     },
     invalidate() {
       hasValue = false;
-      lastDeps = null;
       lastDepRevisions = null;
     },
     get value(): T {
       // Replay known deps into the ambient tracker so outer formulas still
       // depend on the underlying cells even when we short-circuit with the
       // cache. This preserves invalidation semantics for parents.
-      if (currentTracker !== null && lastDeps !== null && lastDeps.size > 0) {
-        lastDeps.forEach((cell) => currentTracker!.add(cell));
+      if (
+        currentTracker !== null &&
+        lastDepRevisions !== null &&
+        lastDepRevisions.size > 0
+      ) {
+        lastDepRevisions.forEach((_revision, cell) =>
+          currentTracker!.add(cell),
+        );
       }
       return readCached();
     },


### PR DESCRIPTION
## Bug

The drain (`syncDomSync`/`Async`) and `flushCellOpcodes` consume a dirty cell's subscriber set before re-executing subscribed tags. A plain formula re-subscribes via its tracking frame, but `cached()`'s clean-read path (`isClean() === true`) returns the memoized value **without re-binding deps** — leaving the cached tag permanently unsubscribed. Trigger: a same-value `cell.update()` (drain consumes the set; `_revision` unchanged, so the cache stays clean). After that, real dep updates never reach the cached tag again.

A second, worse variant fixed by the same change: when seeded via `memo.value`, `lastDeps` **aliased** the inner `MergedCell.relatedCells` — which `MergedCell.value` clears in place as its tracker buffer — silently wiping the cache's dep record.

## Fix

Confined to `cached()` in `reactive.ts`: the clean-read path re-adds the tag to each dep cell's subscriber set (idempotent `Set.add`) and forwards deps into the ambient tracker; dep bookkeeping de-aliased into a single `Map<Cell, number>` (allocation-neutral).

## Testing

3 fail-first regression tests (drain repro, `memo.value` aliasing variant, `flushCellOpcodes` consume path) — all confirmed failing pre-fix. Full suite: 3,809 passed; `tsc --noEmit` clean.

Found during the `{{#each}}` performance work (research branch `exp/d1-drain`) but pre-existing and independent — applies to master as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)