### PR TITLE
perf(list): frame mode (v2) for static-block {{#each}} bodies — per-row frames, no markers/rowCtx/per-binding formulas

### DIFF
--- a/src/core/control-flow/list-frames.test.ts
+++ b/src/core/control-flow/list-frames.test.ts
@@ -22,7 +22,13 @@ import {
 } from '../__test-utils__/list-harness';
 import { Component } from '../component';
 import { $template } from '../shared';
-import { cellFor, opsForTag, relatedTags } from '../reactive';
+import {
+  cellFor,
+  opsForTag,
+  relatedTags,
+  applyCellUpdateSync,
+  type Cell,
+} from '../reactive';
 import { destroyElementSync } from '../destroy';
 import type { ComponentLike } from '../types';
 import { template } from '../../../plugins/runtime-compiler';
@@ -269,6 +275,397 @@ describe('frame-mode {{#each}} (static-block v2)', () => {
     old.label = 'stale write';
     await settle();
     expect(labelAt(2)).toBe('replacement updated');
+  });
+
+  test('reorder + rebind in the same sync: a ref-swapped item that also MOVES relocates correctly', async () => {
+    // Regression: pass 3 pushed EXIST_OLD AFTER rebindFrame had already
+    // overwritten frame.index with the NEW position, so the LIS ran over
+    // corrupted old positions and skipped required relocations.
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(3);
+    await settle();
+    const [a, b, c] = root._items;
+    const elC = trs()[2];
+    // ref-swap c under its stable key AND move it to the front
+    const cPrime: HarnessItem = { id: c.id, label: 'c prime' };
+    cellFor(cPrime, 'label');
+    (root as any)._items = [cPrime, b, a];
+    await settle();
+    expect(trs().length).toBe(3);
+    expect(labelAt(0)).toBe('c prime');
+    expect(labelAt(1)).toBe(b.label);
+    expect(labelAt(2)).toBe(a.label);
+    // same key → same row element, relocated
+    expect(trs()[0]).toBe(elC);
+    // rebound subscriptions still live at the new position
+    cPrime.label = 'c prime updated';
+    await settle();
+    expect(labelAt(0)).toBe('c prime updated');
+  });
+
+  test('error isolation: one throwing slot thunk does not abort the shared-cell sweep or kill the subscription', async () => {
+    let boomId = -1;
+    class BoomRoot extends Component {
+      _items: HarnessItem[] = [];
+      _selected = 0;
+      constructor(args: any) {
+        super(args);
+        cellFor(this as any, '_items');
+        cellFor(this as any, '_selected');
+      }
+      get items() {
+        return this._items;
+      }
+      rowClass = (id: number) => {
+        if (id === boomId && this._selected === id) {
+          throw new Error('boom: bad row thunk');
+        }
+        return this._selected === id ? 'danger' : '';
+      };
+      [$template] = template(FRAME_TEMPLATE);
+    }
+    const root = mountRoot(fixture, BoomRoot as any) as any;
+    root._items = buildItems(8);
+    await settle();
+    boomId = root._items[2].id;
+    // select a healthy row first
+    root._selected = root._items[5].id;
+    await settle();
+    expect(trs()[5].className).toBe('danger');
+    // select the throwing row: its own slots fail (isolated + reported),
+    // but every other row's slots still re-run — row 5 must clear.
+    root._selected = boomId;
+    await settle();
+    expect(trs()[5].className).toBe('');
+    // the shared-cell subscription survives: a later select still works
+    root._selected = root._items[7].id;
+    await settle();
+    expect(trs()[7].className).toBe('danger');
+    expect(trs()[2].className).toBe(''); // boom row recovered (no longer throws)
+    (root as any)._selected = 0;
+    await settle();
+    expect(fixture.container.querySelectorAll('.danger').length).toBe(0);
+  });
+
+  test('probe re-entrancy: a nested slot run during thunk evaluation must not clobber outer dep tracking', async () => {
+    // A thunk getter that synchronously flushes opcodes
+    // (applyCellUpdateSync → flushCellOpcodes) re-enters runSlot while the
+    // outer probe is mid-collection. Regression: both runs shared ONE
+    // module-level probe Set — the nested run cleared the outer's
+    // already-tracked-but-not-yet-routed deps, so the outer slot never
+    // subscribed to them. Needs a SINGLE row (shared routing is list-level
+    // and a second row's clean re-run would repair the loss) and a dep
+    // (`_y`) first tracked on the very re-run that also triggers the flush.
+    let fired = false;
+    class ReentryRoot extends Component {
+      _items: HarnessItem[] = [];
+      _x = 0;
+      _mode = 0;
+      _y = 'y0';
+      constructor(args: any) {
+        super(args);
+        cellFor(this as any, '_items');
+        cellFor(this as any, '_x');
+        cellFor(this as any, '_mode');
+        cellFor(this as any, '_y');
+      }
+      get items() {
+        return this._items;
+      }
+      // slot 0 (class): tracks _x → registers the shared-cell entry
+      classFor = (id: number) => (this._x === id ? 'mark' : '');
+      // slot 1 (text): tracks _mode; once flipped, tracks _y for the FIRST
+      // time and triggers a synchronous sweep of _x (nested runSlot) before
+      // returning
+      compound = (id: number) => {
+        if (this._mode === 0) return 'init';
+        const v = `${this._y}:${id}`;
+        if (!fired) {
+          fired = true;
+          applyCellUpdateSync(cellFor(this as any, '_x') as Cell<number>, id);
+        }
+        return v;
+      };
+      [$template] = template(`
+        <ul>
+          {{#each this.items key="id" as |item|}}
+            <li class={{this.classFor item.id}}>{{this.compound item.id}}</li>
+          {{/each}}
+        </ul>
+      `);
+    }
+    const root = mountRoot(fixture, ReentryRoot as any) as any;
+    root._items = buildItems(1);
+    await settle();
+    const li = () => fixture.container.querySelector('li')!;
+    expect(li().textContent).toBe('init');
+    // flip: the slot re-runs, tracks _y for the first time and flushes _x
+    // mid-collection (nested runSlot on the same frame's class slot)
+    root._mode = 1;
+    await settle();
+    expect(fired).toBe(true);
+    expect(li().textContent).toBe(`y0:${root._items[0].id}`);
+    expect(li().className).toBe('mark'); // the nested sweep applied
+    // the outer slot's first-time _y dep must have survived the nested run
+    root._y = 'y1';
+    await settle();
+    expect(li().textContent).toBe(`y1:${root._items[0].id}`);
+  });
+
+  test('nested sync: a slot thunk synchronously syncing ANOTHER frame list must not corrupt the outer pass', async () => {
+    // Cross-list re-entrancy: list A's row thunk (run inside A's
+    // syncFrames pass 3 / fresh-render loop) synchronously flushes list B's
+    // items cell → B's syncFrames runs NESTED inside A's. Regression: both
+    // passes shared ONE set of module-level scratch arrays (KEYS &c.) — B's
+    // pass truncated A's keys, so A registered rows under undefined keys.
+    let fired = false;
+    class NestedSyncRoot extends Component {
+      _items: HarnessItem[] = [];
+      _itemsB: HarnessItem[] = [];
+      _selected = 0;
+      constructor(args: any) {
+        super(args);
+        cellFor(this as any, '_items');
+        cellFor(this as any, '_itemsB');
+        cellFor(this as any, '_selected');
+      }
+      get items() {
+        return this._items;
+      }
+      get itemsB() {
+        return this._itemsB;
+      }
+      rowClass = (id: number) => {
+        if (!fired) {
+          fired = true;
+          applyCellUpdateSync(
+            cellFor(this as any, '_itemsB') as Cell<HarnessItem[]>,
+            buildItems(2, (i) => `B item ${i}`),
+          );
+        }
+        return this._selected === id ? 'danger' : '';
+      };
+      [$template] = template(`
+        <div>
+          <table><tbody>
+            {{#each this.items key="id" as |item|}}
+              <tr class={{this.rowClass item.id}}><td><a>{{item.label}}</a></td></tr>
+            {{/each}}
+          </tbody></table>
+          <ul>
+            {{#each this.itemsB key="id" as |item|}}
+              <li>{{item.label}}</li>
+            {{/each}}
+          </ul>
+        </div>
+      `);
+    }
+    const root = mountRoot(fixture, NestedSyncRoot as any) as any;
+    root._items = buildItems(3);
+    await settle();
+    expect(fired).toBe(true);
+    // outer pass (list A) survived the nested sync intact
+    expect(trs().length).toBe(3);
+    for (let i = 0; i < 3; i++) {
+      expect(trs()[i].querySelector('a')!.textContent).toBe(
+        root._items[i].label,
+      );
+    }
+    // nested pass (list B) rendered correctly too
+    const lis = fixture.container.querySelectorAll('li');
+    expect(lis.length).toBe(2);
+    expect(lis[0].textContent).toBe('B item 0');
+    // list A's keyed bookkeeping is sane: reorder + per-item update work
+    const reversed = [...root._items].reverse();
+    (root as any)._items = reversed;
+    await settle();
+    expect(trs().length).toBe(3);
+    for (let i = 0; i < 3; i++) {
+      expect(trs()[i].querySelector('a')!.textContent).toBe(reversed[i].label);
+    }
+    reversed[0].label = 'nested sync survivor';
+    await settle();
+    expect(trs()[0].querySelector('a')!.textContent).toBe(
+      'nested sync survivor',
+    );
+    // and the bookkeeping is leak-free: exactly ONE live subscription per
+    // item cell (a corrupted outer pass leaks overwritten frames' subs)
+    for (const it of reversed) {
+      const cell = cellFor(it, 'label') as any;
+      expect(opsForTag.get(cell.id)?.length ?? 0).toBe(1);
+    }
+  });
+
+  test('teardown ordering: list cleared synchronously from a thunk while a shared-cell sweep is mid-flight', async () => {
+    const SENTINEL = -424242;
+    let fired = false;
+    class MidSweepRoot extends Component {
+      _items: HarnessItem[] = [];
+      _selected = 0;
+      constructor(args: any) {
+        super(args);
+        cellFor(this as any, '_items');
+        cellFor(this as any, '_selected');
+      }
+      get items() {
+        return this._items;
+      }
+      rowClass = (id: number) => {
+        if (this._selected === SENTINEL && !fired) {
+          fired = true;
+          // synchronous syncList([]) while the sweep iterates frames
+          applyCellUpdateSync(
+            cellFor(this as any, '_items') as Cell<HarnessItem[]>,
+            [],
+          );
+        }
+        return this._selected === id ? 'danger' : '';
+      };
+      [$template] = template(FRAME_TEMPLATE);
+    }
+    const root = mountRoot(fixture, MidSweepRoot as any) as any;
+    root._items = buildItems(6);
+    await settle();
+    expect(trs().length).toBe(6);
+    root._selected = SENTINEL;
+    await settle();
+    expect(fired).toBe(true);
+    // cleared mid-sweep without corruption; inverse rendered
+    expect(trs().length).toBe(1);
+    expect(trs()[0].textContent).toBe('empty');
+    // the list still works after the mid-sweep teardown
+    root._selected = 0;
+    root._items = buildItems(4);
+    await settle();
+    expect(trs().length).toBe(4);
+    root._items[1].label = 'post-teardown update';
+    await settle();
+    expect(labelAt(1)).toBe('post-teardown update');
+  });
+
+  test('multi-list shared cell: each list unsubscribes ITS OWN sweep on destroy', async () => {
+    class TwoListRoot extends Component {
+      _items: HarnessItem[] = [];
+      _itemsB: HarnessItem[] = [];
+      _selected = 0;
+      _showSecond = true;
+      constructor(args: any) {
+        super(args);
+        cellFor(this as any, '_items');
+        cellFor(this as any, '_itemsB');
+        cellFor(this as any, '_selected');
+        cellFor(this as any, '_showSecond');
+      }
+      get items() {
+        return this._items;
+      }
+      get itemsB() {
+        return this._itemsB;
+      }
+      get showSecond() {
+        return this._showSecond;
+      }
+      rowClass = (id: number) => (this._selected === id ? 'danger' : '');
+      [$template] = template(`
+        <div>
+          <table><tbody>
+            {{#each this.items key="id" as |item|}}
+              <tr class={{this.rowClass item.id}}><td><a>{{item.label}}</a></td></tr>
+            {{/each}}
+          </tbody></table>
+          {{#if this.showSecond}}
+            <ul>
+              {{#each this.itemsB key="id" as |item|}}
+                <li class={{this.rowClass item.id}}>{{item.label}}</li>
+              {{/each}}
+            </ul>
+          {{/if}}
+        </div>
+      `);
+    }
+    const root = mountRoot(fixture, TwoListRoot as any) as any;
+    root._items = buildItems(5);
+    root._itemsB = buildItems(5);
+    await settle();
+    expect(trs().length).toBe(5);
+    expect(fixture.container.querySelectorAll('li').length).toBe(5);
+    const selectedCell = cellFor(root, '_selected') as Cell<number>;
+    // both lists' sweeps react
+    root._selected = root._items[1].id;
+    await settle();
+    expect(fixture.container.querySelectorAll('tr.danger').length).toBe(1);
+    root._selected = root._itemsB[2].id;
+    await settle();
+    expect(fixture.container.querySelectorAll('li.danger').length).toBe(1);
+    const opsWithBoth = opsForTag.get((selectedCell as any).id)?.length ?? 0;
+    expect(opsWithBoth).toBeGreaterThanOrEqual(2);
+    // destroy ONLY the second list ({{#if}} false) → its sweep unsubscribes
+    root._showSecond = false;
+    await settle();
+    expect(fixture.container.querySelectorAll('li').length).toBe(0);
+    const opsAfter = opsForTag.get((selectedCell as any).id)?.length ?? 0;
+    expect(opsAfter).toBeLessThan(opsWithBoth);
+    // the surviving list keeps reacting through ITS subscription
+    root._selected = root._items[3].id;
+    await settle();
+    expect(trs()[3].className).toBe('danger');
+  });
+
+  test('rebind balance: repeated ref-swaps under a stable key neither leak nor double-subscribe', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(5);
+    await settle();
+    let current = root._items[2];
+    const stableId = current.id;
+    const opsBaseline = opsForTag.size;
+    const relatedBaseline = relatedTags.size;
+    for (let cycle = 0; cycle < 25; cycle++) {
+      const oldCell = cellFor(current, 'label') as any;
+      const replacement: HarnessItem = {
+        id: stableId,
+        label: `swap ${cycle}`,
+      };
+      cellFor(replacement, 'label');
+      const next = [...root._items];
+      next[2] = replacement;
+      (root as any)._items = next;
+      await settle();
+      // the OLD item's cell fully unsubscribed (ops array emptied + deleted)
+      expect(opsForTag.has(oldCell.id)).toBe(false);
+      expect(labelAt(2)).toBe(`swap ${cycle}`);
+      current = replacement;
+    }
+    expect(opsForTag.size).toBe(opsBaseline);
+    expect(relatedTags.size).toBe(relatedBaseline);
+    // exactly ONE live subscription on the current item's cell
+    const liveCell = cellFor(current, 'label') as any;
+    expect(opsForTag.get(liveCell.id)?.length).toBe(1);
+    // and it still works
+    current.label = 'final swap check';
+    await settle();
+    expect(labelAt(2)).toBe('final swap check');
+  });
+
+  test('duplicate keys: reorder with a duplicated ref keeps position-qualified rows consistent', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    const items = buildItems(2);
+    const [a, b] = items;
+    (root as any)._items = [a, b, a];
+    await settle();
+    expect(trs().length).toBe(3);
+    // move the duplicate occurrence: [a, b, a] → [a, a, b]
+    (root as any)._items = [a, a, b];
+    await settle();
+    expect(trs().length).toBe(3);
+    expect(labelAt(0)).toBe(a.label);
+    expect(labelAt(1)).toBe(a.label);
+    expect(labelAt(2)).toBe(b.label);
+    // both dup rows still track the shared item cell
+    a.label = 'dup reorder updated';
+    await settle();
+    expect(labelAt(0)).toBe('dup reorder updated');
+    expect(labelAt(1)).toBe('dup reorder updated');
+    expect(labelAt(2)).toBe(b.label);
   });
 
   test('no subscription leak: opsForTag/relatedTags bounded across create+clear cycles', async () => {

--- a/src/core/control-flow/list-frames.test.ts
+++ b/src/core/control-flow/list-frames.test.ts
@@ -1,0 +1,373 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Frame-mode ({{#each}} static-block v2, list-frames.ts) correctness suite.
+ *
+ * Renders runtime-compiled templates whose each-bodies QUALIFY for frame mode
+ * (single-root inline element, attr/class/text slots, no events, no index)
+ * and asserts the full keyed contract: create / per-item update / shared-dep
+ * sweep / LIS reorder / replace / clear / inverse / duplicate keys / rebind —
+ * plus the gate (event bodies and {{index}} bodies stay on v1, observable via
+ * the per-item marker comments frame mode eliminates) and a subscription-leak
+ * bound across create+clear cycles.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { createDOMFixture, type DOMFixture } from '../__test-utils__';
+import {
+  buildItems,
+  settle,
+  mountRoot,
+  setupRuntimeTemplateGlobals,
+  type HarnessItem,
+} from '../__test-utils__/list-harness';
+import { Component } from '../component';
+import { $template } from '../shared';
+import { cellFor, opsForTag, relatedTags } from '../reactive';
+import { destroyElementSync } from '../destroy';
+import type { ComponentLike } from '../types';
+import { template } from '../../../plugins/runtime-compiler';
+
+describe('frame-mode {{#each}} (static-block v2)', () => {
+  let fixture: DOMFixture;
+
+  beforeEach(() => {
+    fixture = createDOMFixture();
+    setupRuntimeTemplateGlobals();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  function defineRoot(listTemplate: string) {
+    class FrameRoot extends Component {
+      _items: HarnessItem[] = [];
+      _selected = 0;
+      constructor(args: any) {
+        super(args);
+        cellFor(this as any, '_items');
+        cellFor(this as any, '_selected');
+      }
+      get items() {
+        return this._items;
+      }
+      rowClass = (id: number) => (this._selected === id ? 'danger' : '');
+      [$template] = template(listTemplate);
+    }
+    return FrameRoot as new (args: any) => Component<any> & {
+      _items: HarnessItem[];
+      _selected: number;
+    };
+  }
+
+  const FRAME_TEMPLATE = `
+    <table><tbody>
+      {{#each this.items key="id" as |item|}}
+        <tr class={{this.rowClass item.id}}>
+          <td>{{item.id}}</td>
+          <td><a class={{this.rowClass item.id}}>{{item.label}}</a></td>
+          <td><span>x</span></td>
+        </tr>
+      {{else}}
+        <tr><td>empty</td></tr>
+      {{/each}}
+    </tbody></table>
+  `;
+
+  const trs = () => fixture.container.querySelectorAll('tbody tr');
+  const labelAt = (i: number) =>
+    trs()[i]?.querySelector('a')?.textContent ?? '';
+  const idAt = (i: number) =>
+    trs()[i]?.querySelector('td')?.textContent ?? '';
+  /** frame rows have NO per-item marker comments between top/bottom markers */
+  const rowMarkerComments = () => {
+    const tbody = fixture.container.querySelector('tbody')!;
+    let count = 0;
+    tbody.childNodes.forEach((n) => {
+      if (n.nodeType === 8) count++;
+    });
+    return count;
+  };
+
+  test('create renders rows without per-item marker comments (frame mode active)', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(5);
+    await settle();
+    expect(trs().length).toBe(5);
+    expect(labelAt(0)).toBe(root._items[0].label);
+    expect(labelAt(4)).toBe(root._items[4].label);
+    expect(idAt(2)).toBe(String(root._items[2].id));
+    // top/bottom list markers + each-placeholder comments only — v1 would add
+    // one marker comment per row (5 more)
+    const baseline = rowMarkerComments();
+    (root as any)._items = [...root._items, ...buildItems(5)];
+    await settle();
+    expect(trs().length).toBe(10);
+    expect(rowMarkerComments()).toBe(baseline);
+  });
+
+  test('per-item cell update routes to one row (label push path)', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(10);
+    await settle();
+    root._items[3].label = 'updated three';
+    root._items[7].label = 'updated seven';
+    await settle();
+    expect(labelAt(3)).toBe('updated three');
+    expect(labelAt(7)).toBe('updated seven');
+    expect(labelAt(0)).toBe(root._items[0].label);
+  });
+
+  test('shared-dep sweep: select applies/clears exactly one row, twice nested (tr + a)', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(20);
+    await settle();
+    (root as any)._selected = root._items[5].id;
+    await settle();
+    expect(fixture.container.querySelectorAll('tr.danger').length).toBe(1);
+    expect(fixture.container.querySelectorAll('a.danger').length).toBe(1);
+    expect(trs()[5].className).toBe('danger');
+    (root as any)._selected = root._items[11].id;
+    await settle();
+    expect(trs()[5].className).toBe('');
+    expect(trs()[11].className).toBe('danger');
+    expect(fixture.container.querySelectorAll('.danger').length).toBe(2); // tr + a
+    (root as any)._selected = 0;
+    await settle();
+    expect(fixture.container.querySelectorAll('.danger').length).toBe(0);
+  });
+
+  test('reorder: swap preserves row identity (same DOM elements relocate)', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(6);
+    await settle();
+    const el1 = trs()[1];
+    const el4 = trs()[4];
+    const swapped = [...root._items];
+    const t = swapped[1];
+    swapped[1] = swapped[4];
+    swapped[4] = t;
+    (root as any)._items = swapped;
+    await settle();
+    expect(trs()[1]).toBe(el4);
+    expect(trs()[4]).toBe(el1);
+    for (let i = 0; i < 6; i++) {
+      expect(labelAt(i)).toBe(swapped[i].label);
+    }
+    // reactivity survives relocation
+    swapped[1].label = 'moved row updated';
+    await settle();
+    expect(labelAt(1)).toBe('moved row updated');
+  });
+
+  test('reorder: full reverse (LIS path) keeps content + identity', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(7);
+    await settle();
+    const original = Array.from(trs());
+    const reversed = [...root._items].reverse();
+    (root as any)._items = reversed;
+    await settle();
+    expect(trs().length).toBe(7);
+    for (let i = 0; i < 7; i++) {
+      expect(labelAt(i)).toBe(reversed[i].label);
+      expect(trs()[i]).toBe(original[6 - i]);
+    }
+  });
+
+  test('partial removal + insertion in one sync', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(6);
+    await settle();
+    const kept = [root._items[4], root._items[0], root._items[2]];
+    const fresh = buildItems(2);
+    const next = [kept[0], fresh[0], kept[1], fresh[1], kept[2]];
+    (root as any)._items = next;
+    await settle();
+    expect(trs().length).toBe(5);
+    for (let i = 0; i < 5; i++) {
+      expect(labelAt(i)).toBe(next[i].label);
+    }
+  });
+
+  test('replace-all with disjoint keys', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(50);
+    await settle();
+    (root as any)._selected = root._items[3].id;
+    await settle();
+    expect(fixture.container.querySelectorAll('tr.danger').length).toBe(1);
+    const next = buildItems(50);
+    (root as any)._items = next;
+    await settle();
+    expect(trs().length).toBe(50);
+    expect(labelAt(0)).toBe(next[0].label);
+    expect(labelAt(49)).toBe(next[49].label);
+    // stale selection (old id) not present on any new row
+    expect(fixture.container.querySelectorAll('.danger').length).toBe(0);
+    // old items' label cells are unsubscribed: mutating them is a no-op
+    // and new items stay reactive
+    next[5].label = 'fresh five';
+    await settle();
+    expect(labelAt(5)).toBe('fresh five');
+  });
+
+  test('clear renders inverse; items again removes inverse', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(8);
+    await settle();
+    expect(trs().length).toBe(8);
+    (root as any)._items = [];
+    await settle();
+    expect(trs().length).toBe(1);
+    expect(trs()[0].textContent).toBe('empty');
+    (root as any)._items = buildItems(3);
+    await settle();
+    expect(trs().length).toBe(3);
+    expect(fixture.container.textContent).not.toContain('empty');
+  });
+
+  test('duplicate keys: same key value renders distinct position-qualified rows', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    const items = buildItems(3);
+    // duplicate the SAME object reference (id collision by construction)
+    (root as any)._items = [items[0], items[1], items[0], items[2]];
+    await settle();
+    expect(trs().length).toBe(4);
+    expect(labelAt(0)).toBe(items[0].label);
+    expect(labelAt(2)).toBe(items[0].label);
+    items[0].label = 'dup updated';
+    await settle();
+    expect(labelAt(0)).toBe('dup updated');
+    expect(labelAt(2)).toBe('dup updated');
+    // dedupe back to unique
+    (root as any)._items = [items[0], items[1], items[2]];
+    await settle();
+    expect(trs().length).toBe(3);
+  });
+
+  test('rebind: ref-swapped item under a stable key re-points subscriptions', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(4);
+    await settle();
+    const old = root._items[2];
+    const el = trs()[2];
+    const replacement: HarnessItem = { id: old.id, label: 'replacement label' };
+    cellFor(replacement, 'label');
+    const next = [...root._items];
+    next[2] = replacement;
+    (root as any)._items = next;
+    await settle();
+    // same key → same row element, new content
+    expect(trs()[2]).toBe(el);
+    expect(labelAt(2)).toBe('replacement label');
+    // new item's cell drives the row…
+    replacement.label = 'replacement updated';
+    await settle();
+    expect(labelAt(2)).toBe('replacement updated');
+    // …and the old item's cell no longer does
+    old.label = 'stale write';
+    await settle();
+    expect(labelAt(2)).toBe('replacement updated');
+  });
+
+  test('no subscription leak: opsForTag/relatedTags bounded across create+clear cycles', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(30);
+    await settle();
+    (root as any)._items = [];
+    await settle();
+    const opsAfterFirst = opsForTag.size;
+    const relatedAfterFirst = relatedTags.size;
+    for (let cycle = 0; cycle < 5; cycle++) {
+      (root as any)._items = buildItems(30);
+      await settle();
+      (root as any)._items = [];
+      await settle();
+    }
+    expect(opsForTag.size).toBe(opsAfterFirst);
+    expect(relatedTags.size).toBe(relatedAfterFirst);
+  });
+
+  test('gate: event-bodied each stays on v1 (per-item markers present)', async () => {
+    const EVENT_TEMPLATE = `
+      <table><tbody>
+        {{#each this.items key="id" as |item|}}
+          <tr><td><button {{on "click" this.rowClass}}>{{item.label}}</button></td></tr>
+        {{/each}}
+      </tbody></table>
+    `;
+    const root = mountRoot(fixture, defineRoot(EVENT_TEMPLATE));
+    const empty = rowMarkerComments();
+    (root as any)._items = buildItems(4);
+    await settle();
+    expect(trs().length).toBe(4);
+    // v1 adds one marker comment per row
+    expect(rowMarkerComments()).toBe(empty + 4);
+  });
+
+  test('gate: index-reading body stays on v1 and renders live indices', async () => {
+    const INDEX_TEMPLATE = `
+      <table><tbody>
+        {{#each this.items key="id" as |item index|}}
+          <tr><td>{{index}}</td><td><a>{{item.label}}</a></td></tr>
+        {{/each}}
+      </tbody></table>
+    `;
+    const root = mountRoot(fixture, defineRoot(INDEX_TEMPLATE));
+    const empty = rowMarkerComments();
+    (root as any)._items = buildItems(3);
+    await settle();
+    expect(trs().length).toBe(3);
+    expect(rowMarkerComments()).toBe(empty + 3);
+    expect(idAt(0)).toBe('0');
+    expect(idAt(2)).toBe('2');
+  });
+
+  test('attr slots: dynamic + static attributes apply and update', async () => {
+    const ATTR_TEMPLATE = `
+      <ul>
+        {{#each this.items key="id" as |item|}}
+          <li data-id={{item.id}} title={{item.label}} data-static="yes">{{item.label}}</li>
+        {{/each}}
+      </ul>
+    `;
+    const root = mountRoot(fixture, defineRoot(ATTR_TEMPLATE));
+    (root as any)._items = buildItems(3);
+    await settle();
+    const lis = fixture.container.querySelectorAll('li');
+    expect(lis.length).toBe(3);
+    expect(lis[0].getAttribute('data-id')).toBe(String(root._items[0].id));
+    expect(lis[0].getAttribute('title')).toBe(root._items[0].label);
+    expect(lis[0].getAttribute('data-static')).toBe('yes');
+    root._items[1].label = 'attr updated';
+    await settle();
+    expect(
+      fixture.container.querySelectorAll('li')[1].getAttribute('title'),
+    ).toBe('attr updated');
+    expect(
+      fixture.container.querySelectorAll('li')[1].textContent,
+    ).toBe('attr updated');
+  });
+
+  test('list destroy (unmount) reclaims frame subscriptions', async () => {
+    const root = mountRoot(fixture, defineRoot(FRAME_TEMPLATE));
+    (root as any)._items = buildItems(15);
+    await settle();
+    expect(trs().length).toBe(15);
+    const items = root._items;
+    // destroy the WHOLE component tree from the render root (runs the list's
+    // destructors, incl. destroyFrameState) — fixture.cleanup() only wipes
+    // the tree maps. The list parents under the mount-level component, so the
+    // cascade must start at the root.
+    destroyElementSync(fixture.root as unknown as ComponentLike, true, fixture.api);
+    // the default {{#each}} is the ASYNC list — its teardown destructor
+    // resolves on a microtask
+    await settle();
+    // post-unmount, the item cells must not be left in opsForTag
+    for (const item of items) {
+      const cell = cellFor(item, 'label');
+      expect(opsForTag.has((cell as any).id)).toBe(false);
+    }
+  });
+});

--- a/src/core/control-flow/list-frames.ts
+++ b/src/core/control-flow/list-frames.ts
@@ -65,6 +65,16 @@
  * Everything else — component bodies, multi-root, nested control flow,
  * modifiers, `...attributes`, duplicate-unsafe constructs — already bailed at
  * the compiler's block extraction and stays on the standard keyed path.
+ *
+ * Dev-tooling caveat: frame rows live ONLY in `list.frames` — the v1 per-row
+ * state (`keyMap` / `indexMap` / `itemMarkers` / rowCtx) is never populated.
+ * Tooling that walks that state sees an empty list: ember-inspector's
+ * render-tree row enumeration (`Array.from(component.keyMap.values())`) shows
+ * no rows for a frame list, and HMR's keyMap component-swap walk has nothing
+ * to visit (benign — frame bodies cannot contain components by
+ * qualification, and a template edit still re-renders through the normal
+ * component-level HMR path). If row-level introspection for frame lists is
+ * ever needed, expose it from `list.frames` directly.
  */
 import type { DOMApi } from '@/core/types';
 import type { StaticBlockDef, StaticBlockSlot } from '@/core/static-block';

--- a/src/core/control-flow/list-frames.ts
+++ b/src/core/control-flow/list-frames.ts
@@ -107,6 +107,9 @@ export interface EachFrame<T> {
   itemSlots: number[] | null;
   /** The row's single update op (reused across rebinds). */
   itemOp: tagOp | null;
+  /** `cellsMap.get(item)` snapshot at bind/rebind (item-cell classification —
+   * avoids a WeakMap get per slot run). */
+  bag: Map<string | number | symbol, Cell<unknown>> | undefined;
 }
 
 /** One list-level subscription per distinct shared (non-item) dep cell. */
@@ -199,10 +202,12 @@ function routeSlotDeps(
   s: number,
 ): void {
   const item = frame.item;
-  const bag =
-    item !== null && typeof item === 'object'
-      ? cellsMap.get(item as object)
-      : undefined;
+  let bag = frame.bag;
+  if (bag === undefined && item !== null && typeof item === 'object') {
+    // the probe itself may have materialized the item's first cell (lazy
+    // `@tracked` getters) — refresh the snapshot before classifying
+    bag = frame.bag = cellsMap.get(item as object);
+  }
   for (const cell of PROBE) {
     if (isItemCell(cell, item, bag)) {
       let cells = frame.itemCells;
@@ -241,7 +246,10 @@ function routeSlotDeps(
           if (frames === null) return;
           for (const f of frames.values()) {
             for (let i = 0; i < slots.length; i++) {
-              runSlot(list, f, slots[i], false);
+              // `cell` is this entry's own dep — when a re-probe yields
+              // exactly it again (the overwhelmingly common stable-dep
+              // case), routing is provably already in place and skipped.
+              runSlot(list, f, slots[i], false, cell);
             }
           }
         };
@@ -338,6 +346,7 @@ function runSlot(
   frame: EachFrame<unknown>,
   s: number,
   initial: boolean,
+  knownCell?: AnyCell,
 ): void {
   const slot = list.block!.slots[s];
   const raw = frame.thunks[s];
@@ -353,7 +362,15 @@ function runSlot(
       setTracker(prevTracker);
     }
     if (PROBE.size > 0) {
-      routeSlotDeps(list, frame, s);
+      // sweep fast path: the probe re-found exactly the cell whose op is
+      // running — its (cell → slot) routing already exists by construction
+      if (
+        PROBE.size !== 1 ||
+        knownCell === undefined ||
+        !PROBE.has(knownCell as Cell)
+      ) {
+        routeSlotDeps(list, frame, s);
+      }
     } else if (initial) {
       isStatic = true;
     }
@@ -383,6 +400,10 @@ function createFrame(
     itemUnsubs: null,
     itemSlots: null,
     itemOp: null,
+    bag:
+      item !== null && typeof item === 'object'
+        ? cellsMap.get(item as object)
+        : undefined,
   };
   for (let s = 0; s < k; s++) {
     runSlot(list, frame, s, true);
@@ -418,6 +439,10 @@ function rebindFrame(
   frame.item = item;
   frame.index = index;
   frame.thunks = list.blockValues!(item, index, list);
+  frame.bag =
+    item !== null && typeof item === 'object'
+      ? cellsMap.get(item as object)
+      : undefined;
   const k = list.block!.slots.length;
   for (let s = 0; s < k; s++) {
     runSlot(list, frame, s, false);

--- a/src/core/control-flow/list-frames.ts
+++ b/src/core/control-flow/list-frames.ts
@@ -392,7 +392,10 @@ function runSlot(
   const raw = frame.thunks[s];
   let value: unknown;
   let isStatic = false;
-  if (isFn(raw) || isTagLike(raw)) {
+  // Nullish guard before isTagLike — it dereferences its argument, and a
+  // nullish CONST binding (`data-x={{undefined}}`) compiles to the bare value,
+  // not a thunk. Mirrors resolveBindingValue's guard on the v1 path.
+  if (raw !== null && raw !== undefined && (isFn(raw) || isTagLike(raw))) {
     const prevTracker = getTracker();
     // Re-entrancy guard: a thunk getter can synchronously flush opcodes
     // (`applyCellUpdateSync` → `flushCellOpcodes`) and re-run another slot

--- a/src/core/control-flow/list-frames.ts
+++ b/src/core/control-flow/list-frames.ts
@@ -1,0 +1,607 @@
+/**
+ * Frame mode (v2) for the static-block {{#each}} fast path.
+ *
+ * RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A1 / §5 (E5): the static-block v1
+ * path already builds qualifying rows via cloneNode + slot wiring, but still
+ * pays the FULL per-row keyed bookkeeping: a marker comment, ~7 map entries
+ * (keyMap/indexMap/boundItemMap/itemMarkers/markerSet/rowCtxMap), a RowContext
+ * with cId()/addToTree/destructor registry, renderElement recursion and one
+ * MergedCell formula per binding. Instrumentation showed that bookkeeping —
+ * not clone+bind — dominates happy-dom create1k. Frame mode removes it:
+ *
+ *   Per row, ONE record:    Frame = { root, nodes[], thunks[], values[],
+ *                                     item, index, itemCells/Unsubs/Slots, itemOp }
+ *   Row boundary:           the single root element itself (the compiler gate
+ *                           guarantees single-root blocks) — no marker comment.
+ *   Teardown ownership:     the LIST owns frame teardown (run `itemUnsubs`);
+ *                           no rowBodyCtx / cId / addToTree / destructor cascade.
+ *   Bindings:               no per-binding MergedCells. Each slot's value thunk
+ *                           is PROBED with the ambient tracker (the same
+ *                           tracking primitive `formula` uses) on every run:
+ *     - tracked cell owned by the row's item (`cellFor(item, k)` /
+ *       `@tracked`-backed — detected via `_relatedObj` or membership in
+ *       `cellsMap.get(item)`) → ONE op subscription per (row, cell); the op
+ *       re-runs only that row's item-dep slots with prev-value guards.
+ *     - any other tracked cell (`this.*`, args, outer formulas — formulas
+ *       probe through to their LEAF cells, since reading a MergedCell under a
+ *       tracker runs its fn() in OUR frame) → ONE LIST-LEVEL subscription per
+ *       distinct cell; its op sweeps all frames re-running only the slots
+ *       registered for that cell (flat loop + value guards — no formula
+ *       re-tracking, no relatedTags churn).
+ *     - no cells tracked on the FIRST run → static slot: written once
+ *       (mirroring `$prop`/`$attr`/`$ev`'s const-collapse), never re-run.
+ *   Routing is GROW-ONLY and re-probed on every slot re-run, so conditional
+ *   dep sets (`this.a ? this.b : this.c`) can only ever OVER-subscribe
+ *   (guarded no-op re-runs), never go stale. Dropped deps are reclaimed on
+ *   row teardown (item cells) / list teardown (shared cells).
+ *   Relocation:             keyed LIS move phase preserved; a move is ONE
+ *                           `insertBefore(frame.root, anchor)` instead of a
+ *                           marker-extent fragment walk.
+ *   Rebind (ref-swapped item under a stable key): swap `frame.item`,
+ *   re-create the thunks from the new item, re-run every slot, re-route the
+ *   item-dep subscriptions. (Subsumes the `__gxtRebindEachItem` host hook —
+ *   frame mode is gated OFF when an Ember host is detected, see below.)
+ *
+ * Reactive core reuse: subscriptions go through the SAME `opsForTag` channel
+ * `opcodeFor` uses (see `subscribeOp` — identical to `opcodeFor` minus the
+ * immediate evaluation, because the initial slot run already happened);
+ * delivery is the normal `tagsToRevalidate` → drain. No parallel reactivity.
+ *
+ * Qualification (runtime gate, decided once in the BasicListComponent
+ * constructor — the compiler already guarantees single-root inline-element
+ * bodies for any emitted `$_blk`):
+ *   - a compiler-emitted block + blockValues (v1 prerequisite);
+ *   - NO 'event' slots (event listeners keep v1 — they need the per-row
+ *     destructor plumbing frame records intentionally drop);
+ *   - `hasIndex === false` (bodies reading `{{index}}` need the per-row index
+ *     formula machinery — v1);
+ *   - not SSR / not rehydrating (block path can't adopt server DOM);
+ *   - no Ember-host hooks installed (`__gxtRegisterObjectValueOwner` /
+ *     `__gxtCurrentTemplateThis` / `__gxtRebindEachItem`): those hosts rely
+ *     on per-binding formulas for leaf-owner registration
+ *     (registerLeafOwnersForFormula / materializeAbsentPathCell) and on the
+ *     rebind hook's proxy-holder swap — keep them on v1;
+ *   - not recycle mode (its own dedicated path).
+ * Everything else — component bodies, multi-root, nested control flow,
+ * modifiers, `...attributes`, duplicate-unsafe constructs — already bailed at
+ * the compiler's block extraction and stays on the standard keyed path.
+ */
+import type { DOMApi } from '@/core/types';
+import type { StaticBlockDef, StaticBlockSlot } from '@/core/static-block';
+import {
+  type AnyCell,
+  type Cell,
+  type tagOp,
+  opsFor,
+  opsForTag,
+  releaseOpArray,
+  getTracker,
+  setTracker,
+  cellsMap,
+  deepFnValue,
+} from '@/core/reactive';
+import { isFn, isEmpty, isTagLike } from '@/core/shared';
+import {
+  longestIncreasingSubsequence,
+  type BasicListComponent,
+} from './list';
+
+/** Per-row frame record — the ONLY per-row state frame mode keeps. */
+export interface EachFrame<T> {
+  /** The cloned single-root row element. IS the row boundary (no marker). */
+  root: Node;
+  /** Slot nodes, parallel to the block's slot table. */
+  nodes: Node[];
+  /** Raw positional slot values from `blockValues(item, index, list)`. */
+  thunks: readonly unknown[];
+  /** Last APPLIED values (per-kind normalized), parallel to the slot table. */
+  values: unknown[];
+  item: T;
+  /** Position as of the last sync (feeds the LIS move phase). */
+  index: number;
+  /** Item-owned dep cells subscribed for this row (null until first dep). */
+  itemCells: AnyCell[] | null;
+  /** subscribeOp cleanups, parallel to itemCells. */
+  itemUnsubs: Array<() => void> | null;
+  /** Slot indices with item-cell deps — what `itemOp` re-runs. */
+  itemSlots: number[] | null;
+  /** The row's single update op (reused across rebinds). */
+  itemOp: tagOp | null;
+}
+
+/** One list-level subscription per distinct shared (non-item) dep cell. */
+export interface FrameSharedEntry {
+  /** Union of slot indices (across rows) that tracked this cell. */
+  slots: number[];
+  unsub: () => void;
+}
+
+/** "no value applied yet" — lets the prop/class first-run guard mirror
+ * `$prop`'s `prevPropValue = undefined` semantics exactly. */
+const UNSET: unknown = Symbol();
+
+/** Runtime frame-mode qualification over the compiled slot table. */
+export function framesQualify(block: StaticBlockDef): boolean {
+  const slots = block.slots;
+  for (let i = 0; i < slots.length; i++) {
+    if (slots[i].k === 'event') return false;
+  }
+  return true;
+}
+
+/** Ember-host detection — hosts keep the v1 formula-based bindings. */
+export function frameHostHooksInstalled(): boolean {
+  const g = globalThis as Record<string, unknown>;
+  return (
+    typeof g.__gxtRegisterObjectValueOwner === 'function' ||
+    g.__gxtCurrentTemplateThis !== undefined ||
+    typeof g.__gxtRebindEachItem === 'function'
+  );
+}
+
+/**
+ * Subscribe an op to a tag WITHOUT the immediate evaluation `opcodeFor`
+ * performs (the caller has already run/applied the slot). The returned
+ * unsubscribe is byte-for-byte `opcodeFor`'s.
+ */
+function subscribeOp(tag: AnyCell, op: tagOp): () => void {
+  const ops = opsFor(tag)!;
+  ops.push(op);
+  return () => {
+    const index = ops.indexOf(op);
+    if (index > -1) {
+      ops.splice(index, 1);
+    }
+    if (ops.length === 0) {
+      opsForTag.delete(tag.id);
+      releaseOpArray(ops);
+      if ('destroy' in tag) {
+        tag.destroy();
+      }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reusable scratch (module-level; frame syncs never nest: frame bodies contain
+// no control flow, so no inner list can sync while a frame sync is mid-flight,
+// and slot runs are synchronous + non-reentrant)
+// ---------------------------------------------------------------------------
+const PROBE: Set<Cell> = new Set();
+const KEYS: string[] = [];
+const KEYSET: Set<string> = new Set();
+const EXIST_KEYS: string[] = [];
+const EXIST_OLD: number[] = [];
+const EXIST_NEW: number[] = [];
+const LIS_OUT: Set<number> = new Set();
+const MOVE: Set<string> = new Set();
+
+type AnyList = BasicListComponent<any>;
+
+function isItemCell(
+  cell: AnyCell,
+  item: unknown,
+  bag: Map<string | number | symbol, Cell<unknown>> | undefined,
+): boolean {
+  if ((cell as Cell)._relatedObj === (item as object)) return true;
+  if (bag !== undefined) {
+    for (const c of bag.values()) {
+      if ((c as AnyCell) === cell) return true;
+    }
+  }
+  return false;
+}
+
+/** Route the cells PROBE collected for slot `s` (grow-only). */
+function routeSlotDeps(
+  list: AnyList,
+  frame: EachFrame<unknown>,
+  s: number,
+): void {
+  const item = frame.item;
+  const bag =
+    item !== null && typeof item === 'object'
+      ? cellsMap.get(item as object)
+      : undefined;
+  for (const cell of PROBE) {
+    if (isItemCell(cell, item, bag)) {
+      let cells = frame.itemCells;
+      if (cells === null) {
+        cells = frame.itemCells = [];
+        frame.itemUnsubs = [];
+        frame.itemSlots = [];
+      }
+      if (cells.indexOf(cell) === -1) {
+        cells.push(cell);
+        let op = frame.itemOp;
+        if (op === null) {
+          op = frame.itemOp = () => {
+            const slots = frame.itemSlots;
+            if (slots === null) return;
+            for (let i = 0; i < slots.length; i++) {
+              runSlot(list, frame, slots[i], false);
+            }
+          };
+        }
+        frame.itemUnsubs!.push(subscribeOp(cell, op));
+      }
+      if (frame.itemSlots!.indexOf(s) === -1) {
+        frame.itemSlots!.push(s);
+      }
+    } else {
+      let shared = list.frameShared;
+      if (shared === null) {
+        shared = list.frameShared = new Map();
+      }
+      const entry = shared.get(cell);
+      if (entry === undefined) {
+        const slots: number[] = [s];
+        const op: tagOp = () => {
+          const frames = list.frames;
+          if (frames === null) return;
+          for (const f of frames.values()) {
+            for (let i = 0; i < slots.length; i++) {
+              runSlot(list, f, slots[i], false);
+            }
+          }
+        };
+        shared.set(cell, { slots, unsub: subscribeOp(cell, op) });
+      } else if (entry.slots.indexOf(s) === -1) {
+        entry.slots.push(s);
+      }
+    }
+  }
+}
+
+/**
+ * Apply a computed slot value — per-kind semantics mirror what v1 wires
+ * through `$prop` / `$attr` / `$ev(TEXT_CONTENT)`:
+ *   static  (first run tracked no cells): the const-collapsed branch —
+ *           empty values are skipped, others written raw, never re-run;
+ *   text    : `String(value ?? '')`, guarded on the applied string;
+ *   class/prop: `null → ''`, first-run `undefined` skipped (the
+ *           `prevPropValue` quirk), `style`-empty removes the attribute;
+ *   attr    : initial run always writes (opcodeFor's immediate evaluation
+ *           parity), re-runs guarded on the raw value.
+ */
+function applySlot(
+  api: DOMApi,
+  frame: EachFrame<unknown>,
+  s: number,
+  slot: StaticBlockSlot,
+  value: unknown,
+  initial: boolean,
+  isStatic: boolean,
+): void {
+  const node = frame.nodes[s];
+  const kind = slot.k;
+  if (kind === 'text') {
+    if (isStatic) {
+      frame.values[s] = value;
+      if (isEmpty(value)) return;
+      api.textContent(node, value as string);
+      return;
+    }
+    const str = String(value ?? '');
+    if (frame.values[s] === str) return;
+    frame.values[s] = str;
+    api.textContent(node, str);
+  } else if (kind === 'attr') {
+    if (isStatic) {
+      frame.values[s] = value;
+      if (isEmpty(value)) return;
+      api.attr(node, slot.n!, value as string);
+      return;
+    }
+    if (!initial && frame.values[s] === value) return;
+    frame.values[s] = value;
+    api.attr(node, slot.n!, value as string);
+  } else {
+    // 'class' | 'prop'
+    const name = kind === 'class' ? 'className' : slot.n!;
+    if (isStatic) {
+      frame.values[s] = value;
+      if (isEmpty(value)) return;
+      api.prop(node, name, value);
+      return;
+    }
+    const val = value === null ? '' : value;
+    const prev = frame.values[s] === UNSET ? undefined : frame.values[s];
+    if (val === prev) return;
+    frame.values[s] = val;
+    // mirrors $prop's reactive-style cleanup: an empty style write must not
+    // leave a stale `style=""` attribute behind
+    if (
+      name === 'style' &&
+      (val === '' || val === undefined) &&
+      (node as HTMLElement).removeAttribute
+    ) {
+      api.prop(node, name, val);
+      if ((node as HTMLElement).getAttribute('style') === '') {
+        (node as HTMLElement).removeAttribute('style');
+      }
+      return;
+    }
+    api.prop(node, name, val);
+  }
+}
+
+/**
+ * Run one slot: evaluate its thunk under the tracker (probe), route any
+ * tracked cells (grow-only), apply with the per-kind guard. The probe is the
+ * same mechanism `formula`/`resolveBindingValue` use — a MergedCell read
+ * under an active tracker runs its fn() in our frame, so deps flatten to
+ * leaf cells.
+ */
+function runSlot(
+  list: AnyList,
+  frame: EachFrame<unknown>,
+  s: number,
+  initial: boolean,
+): void {
+  const slot = list.block!.slots[s];
+  const raw = frame.thunks[s];
+  let value: unknown;
+  let isStatic = false;
+  if (isFn(raw) || isTagLike(raw)) {
+    const prevTracker = getTracker();
+    PROBE.clear();
+    setTracker(PROBE);
+    try {
+      value = isFn(raw) ? deepFnValue(raw) : (raw as AnyCell).value;
+    } finally {
+      setTracker(prevTracker);
+    }
+    if (PROBE.size > 0) {
+      routeSlotDeps(list, frame, s);
+    } else if (initial) {
+      isStatic = true;
+    }
+  } else {
+    value = raw;
+    isStatic = initial;
+  }
+  applySlot(list.api, frame, s, slot, value, initial, isStatic);
+}
+
+function createFrame(
+  list: AnyList,
+  item: unknown,
+  index: number,
+): EachFrame<unknown> {
+  const block = list.block!;
+  const { root, nodes } = block.cloneFrame(list.api);
+  const k = block.slots.length;
+  const frame: EachFrame<unknown> = {
+    root,
+    nodes,
+    thunks: list.blockValues!(item, index, list),
+    values: new Array(k).fill(UNSET),
+    item,
+    index,
+    itemCells: null,
+    itemUnsubs: null,
+    itemSlots: null,
+    itemOp: null,
+  };
+  for (let s = 0; s < k; s++) {
+    runSlot(list, frame, s, true);
+  }
+  return frame;
+}
+
+function unsubscribeFrameItems(frame: EachFrame<unknown>): void {
+  const unsubs = frame.itemUnsubs;
+  if (unsubs !== null) {
+    for (let i = 0; i < unsubs.length; i++) {
+      unsubs[i]();
+    }
+    frame.itemUnsubs = null;
+    frame.itemCells = null;
+    frame.itemSlots = null;
+  }
+}
+
+/**
+ * Keyed reuse with a ref-swapped item: swap `frame.item`, rebuild the thunks
+ * from the new item and re-run every slot (values guards skip unchanged DOM),
+ * re-routing the item-dep subscriptions. `itemOp` is reused — it reads the
+ * frame's current itemSlots.
+ */
+function rebindFrame(
+  list: AnyList,
+  frame: EachFrame<unknown>,
+  item: unknown,
+  index: number,
+): void {
+  unsubscribeFrameItems(frame);
+  frame.item = item;
+  frame.index = index;
+  frame.thunks = list.blockValues!(item, index, list);
+  const k = list.block!.slots.length;
+  for (let s = 0; s < k; s++) {
+    runSlot(list, frame, s, false);
+  }
+}
+
+function dropFrame(api: DOMApi, frame: EachFrame<unknown>, removeDom: boolean): void {
+  unsubscribeFrameItems(frame);
+  if (removeDom) {
+    api.destroy(frame.root);
+  }
+}
+
+/**
+ * Tear down every frame. Bulk-clears the parent DOM (O(1) innerHTML='') when
+ * this list owns it end-to-end — the same guard `fastCleanup` uses — falling
+ * back to per-root removal otherwise. Frame teardown is just "run the
+ * unsubs": frame rows have no modifiers/components, so no destructor cascade
+ * exists to run.
+ */
+export function clearAllFrames(list: AnyList): void {
+  const frames = list.frames;
+  if (frames === null || frames.size === 0) return;
+  const api = list.api;
+  const { topMarker, bottomMarker } = list;
+  const parent = api.parent(bottomMarker);
+  const bulk =
+    parent !== null &&
+    parent.lastChild === bottomMarker &&
+    parent.firstChild === topMarker;
+  if (bulk) {
+    api.clearChildren(parent);
+    api.insert(parent, topMarker);
+    api.insert(parent, bottomMarker);
+  }
+  for (const frame of frames.values()) {
+    dropFrame(api, frame, !bulk);
+  }
+  frames.clear();
+}
+
+/**
+ * Full frame-state teardown for the LIST's own destruction: frames + the
+ * list-level shared-dep subscriptions. Idempotent (the list destructor and
+ * the `syncList([])` teardown destructor can both reach it).
+ */
+export function destroyFrameState(list: AnyList): void {
+  clearAllFrames(list);
+  const shared = list.frameShared;
+  if (shared !== null) {
+    for (const entry of shared.values()) {
+      entry.unsub();
+    }
+    shared.clear();
+    list.frameShared = null;
+  }
+}
+
+/**
+ * The frame-mode keyed sync (replaces updateItems/fastCleanup/destroyItem for
+ * frame lists). Same observable keyed semantics as v1: position-qualified
+ * duplicate keys (via the list's own `keyForItem`), removals before
+ * insertions, LIS-minimal relocation, append/replace/clear fast paths.
+ * Inverse rendering stays with the caller (the subclass syncList wrappers).
+ */
+export function syncFrames<T extends { id: number }>(
+  list: BasicListComponent<T>,
+  items: T[],
+): void {
+  return syncFramesAny(list, items);
+}
+
+function syncFramesAny(list: AnyList, items: unknown[]): void {
+  const api = list.api;
+  const bottomMarker = list.bottomMarker;
+  let frames = list.frames;
+  if (frames === null) {
+    frames = list.frames = new Map();
+  }
+  if (list.isFirstRender) {
+    list.isFirstRender = false;
+  }
+  const n = items.length;
+
+  // ----- clear
+  if (n === 0) {
+    clearAllFrames(list);
+    return;
+  }
+
+  const keyForItem = list.keyForItem;
+
+  // ----- pass 1: keys (position-qualified for duplicates by keyForItem)
+  KEYS.length = n;
+  KEYSET.clear();
+  for (let i = 0; i < n; i++) {
+    const key = keyForItem(items[i], i, items);
+    KEYS[i] = key;
+    KEYSET.add(key);
+  }
+
+  // ----- pass 2: removals (bulk when EVERY existing row goes away)
+  if (frames.size > 0) {
+    let survivors = 0;
+    for (const key of frames.keys()) {
+      if (KEYSET.has(key)) survivors++;
+    }
+    if (survivors === 0) {
+      clearAllFrames(list);
+    } else if (survivors < frames.size) {
+      for (const [key, frame] of frames) {
+        if (!KEYSET.has(key)) {
+          dropFrame(api, frame, true);
+          frames.delete(key);
+        }
+      }
+    }
+  }
+
+  // ----- fresh render: batch every row through one fragment insert
+  if (frames.size === 0) {
+    const fragment = api.fragment();
+    for (let i = 0; i < n; i++) {
+      const frame = createFrame(list, items[i], i);
+      frames.set(KEYS[i], frame);
+      api.insert(fragment, frame.root);
+    }
+    const parent = api.parent(bottomMarker);
+    if (parent !== null) {
+      api.insert(parent, fragment, bottomMarker);
+    }
+    KEYS.length = 0;
+    return;
+  }
+
+  // ----- pass 3: create/rebind + collect existing-row order for LIS
+  EXIST_KEYS.length = 0;
+  EXIST_OLD.length = 0;
+  EXIST_NEW.length = 0;
+  for (let i = 0; i < n; i++) {
+    const key = KEYS[i];
+    const frame = frames.get(key);
+    if (frame === undefined) {
+      // built now, inserted by the move phase below (root not yet connected)
+      frames.set(key, createFrame(list, items[i], i));
+    } else {
+      if (frame.item !== items[i]) {
+        rebindFrame(list, frame, items[i], i);
+      }
+      EXIST_KEYS.push(key);
+      EXIST_NEW.push(i);
+      EXIST_OLD.push(frame.index);
+      frame.index = i;
+    }
+  }
+
+  // ----- LIS over the existing rows' old indices (new-list order): only
+  // rows OUTSIDE the longest stable subsequence relocate.
+  MOVE.clear();
+  if (EXIST_KEYS.length > 1) {
+    const stable = longestIncreasingSubsequence(EXIST_OLD, LIS_OUT);
+    for (let j = 0; j < EXIST_KEYS.length; j++) {
+      if (!stable.has(j)) {
+        MOVE.add(EXIST_KEYS[j]);
+      }
+    }
+  } else if (EXIST_KEYS.length === 1 && EXIST_OLD[0] !== EXIST_NEW[0]) {
+    MOVE.add(EXIST_KEYS[0]);
+  }
+
+  // ----- move phase: right-to-left anchor walk; relocation moves frame.root
+  // directly (single node — no marker-extent fragment collection).
+  const parent = api.parent(bottomMarker);
+  let anchor: Node = bottomMarker;
+  for (let i = n - 1; i >= 0; i--) {
+    const frame = frames.get(KEYS[i])!;
+    const root = frame.root;
+    if (root.parentNode === null) {
+      // fresh row
+      if (parent !== null) api.insert(parent, root, anchor);
+    } else if (MOVE.has(KEYS[i]) && root.nextSibling !== anchor) {
+      if (parent !== null) api.insert(parent, root, anchor);
+    }
+    anchor = root;
+  }
+  KEYS.length = 0;
+}

--- a/src/core/control-flow/list-frames.ts
+++ b/src/core/control-flow/list-frames.ts
@@ -79,6 +79,7 @@ import {
   setTracker,
   cellsMap,
   deepFnValue,
+  reportOpcodeError,
 } from '@/core/reactive';
 import { isFn, isEmpty, isTagLike } from '@/core/shared';
 import {
@@ -166,18 +167,45 @@ function subscribeOp(tag: AnyCell, op: tagOp): () => void {
 }
 
 // ---------------------------------------------------------------------------
-// Reusable scratch (module-level; frame syncs never nest: frame bodies contain
-// no control flow, so no inner list can sync while a frame sync is mid-flight,
-// and slot runs are synchronous + non-reentrant)
+// Reusable scratch (module-level). Frame bodies contain no control flow, so
+// no inner list renders DURING a frame sync — but slot thunks run USER
+// getters, and user code can synchronously flush opcodes
+// (`applyCellUpdateSync` → `flushCellOpcodes`), which may re-enter this
+// module: another list's `syncFrames` while ours is mid-pass, or a nested
+// `runSlot` while an outer probe is mid-collection. Both entry points are
+// therefore depth-guarded: the outermost invocation uses the shared
+// module-level scratch (the hot path — zero allocation), any nested
+// invocation falls back to fresh per-call structures.
 // ---------------------------------------------------------------------------
 const PROBE: Set<Cell> = new Set();
-const KEYS: string[] = [];
-const KEYSET: Set<string> = new Set();
-const EXIST_KEYS: string[] = [];
-const EXIST_OLD: number[] = [];
-const EXIST_NEW: number[] = [];
-const LIS_OUT: Set<number> = new Set();
-const MOVE: Set<string> = new Set();
+/** True while the shared PROBE set is mid-collection (see runSlot). */
+let probeBusy = false;
+
+interface FrameSyncScratch {
+  keys: string[];
+  keyset: Set<string>;
+  existKeys: string[];
+  existOld: number[];
+  existNew: number[];
+  lisOut: Set<number>;
+  move: Set<string>;
+}
+
+function makeSyncScratch(): FrameSyncScratch {
+  return {
+    keys: [],
+    keyset: new Set(),
+    existKeys: [],
+    existOld: [],
+    existNew: [],
+    lisOut: new Set(),
+    move: new Set(),
+  };
+}
+
+const SYNC_SCRATCH = makeSyncScratch();
+/** >0 while a syncFramesAny is on the stack (nested syncs get fresh scratch). */
+let syncDepth = 0;
 
 type AnyList = BasicListComponent<any>;
 
@@ -195,11 +223,12 @@ function isItemCell(
   return false;
 }
 
-/** Route the cells PROBE collected for slot `s` (grow-only). */
+/** Route the cells `probe` collected for slot `s` (grow-only). */
 function routeSlotDeps(
   list: AnyList,
   frame: EachFrame<unknown>,
   s: number,
+  probe: Set<Cell>,
 ): void {
   const item = frame.item;
   let bag = frame.bag;
@@ -208,7 +237,7 @@ function routeSlotDeps(
     // `@tracked` getters) — refresh the snapshot before classifying
     bag = frame.bag = cellsMap.get(item as object);
   }
-  for (const cell of PROBE) {
+  for (const cell of probe) {
     if (isItemCell(cell, item, bag)) {
       let cells = frame.itemCells;
       if (cells === null) {
@@ -222,9 +251,10 @@ function routeSlotDeps(
         if (op === null) {
           op = frame.itemOp = () => {
             const slots = frame.itemSlots;
-            if (slots === null) return;
+            const itemCells = frame.itemCells;
+            if (slots === null || itemCells === null) return;
             for (let i = 0; i < slots.length; i++) {
-              runSlot(list, frame, slots[i], false);
+              runSlotGuarded(list, frame, slots[i], itemCells[0]);
             }
           };
         }
@@ -249,7 +279,7 @@ function routeSlotDeps(
               // `cell` is this entry's own dep — when a re-probe yields
               // exactly it again (the overwhelmingly common stable-dep
               // case), routing is provably already in place and skipped.
-              runSlot(list, f, slots[i], false, cell);
+              runSlotGuarded(list, f, slots[i], cell, cell);
             }
           }
         };
@@ -354,22 +384,33 @@ function runSlot(
   let isStatic = false;
   if (isFn(raw) || isTagLike(raw)) {
     const prevTracker = getTracker();
-    PROBE.clear();
-    setTracker(PROBE);
+    // Re-entrancy guard: a thunk getter can synchronously flush opcodes
+    // (`applyCellUpdateSync` → `flushCellOpcodes`) and re-run another slot
+    // while THIS probe is mid-collection. The nested run must not clear the
+    // outer's already-tracked deps — give it a private set instead of the
+    // shared scratch (the outermost run keeps the zero-alloc path).
+    const probe: Set<Cell> = probeBusy ? new Set() : PROBE;
+    const owned = probe === PROBE;
+    if (owned) {
+      probeBusy = true;
+      probe.clear();
+    }
+    setTracker(probe);
     try {
       value = isFn(raw) ? deepFnValue(raw) : (raw as AnyCell).value;
     } finally {
       setTracker(prevTracker);
+      if (owned) probeBusy = false;
     }
-    if (PROBE.size > 0) {
+    if (probe.size > 0) {
       // sweep fast path: the probe re-found exactly the cell whose op is
       // running — its (cell → slot) routing already exists by construction
       if (
-        PROBE.size !== 1 ||
+        probe.size !== 1 ||
         knownCell === undefined ||
-        !PROBE.has(knownCell as Cell)
+        !probe.has(knownCell as Cell)
       ) {
-        routeSlotDeps(list, frame, s);
+        routeSlotDeps(list, frame, s, probe);
       }
     } else if (initial) {
       isStatic = true;
@@ -379,6 +420,33 @@ function runSlot(
     isStatic = initial;
   }
   applySlot(list.api, frame, s, slot, value, initial, isStatic);
+}
+
+/**
+ * Error-isolated slot re-run for the update ops (itemOp / shared sweeps).
+ * Parity with v1's granularity: there each binding is its own formula opcode,
+ * so one throwing binding loses only itself. Frame mode batches many slots
+ * behind ONE op — without isolation a single bad thunk would abort the whole
+ * sweep AND get the batched op spliced out by `handleOpcodeError`, silencing
+ * every row's updates for that cell. Errors are reported through the same
+ * channel the drain uses (dev console + host opcode-error reporter).
+ */
+function runSlotGuarded(
+  list: AnyList,
+  frame: EachFrame<unknown>,
+  s: number,
+  tag: AnyCell,
+  knownCell?: AnyCell,
+): void {
+  if (TRY_CATCH_ERROR_HANDLING) {
+    try {
+      runSlot(list, frame, s, false, knownCell);
+    } catch (e) {
+      reportOpcodeError(e, tag as Cell);
+    }
+  } else {
+    runSlot(list, frame, s, false, knownCell);
+  }
 }
 
 function createFrame(
@@ -516,6 +584,24 @@ export function syncFrames<T extends { id: number }>(
 }
 
 function syncFramesAny(list: AnyList, items: unknown[]): void {
+  // Outermost sync uses the shared zero-alloc scratch; a NESTED sync (user
+  // code inside a slot thunk synchronously flushing another — or this —
+  // list's items cell) gets fresh structures so it can't corrupt the
+  // suspended outer pass.
+  const S = syncDepth === 0 ? SYNC_SCRATCH : makeSyncScratch();
+  syncDepth++;
+  try {
+    syncFramesScratch(list, items, S);
+  } finally {
+    syncDepth--;
+  }
+}
+
+function syncFramesScratch(
+  list: AnyList,
+  items: unknown[],
+  S: FrameSyncScratch,
+): void {
   const api = list.api;
   const bottomMarker = list.bottomMarker;
   let frames = list.frames;
@@ -534,6 +620,8 @@ function syncFramesAny(list: AnyList, items: unknown[]): void {
   }
 
   const keyForItem = list.keyForItem;
+  const KEYS = S.keys;
+  const KEYSET = S.keyset;
 
   // ----- pass 1: keys (position-qualified for duplicates by keyForItem)
   KEYS.length = n;
@@ -579,6 +667,9 @@ function syncFramesAny(list: AnyList, items: unknown[]): void {
   }
 
   // ----- pass 3: create/rebind + collect existing-row order for LIS
+  const EXIST_KEYS = S.existKeys;
+  const EXIST_OLD = S.existOld;
+  const EXIST_NEW = S.existNew;
   EXIST_KEYS.length = 0;
   EXIST_OLD.length = 0;
   EXIST_NEW.length = 0;
@@ -589,21 +680,25 @@ function syncFramesAny(list: AnyList, items: unknown[]): void {
       // built now, inserted by the move phase below (root not yet connected)
       frames.set(key, createFrame(list, items[i], i));
     } else {
-      if (frame.item !== items[i]) {
-        rebindFrame(list, frame, items[i], i);
-      }
+      // Record the OLD position BEFORE any rebind: rebindFrame overwrites
+      // frame.index with the new one, and the LIS below MUST see true old
+      // positions or a ref-swapped row that also moved is never relocated.
       EXIST_KEYS.push(key);
       EXIST_NEW.push(i);
       EXIST_OLD.push(frame.index);
+      if (frame.item !== items[i]) {
+        rebindFrame(list, frame, items[i], i);
+      }
       frame.index = i;
     }
   }
 
   // ----- LIS over the existing rows' old indices (new-list order): only
   // rows OUTSIDE the longest stable subsequence relocate.
+  const MOVE = S.move;
   MOVE.clear();
   if (EXIST_KEYS.length > 1) {
-    const stable = longestIncreasingSubsequence(EXIST_OLD, LIS_OUT);
+    const stable = longestIncreasingSubsequence(EXIST_OLD, S.lisOut);
     for (let j = 0; j < EXIST_KEYS.length; j++) {
       if (!stable.has(j)) {
         MOVE.add(EXIST_KEYS[j]);

--- a/src/core/control-flow/list.ts
+++ b/src/core/control-flow/list.ts
@@ -18,6 +18,7 @@ import {
   formula,
   deepFnValue,
   registerLeafOwnersForFormula,
+  type AnyCell,
 } from '@/core/reactive';
 import { opcodeFor } from '@/core/vm';
 import {
@@ -46,6 +47,14 @@ import {
   type Destructors,
 } from '../glimmer/destroyable';
 import type { StaticBlockDef } from '@/core/static-block';
+import {
+  framesQualify,
+  frameHostHooksInstalled,
+  syncFrames,
+  destroyFrameState,
+  type EachFrame,
+  type FrameSharedEntry,
+} from './list-frames';
 import { setParentContext, getParentContext } from '../tracking';
 import { HOST_HOOKS } from '@/core/host-hooks';
 
@@ -560,6 +569,14 @@ export class BasicListComponent<T extends { id: number }> {
   blockValues:
     | ((item: T, index: number | MergedCell, ctx: unknown) => readonly unknown[])
     | null = null;
+  // Frame mode (static-block v2, src/core/control-flow/list-frames.ts):
+  // qualifying block-bodied lists keep ONE Frame record per row instead of
+  // the marker + 7-map-entry + rowCtx + per-binding-formula bookkeeping.
+  // Decided once in the constructor; when true, syncList dispatches to
+  // syncFrames and the v1 keyMap/marker machinery is never populated.
+  frameMode = false;
+  frames: Map<string, EachFrame<T>> | null = null;
+  frameShared: Map<AnyCell, FrameSharedEntry> | null = null;
   constructor(
     {
       tag,
@@ -628,6 +645,26 @@ export class BasicListComponent<T extends { id: number }> {
     ) {
       this.block = block;
       this.blockValues = blockValues;
+      // Frame mode (static-block v2): single-root no-event block bodies skip
+      // the per-row marker/map/rowCtx/formula bookkeeping entirely (see
+      // list-frames.ts for the gate rationale). Bodies reading `{{index}}`,
+      // SSR/rehydration renders and Ember hosts stay on v1.
+      if (
+        !this.hasIndex &&
+        !IN_SSR_ENV &&
+        !isRehydrationScheduled() &&
+        framesQualify(block) &&
+        !frameHostHooksInstalled()
+      ) {
+        this.frameMode = true;
+        // Frame teardown is owned by the LIST: when this instance is
+        // destroyed, reclaim every frame's subscriptions + the list-level
+        // shared-dep subscriptions. Idempotent with the subclass destructor's
+        // `syncList([])` (whichever runs first does the work).
+        registerDestructor(this, () => {
+          destroyFrameState(this);
+        });
+      }
     }
     this.setupKeyForItem();
     // Register destructor to clean up the list's own TREE/PARENT/CHILD entries.
@@ -1669,6 +1706,25 @@ export class SyncListComponent<
       this.recycleImpl(this, items);
       return;
     }
+    // Frame mode (static-block v2): the entire keyed sync runs over Frame
+    // records (list-frames.ts). Fully synchronous — frame rows carry no
+    // modifiers/components, so no destructor cascade can re-enter.
+    if (this.frameMode) {
+      this._syncInProgress = true;
+      this._dupItemsRef = null;
+      try {
+        if (items.length > 0 && this.inverseContent !== null) {
+          this.destroyInverseSync();
+        }
+        syncFrames(this, items);
+        if (items.length === 0 && this.inverseFn) {
+          this.renderInverse();
+        }
+      } finally {
+        this._syncInProgress = false;
+      }
+      return;
+    }
     this._syncInProgress = true;
     // Invalidate the duplicate-key detection cache for this sync pass — a
     // mutated-in-place array would otherwise carry stale verdict forward.
@@ -2051,6 +2107,20 @@ export class AsyncListComponent<
     // re-entry guard lives inside the impl, shared with the sync subclass.
     if (this.recycleImpl !== undefined) {
       this.recycleImpl(this, items);
+      return;
+    }
+    // Frame mode (static-block v2): synchronous frame sync (no async
+    // destructors exist on frame rows — modifiers/events bail to v1). The
+    // inverse keeps this subclass's async teardown semantics.
+    if (this.frameMode) {
+      this._dupItemsRef = null;
+      if (items.length > 0 && this.inverseContent !== null) {
+        await this.destroyInverseAsync();
+      }
+      syncFrames(this, items);
+      if (items.length === 0 && this.inverseFn) {
+        this.renderInverse();
+      }
       return;
     }
     // Invalidate per-items-array duplicate-key cache (see SyncListComponent)

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -293,37 +293,55 @@ export function relatedTagsForCell(cell: Cell) {
  * error is surfaced to the host via the opcode-error reporter (NOT swallowed).
  */
 export function flushCellOpcodes(cell: Cell | MergedCell): void {
-  // Only execute the cell's own opcodes when it actually has some — for cells
-  // that exist purely as subscription targets (selector key cells, recycle
-  // holder cells) an unguarded executeTagSync would MATERIALIZE an empty
-  // pooled ops array into the global opsForTag map per flush.
-  const ownOps = opsForTag.get((cell as Cell).id);
-  if (ownOps !== undefined && ownOps.length > 0) {
-    try {
-      executeTagSync(cell);
-    } catch (e) {
-      // Don't abort the flush, but report to the host (mirrors the normal
-      // drain's handleOpcodeError reporter path) rather than silently
-      // swallowing.
-      reportOpcodeError(e, cell);
+  // Opcode execution is a drain, NOT part of any tracking scope. A flush can
+  // be triggered from INSIDE an active tracking frame (e.g. a getter read by
+  // a frame-mode slot probe, or a formula evaluation, calling
+  // `applyCellUpdateSync`). Two corruptions follow if the tracker leaks in:
+  //   1. `MergedCell.value` short-circuits dep re-collection while a tracker
+  //      is active — but this flush has already CONSUMED the formula's
+  //      `relatedTags` entry below, so the formula would stay permanently
+  //      unsubscribed from its deps (observed: an {{#each}} source formula
+  //      going dead after a thunk-triggered flush).
+  //   2. every leaf cell read by the executed opcodes would be tracked into
+  //      the CALLER's frame, attributing foreign deps to it.
+  // Suspend the tracker for the duration of the flush; restore after.
+  const prevTracker = getTracker();
+  if (prevTracker !== null) setTracker(null);
+  try {
+    // Only execute the cell's own opcodes when it actually has some — for
+    // cells that exist purely as subscription targets (selector key cells,
+    // recycle holder cells) an unguarded executeTagSync would MATERIALIZE an
+    // empty pooled ops array into the global opsForTag map per flush.
+    const ownOps = opsForTag.get((cell as Cell).id);
+    if (ownOps !== undefined && ownOps.length > 0) {
+      try {
+        executeTagSync(cell);
+      } catch (e) {
+        // Don't abort the flush, but report to the host (mirrors the normal
+        // drain's handleOpcodeError reporter path) rather than silently
+        // swallowing.
+        reportOpcodeError(e, cell);
+      }
     }
-  }
-  const subTags = relatedTags.get((cell as Cell).id);
-  if (subTags === undefined) {
-    return;
-  }
-  relatedTags.delete((cell as Cell).id);
-  const ordered = [...subTags];
-  subTags.clear();
-  if (ordered.length > 1) {
-    ordered.sort((a, b) => a.id - b.id);
-  }
-  for (const tag of ordered) {
-    try {
-      executeTagSync(tag);
-    } catch (e) {
-      reportOpcodeError(e, tag);
+    const subTags = relatedTags.get((cell as Cell).id);
+    if (subTags === undefined) {
+      return;
     }
+    relatedTags.delete((cell as Cell).id);
+    const ordered = [...subTags];
+    subTags.clear();
+    if (ordered.length > 1) {
+      ordered.sort((a, b) => a.id - b.id);
+    }
+    for (const tag of ordered) {
+      try {
+        executeTagSync(tag);
+      } catch (e) {
+        reportOpcodeError(e, tag);
+      }
+    }
+  } finally {
+    if (prevTracker !== null) setTracker(prevTracker);
   }
 }
 
@@ -587,9 +605,10 @@ function handleOpcodeError(e: any, tag: Cell | MergedCell, opcode: tagOp | null,
 }
 
 // Surface an opcode error from a context that has no `ops` array to splice
-// (e.g. the synchronous `flushCellOpcodes` path). Dev-logs and forwards to the
-// host reporter; never throws. Keeps flush errors from being silently dropped.
-function reportOpcodeError(e: any, tag: Cell | MergedCell): void {
+// (e.g. the synchronous `flushCellOpcodes` path, or frame-mode's per-slot
+// isolation in list-frames.ts). Dev-logs and forwards to the host reporter;
+// never throws. Keeps such errors from being silently dropped.
+export function reportOpcodeError(e: any, tag: Cell | MergedCell): void {
   if (IS_DEV_MODE) {
     console.error({ message: 'Error executing tag (flush)', error: e, tag });
   }

--- a/src/core/static-block.ts
+++ b/src/core/static-block.ts
@@ -39,6 +39,8 @@ export interface StaticBlockSlot {
 }
 
 export interface StaticBlockDef {
+  /** The static slot table (frame mode reads kinds/names/paths from here). */
+  readonly slots: readonly StaticBlockSlot[];
   /**
    * Clone the block and wire the positional `values` (matching the slot
    * table) into the slot nodes. Binding destructors are pushed into the
@@ -50,6 +52,12 @@ export interface StaticBlockDef {
     values: readonly unknown[],
     destructors: DestructorFn[],
   ): Node;
+  /**
+   * Frame-mode clone (src/core/control-flow/list-frames.ts): clone the block
+   * and resolve every slot node ONCE, WITHOUT wiring any bindings. The frame
+   * runtime applies/updates slot values itself (no per-binding formulas).
+   */
+  cloneFrame(api: DOMApi): { root: Node; nodes: Node[] };
 }
 
 /**
@@ -94,7 +102,7 @@ function resolvePath(root: Node, path: readonly number[]): Node {
 
 class StaticBlock implements StaticBlockDef {
   private html: string;
-  private slots: readonly StaticBlockSlot[];
+  readonly slots: readonly StaticBlockSlot[];
   private roots: WeakMap<Document, Node>;
   constructor(
     html: string,
@@ -105,11 +113,8 @@ class StaticBlock implements StaticBlockDef {
     this.slots = slots;
     this.roots = roots;
   }
-  create(
-    api: DOMApi,
-    values: readonly unknown[],
-    destructors: DestructorFn[],
-  ): Node {
+  /** Parse-once (per document) + cloneNode — shared by create/cloneFrame. */
+  private cloneRoot(api: DOMApi): Node {
     const doc = documentFor(api);
     let proto = this.roots.get(doc);
     if (proto === undefined) {
@@ -129,7 +134,24 @@ class StaticBlock implements StaticBlockDef {
       proto = content.firstChild!;
       this.roots.set(doc, proto);
     }
-    const root = proto.cloneNode(true);
+    return proto.cloneNode(true);
+  }
+  cloneFrame(api: DOMApi): { root: Node; nodes: Node[] } {
+    const root = this.cloneRoot(api);
+    const slots = this.slots;
+    const nodes: Node[] = new Array(slots.length);
+    for (let i = 0; i < slots.length; i++) {
+      const p = slots[i].p;
+      nodes[i] = p.length === 0 ? root : resolvePath(root, p);
+    }
+    return { root, nodes };
+  }
+  create(
+    api: DOMApi,
+    values: readonly unknown[],
+    destructors: DestructorFn[],
+  ): Node {
+    const root = this.cloneRoot(api);
     const slots = this.slots;
     for (let i = 0; i < slots.length; i++) {
       const slot = slots[i];


### PR DESCRIPTION
> Base PRs #220/#221/#225 have merged — this PR now sits directly on master (5 commits: 4 frame commits + the nullish-slot guard surfaced by #225's tests running in frame mode). Merge before #227 (which rebases over this).

## What

Frame mode (v2) builds on the static-block fast path (#221): for qualifying bodies (compiler-emitted `$_blk`, single root, attr/prop/class/text slots, no events, no `{{index}}`, standalone mode), per-row construction and reactivity become:

- one frame record per row (`{root, nodes, thunks, values, item, subscriptions}`) instead of ~7 map entries + per-row marker comment + `rowBodyCtx`/`cId`/`addToTree`;
- the single root node IS the row boundary (LIS/relocation move `frame.root` directly);
- **one subscription per (row, item-cell)** instead of a `MergedCell` formula per binding; shared cells (e.g. `selected`) get ONE list-level subscription sweeping only their slots with prev-value guards;
- teardown is list-owned (no destructor cascade); rebind (ref-swapped item, stable key) re-runs slots from the new item.

Everything else — events, `{{index}}`, components, Ember hosts, SSR/rehydration, `@recycle` — bails to v1 byte-identically. Keyed semantics (LIS, duplicate keys, inverse blocks) preserved and tested.

## Measured

**Real Chromium** (production build, kill-switch A/B, 7 interleaved rounds, in-page timing, usage proven by per-row counters — 8,000 frame creates per ON round, 0 per OFF):

| scenario | frames | v1 | speedup |
|---|---|---|---|
| create1k | 4.4ms | 9.4ms | **2.1×** |
| select20 | 5.0ms | 36.0ms | **7.2×** |
| replace1k | 6.1ms | 30.5ms | **5.0×** |
| clear1k | 2.3ms | 4.0ms | 1.7× |
| create5k | 22.7ms | 35.9ms | 1.6× |
| create1k @ 4× CPU throttle | 17.4ms | 28.0ms | 1.6× |

happy-dom harness (serial, idle): create1k 238.6→121.8, append −71%, replace −58%, clear −73%, select −37%, update parity.

## Hardening (self-review round, each fix has a fail-first regression test)

1. LIS-vs-rebind index corruption when a ref-swapped row also moves in the same sync.
2. Per-slot error isolation — a throwing slot thunk no longer aborts the sweep or silences the row's cell (v1 parity).
3. **Core fix in `reactive.ts`**: `flushCellOpcodes` ran under the caller's active tracker, suppressing dep re-collection (could permanently kill a list's source formula); the tracker is now suspended for the flush — this also hardens the host-facing API introduced in #220.
4. Probe re-entrancy guard (nested sync flush inside a thunk).
5. Nested-sync scratch isolation (a thunk syncing another frame list mid-pass).

Known trade (documented in the module docblock): frame lists hold no component instances per row, so inspector/HMR row-walks see no rows — same as v1's inline-element rows.

## Testing

23 frame tests (15 feature + 8 hardening regressions); full suite 3,879 passed; `tsc --noEmit` clean; QUnit-in-Chromium green on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
