### PR TITLE
refactor(reactive): drain-overhead diet — per-cell subscriber sets, skip-sort, epoch-free dedup

### DIFF
--- a/src/core/component.test.ts
+++ b/src/core/component.test.ts
@@ -975,7 +975,7 @@ describe('destroyNodes - nested components', () => {
 // ============================================
 
 import { IfCondition } from './control-flow/if';
-import { cell, formula, opsForTag, relatedTags, tagsToRevalidate } from './reactive';
+import { cell, formula, opsForTag, tagsToRevalidate } from './reactive';
 import { opcodeFor } from './vm';
 
 describe('If Component Destruction', () => {
@@ -1066,16 +1066,16 @@ describe('If Component Destruction', () => {
     // Wait for initial render
     await new Promise(resolve => setTimeout(resolve, 10));
 
-    // Verify relatedTags contains the derived cell
-    const relatedBefore = relatedTags.get(baseCell.id);
+    // Verify the cell's subscriber set contains the derived cell
+    const relatedBefore = baseCell.relatedTags;
     expect(relatedBefore?.size).toBeGreaterThan(0);
 
     // Destroy the if component
     await ifInstance.destroy();
 
-    // Verify relatedTags is cleaned up
-    const relatedAfter = relatedTags.get(baseCell.id);
-    // Either deleted or empty
+    // Verify the subscriber set is cleaned up
+    const relatedAfter = baseCell.relatedTags;
+    // Either never materialized or empty
     expect(relatedAfter?.size ?? 0).toBe(0);
   });
 

--- a/src/core/control-flow/if.runtime.test.ts
+++ b/src/core/control-flow/if.runtime.test.ts
@@ -3,7 +3,7 @@
  * These tests verify actual behavior without mocking.
  */
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
-import { cell, tagsToRevalidate, opsForTag, relatedTags } from '../reactive';
+import { cell, tagsToRevalidate, opsForTag } from '../reactive';
 import { createCallTracker, createTrackedCell, createDOMFixture, type DOMFixture } from '../__test-utils__';
 import { IfCondition } from './if';
 import { Component } from '../component';
@@ -13,7 +13,6 @@ beforeEach(() => {
   // Clear reactive state between tests
   tagsToRevalidate.clear();
   opsForTag.clear();
-  relatedTags.clear();
 });
 
 describe('If condition - reactive behavior', () => {

--- a/src/core/control-flow/list-frames.test.ts
+++ b/src/core/control-flow/list-frames.test.ts
@@ -25,7 +25,7 @@ import { $template } from '../shared';
 import {
   cellFor,
   opsForTag,
-  relatedTags,
+  activeRelatedTagsCount,
   applyCellUpdateSync,
   type Cell,
 } from '../reactive';
@@ -618,7 +618,7 @@ describe('frame-mode {{#each}} (static-block v2)', () => {
     let current = root._items[2];
     const stableId = current.id;
     const opsBaseline = opsForTag.size;
-    const relatedBaseline = relatedTags.size;
+    const relatedBaseline = activeRelatedTagsCount();
     for (let cycle = 0; cycle < 25; cycle++) {
       const oldCell = cellFor(current, 'label') as any;
       const replacement: HarnessItem = {
@@ -636,7 +636,7 @@ describe('frame-mode {{#each}} (static-block v2)', () => {
       current = replacement;
     }
     expect(opsForTag.size).toBe(opsBaseline);
-    expect(relatedTags.size).toBe(relatedBaseline);
+    expect(activeRelatedTagsCount()).toBe(relatedBaseline);
     // exactly ONE live subscription on the current item's cell
     const liveCell = cellFor(current, 'label') as any;
     expect(opsForTag.get(liveCell.id)?.length).toBe(1);
@@ -675,7 +675,7 @@ describe('frame-mode {{#each}} (static-block v2)', () => {
     (root as any)._items = [];
     await settle();
     const opsAfterFirst = opsForTag.size;
-    const relatedAfterFirst = relatedTags.size;
+    const relatedAfterFirst = activeRelatedTagsCount();
     for (let cycle = 0; cycle < 5; cycle++) {
       (root as any)._items = buildItems(30);
       await settle();
@@ -683,7 +683,7 @@ describe('frame-mode {{#each}} (static-block v2)', () => {
       await settle();
     }
     expect(opsForTag.size).toBe(opsAfterFirst);
-    expect(relatedTags.size).toBe(relatedAfterFirst);
+    expect(activeRelatedTagsCount()).toBe(relatedAfterFirst);
   });
 
   test('gate: event-bodied each stays on v1 (per-item markers present)', async () => {

--- a/src/core/drain-overhead.bench.test.ts
+++ b/src/core/drain-overhead.bench.test.ts
@@ -1,0 +1,366 @@
+/**
+ * @vitest-environment node
+ *
+ * D1 — drain-overhead micro-benchmark: GXT's REAL push pipeline (pushReal)
+ * vs a minimal push model doing identical work (pushMinimal). Adapted from
+ * the E6 bench (exp/e6-binary-validation:src/core/validation-strategies.bench.test.ts),
+ * with the segment-tree strategy and reorder scenarios dropped — this file
+ * isolates the pushReal-vs-pushMinimal gap that E6 flagged as a standalone
+ * optimization target (RESEARCH_LIST_TRACKING_OPTIMIZATION.md §5, E6 row:
+ * "pushReal is 4-6× slower than a minimal push model — GXT's own drain
+ * bookkeeping (dirty-set sort, relatedTags churn, epoch WeakMap) is a
+ * standalone optimization target").
+ *
+ * Pure JS micro-benchmark, no DOM. "Apply update to row i" is the same
+ * trivial sink for both strategies: write the row's current value into a
+ * preallocated Float64Array slot.
+ *
+ *  a. PUSH-REAL — the actual GXT primitives:
+ *     - one Cell per row via `cellFor(item, 'v')` (cellsMap Map + accessor
+ *       defineProperty, exactly the Krausest `cellFor(item,'label')` path);
+ *     - one `opcodeFor(cell, sink)` subscription per row;
+ *     - dirty d rows via the accessor setter → `Cell.update` →
+ *       `tagsToRevalidate.add` + `scheduleRevalidate`;
+ *     - drain via the REAL production path: `takeRenderingControl()`
+ *       suppresses the microtask scheduling, then the exported `syncDom()`
+ *       dispatches to `syncDomSync` (the exact production drain).
+ *
+ *  b. PUSH-MINIMAL — stripped reimplementation of the model
+ *     (Map<cellId, op[]> + dirty Set + drain loop). No relatedTags lookup,
+ *     no dedup bookkeeping, no id-sort, no accessor indirection — isolates
+ *     the push MODEL from GXT's bookkeeping overhead.
+ *
+ * Results print as one `PERF_RESULTS_JSON {...}` line (median of 7,
+ * performance.now), including the per-d pushReal/pushMinimal ratio.
+ *
+ * Gated behind RUN_LIST_PERF=1 (like list-perf.bench.test.ts). Run with:
+ *   RUN_LIST_PERF=1 npx vitest run --no-file-parallelism src/core/drain-overhead.bench.test.ts
+ */
+import { describe, test, expect } from 'vitest';
+import { cellFor, hasAsyncOpcodes, tagsToRevalidate } from '@/core/reactive';
+import { opcodeFor } from '@/core/vm';
+import { syncDom, takeRenderingControl } from '@/core/runtime';
+
+const N = 10_000;
+const RUNS = 7;
+const D_VALUES = [1, 10, 100, 1000, 10000] as const;
+// repetitions per timed sample so tiny d values produce measurable times
+const REPS: Record<number, number> = {
+  1: 2000,
+  10: 500,
+  100: 200,
+  1000: 40,
+  10000: 7,
+};
+const MIXED_ROUNDS = 100;
+const MIXED_D = 10;
+
+let valSeq = 1;
+
+const median = (xs: number[]) =>
+  [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+const round6 = (x: number) => Math.round(x * 1e6) / 1e6;
+
+interface Strategy {
+  readonly name: string;
+  readonly sink: Float64Array;
+  /** untimed: raw user data (item objects exist in every model) */
+  prepare(initial: Float64Array): void;
+  /** timed: wire up the reactive bookkeeping */
+  setup(initial: Float64Array): void;
+  update(i: number, v: number): void;
+  drain(): void;
+  /** untimed */
+  teardown(): void;
+}
+
+// ---------------------------------------------------------------------------
+// a. PUSH-REAL — actual GXT primitives
+// ---------------------------------------------------------------------------
+interface Row {
+  v: number;
+}
+
+class PushReal implements Strategy {
+  readonly name = 'pushReal';
+  readonly sink = new Float64Array(N);
+  items: Row[] = [];
+  destructors: Array<() => void> = [];
+
+  prepare(initial: Float64Array) {
+    const items: Row[] = new Array(N);
+    for (let i = 0; i < N; i++) items[i] = { v: initial[i] };
+    this.items = items;
+  }
+  setup(_initial: Float64Array) {
+    const { sink, items, destructors } = this;
+    for (let i = 0; i < N; i++) {
+      // Cell + cellsMap Map-per-item + defineProperty accessor (Krausest path)
+      const c = cellFor(items[i], 'v');
+      const idx = i;
+      // NB: braces — an expression-bodied arrow would RETURN the value and
+      // evaluateOpcode (ASYNC_COMPILE_TRANSFORMS) would mark the op async,
+      // silently rerouting syncDom to the async drain.
+      destructors.push(
+        opcodeFor(c, (val) => {
+          sink[idx] = val as number;
+        }),
+      );
+    }
+  }
+  update(i: number, v: number) {
+    // accessor setter → Cell.update → tagsToRevalidate.add + scheduleRevalidate
+    this.items[i].v = v;
+  }
+  drain() {
+    // real production drain (syncDomSync behind the exported dispatcher)
+    syncDom();
+  }
+  teardown() {
+    for (const d of this.destructors) d();
+    this.destructors.length = 0;
+    this.items.length = 0;
+    tagsToRevalidate.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// b. PUSH-MINIMAL — the model without GXT's bookkeeping
+// ---------------------------------------------------------------------------
+class MiniCell {
+  constructor(
+    public id: number,
+    public value: number,
+  ) {}
+}
+
+class PushMinimal implements Strategy {
+  readonly name = 'pushMinimal';
+  readonly sink = new Float64Array(N);
+  ops: Map<number, Array<(v: number) => void>> = new Map();
+  dirty: Set<MiniCell> = new Set();
+  cells: MiniCell[] = [];
+
+  prepare(_initial: Float64Array) {
+    // no separate user-data carrier needed: MiniCell IS the row holder,
+    // created in setup (it is part of this model's bookkeeping)
+  }
+  setup(initial: Float64Array) {
+    const { sink, ops, cells } = this;
+    for (let i = 0; i < N; i++) {
+      const c = new MiniCell(i, initial[i]);
+      cells.push(c);
+      const idx = i;
+      const op = (v: number) => {
+        sink[idx] = v;
+      };
+      ops.set(c.id, [op]);
+      op(c.value); // initial apply (parity with opcodeFor's evaluateOpcode)
+    }
+  }
+  update(i: number, v: number) {
+    const c = this.cells[i];
+    c.value = v;
+    this.dirty.add(c);
+  }
+  drain() {
+    // dirty → direct op arrays; no sort, no relatedTags, no dedup bookkeeping
+    for (const c of this.dirty) {
+      const list = this.ops.get(c.id);
+      if (list !== undefined) {
+        for (let k = 0; k < list.length; k++) list[k](c.value);
+      }
+    }
+    this.dirty.clear();
+  }
+  teardown() {
+    this.ops.clear();
+    this.dirty.clear();
+    this.cells.length = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+function makeInitial(): Float64Array {
+  const a = new Float64Array(N);
+  for (let i = 0; i < N; i++) a[i] = i + 0.25;
+  return a;
+}
+
+function dirtyIndices(d: number): number[] {
+  const step = N / d;
+  const idx: number[] = new Array(d);
+  for (let k = 0; k < d; k++) idx[k] = Math.floor(k * step);
+  return idx;
+}
+
+function buildStrategy(kind: 'pushReal' | 'pushMinimal'): Strategy {
+  if (kind === 'pushReal') return new PushReal();
+  return new PushMinimal();
+}
+
+const KINDS = ['pushReal', 'pushMinimal'] as const;
+
+describe('D1: real push pipeline vs minimal push model', () => {
+  test('both strategies produce identical sinks for the same update stream', () => {
+    const release = takeRenderingControl();
+    try {
+      const initial = makeInitial();
+      const strategies = KINDS.map((k) => {
+        const s = buildStrategy(k);
+        s.prepare(initial);
+        s.setup(initial);
+        return s;
+      });
+      expect(hasAsyncOpcodes()).toBe(false); // sink ops must stay sync
+      let initMismatches = 0;
+      for (const s of strategies) {
+        for (let i = 0; i < N; i++) {
+          if (s.sink[i] !== initial[i]) initMismatches++;
+        }
+      }
+      expect(initMismatches).toBe(0);
+      for (let round = 0; round < 5; round++) {
+        const idx = dirtyIndices([1, 10, 100, 1000, 10000][round]);
+        const vals = idx.map(() => ++valSeq);
+        for (const s of strategies) {
+          for (let k = 0; k < idx.length; k++) s.update(idx[k], vals[k]);
+          const drained = (s.drain() as unknown) ?? undefined;
+          expect(drained).toBeUndefined(); // pushReal: sync drain, no Promise
+        }
+        const [a, b] = strategies;
+        let mismatches = 0;
+        for (let i = 0; i < N; i++) {
+          if (b.sink[i] !== a.sink[i]) mismatches++;
+        }
+        expect(mismatches).toBe(0);
+      }
+      strategies.forEach((s) => s.teardown());
+    } finally {
+      release();
+    }
+  });
+
+  test.runIf(process.env.RUN_LIST_PERF)(
+    'bench',
+    { timeout: 300_000 },
+    () => {
+      const release = takeRenderingControl();
+      try {
+        const initial = makeInitial();
+        const results: any = {
+          meta: {
+            N,
+            runs: RUNS,
+            reps: REPS,
+            mixed: { rounds: MIXED_ROUNDS, d: MIXED_D },
+            env: 'node',
+            note:
+              'pushReal drains via exported syncDom() (real syncDomSync); ' +
+              'takeRenderingControl() suppresses microtask scheduling; ' +
+              'updateDrainMs is per-cycle, setup/mixed are totals; ' +
+              'ratio = pushReal / pushMinimal (lower is better for GXT)',
+          },
+          setupMs: {},
+          updateDrainMs: {},
+          updateDrainRatio: {},
+          mixedMs: {},
+        };
+
+        // ---- SETUP (median of RUNS, fresh build each sample) ---------------
+        for (const kind of KINDS) {
+          const samples: number[] = [];
+          for (let r = 0; r < RUNS; r++) {
+            const s = buildStrategy(kind);
+            s.prepare(initial); // untimed: raw user data
+            const t0 = performance.now();
+            s.setup(initial);
+            const t1 = performance.now();
+            samples.push(t1 - t0);
+            s.teardown();
+          }
+          results.setupMs[kind] = round6(median(samples));
+        }
+
+        // ---- long-lived instances for update/drain benches -----------------
+        const live: Record<string, Strategy> = {};
+        for (const kind of KINDS) {
+          const s = buildStrategy(kind);
+          s.prepare(initial);
+          s.setup(initial);
+          live[kind] = s;
+        }
+        expect(hasAsyncOpcodes()).toBe(false);
+
+        // ---- UPDATE+DRAIN per d (per-cycle ms, median of RUNS samples) -----
+        for (const d of D_VALUES) {
+          const idx = dirtyIndices(d);
+          const reps = REPS[d];
+          const key = `d=${d}`;
+          results.updateDrainMs[key] = {};
+          for (const kind of KINDS) {
+            const s = live[kind];
+            const samples: number[] = [];
+            for (let r = 0; r < RUNS; r++) {
+              const t0 = performance.now();
+              for (let rep = 0; rep < reps; rep++) {
+                for (let k = 0; k < d; k++) s.update(idx[k], ++valSeq);
+                s.drain();
+              }
+              const t1 = performance.now();
+              samples.push((t1 - t0) / reps);
+            }
+            results.updateDrainMs[key][kind] = round6(median(samples));
+            // sanity (untimed): one checked cycle
+            const checkVals = idx.map(() => ++valSeq);
+            for (let k = 0; k < d; k++) s.update(idx[k], checkVals[k]);
+            s.drain();
+            let mismatches = 0;
+            for (let k = 0; k < d; k++) {
+              if (s.sink[idx[k]] !== checkVals[k]) mismatches++;
+            }
+            expect(mismatches).toBe(0);
+          }
+          results.updateDrainRatio[key] = round6(
+            results.updateDrainMs[key].pushReal /
+              results.updateDrainMs[key].pushMinimal,
+          );
+        }
+        for (const kind of KINDS) live[kind].teardown();
+
+        // ---- MIXED workload: create 10k + 100 rounds of d=10 ----------------
+        const mixedIdx = dirtyIndices(MIXED_D);
+        for (const kind of KINDS) {
+          const samples: number[] = [];
+          for (let r = 0; r < RUNS; r++) {
+            const s = buildStrategy(kind);
+            s.prepare(initial); // untimed
+            const t0 = performance.now();
+            s.setup(initial);
+            for (let round = 0; round < MIXED_ROUNDS; round++) {
+              for (let k = 0; k < MIXED_D; k++) s.update(mixedIdx[k], ++valSeq);
+              s.drain();
+            }
+            const t1 = performance.now();
+            samples.push(t1 - t0);
+            s.teardown();
+          }
+          results.mixedMs[kind] = round6(median(samples));
+        }
+
+        // basic sanity on the numbers
+        for (const kind of KINDS) {
+          expect(Number.isFinite(results.setupMs[kind])).toBe(true);
+          expect(Number.isFinite(results.mixedMs[kind])).toBe(true);
+        }
+
+        // eslint-disable-next-line no-console
+        console.log('PERF_RESULTS_JSON ' + JSON.stringify(results));
+      } finally {
+        release();
+      }
+    },
+  );
+});

--- a/src/core/element-helper.runtime.test.ts
+++ b/src/core/element-helper.runtime.test.ts
@@ -5,7 +5,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { Window } from 'happy-dom';
 import { compile } from '../../plugins/compiler/compile';
-import { cell, Cell, tagsToRevalidate, opsForTag, relatedTags } from './reactive';
+import { cell, Cell, tagsToRevalidate, opsForTag } from './reactive';
 
 // Set up a DOM environment for runtime tests
 let window: Window;
@@ -17,7 +17,6 @@ beforeEach(() => {
   // Clear reactive state between tests
   tagsToRevalidate.clear();
   opsForTag.clear();
-  relatedTags.clear();
 });
 
 afterEach(() => {

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -29,8 +29,12 @@ export const opsForTag: Map<
 > = new Map();
 // REVISION replacement, we use a set of tags to revalidate
 export const tagsToRevalidate: Set<Cell> = new Set();
-// List of derived tags for each cell
-export const relatedTags: Map<number, Set<MergedCell>> = new Map();
+// D1: the per-cell subscriber set (formulas depending on a cell) used to live
+// in a global `Map<number, Set<MergedCell>>` keyed by cell id. It is now a
+// field on the Cell itself (`cell.relatedTags`) — one property load instead of
+// a Map hash per access on the drain/bind hot paths, and the set's lifetime is
+// tied to the cell (the global map retained entries for cells that were
+// otherwise collectable; numeric keys are never weak).
 
 // Adaptive pool for ops arrays with automatic growth/shrink
 const opsPool = new AdaptivePool<Array<tagOp>>(
@@ -73,10 +77,35 @@ export function getMergedCells() {
   return Array.from(DEBUG_MERGED_CELLS);
 }
 
+// Dev/test introspection: number of cells currently holding a non-empty
+// subscriber set. Replaces the old global `relatedTags.size` after the
+// subscriber set moved onto each cell (per-cell field). Dev-only — relies on
+// DEBUG_CELLS/DEBUG_MERGED_CELLS, which are only populated under IS_DEV_MODE.
+export function activeRelatedTagsCount(): number {
+  let n = 0;
+  DEBUG_CELLS.forEach((c) => {
+    if (c.relatedTags !== null && c.relatedTags.size > 0) n++;
+  });
+  DEBUG_MERGED_CELLS.forEach((c) => {
+    if (c.relatedTags !== null && c.relatedTags.size > 0) n++;
+  });
+  return n;
+}
+
 if (IS_DEV_MODE) {
   if (!import.meta.env.SSR) {
     window['getVM'] = () => ({
-      relatedTags,
+      // Rebuilt on demand from the per-cell fields (dev-only introspection;
+      // the global subscriber map no longer exists at runtime).
+      get relatedTags() {
+        const m = new Map<number, Set<MergedCell>>();
+        DEBUG_CELLS.forEach((cell) => {
+          if (cell.relatedTags !== null && cell.relatedTags.size > 0) {
+            m.set(cell.id, cell.relatedTags);
+          }
+        });
+        return m;
+      },
       tagsToRevalidate,
       opsForTag,
     });
@@ -160,6 +189,13 @@ export class Cell<T extends unknown = unknown> {
   // nested-object subscription. Purely metadata — never read by update().
   _relatedObj?: object;
   _relatedKey?: string | number | symbol;
+  // D1: subscriber formulas (MergedCells whose last execution read this cell).
+  // Lazily allocated on first subscription; CONSUMED (cleared in place, same
+  // Set object kept attached for reuse) by the drain / flushCellOpcodes when
+  // this cell dirties — re-executing formulas that still read the cell re-add
+  // themselves (dynamic dep pruning). Replaces the global
+  // `relatedTags: Map<number, Set<MergedCell>>`.
+  relatedTags: Set<MergedCell> | null = null;
   [Symbol.toPrimitive]() {
     return this.value;
   }
@@ -272,10 +308,10 @@ export function opsFor(cell: AnyCell) {
 }
 
 export function relatedTagsForCell(cell: Cell) {
-  let tags = relatedTags.get(cell.id);
-  if (tags === undefined) {
+  let tags = cell.relatedTags;
+  if (tags === null) {
     tags = new Set<MergedCell>();
-    relatedTags.set(cell.id, tags);
+    cell.relatedTags = tags;
   }
   return tags;
 }
@@ -323,15 +359,32 @@ export function flushCellOpcodes(cell: Cell | MergedCell): void {
         reportOpcodeError(e, cell);
       }
     }
-    const subTags = relatedTags.get((cell as Cell).id);
-    if (subTags === undefined) {
+    // Per-cell subscriber field (D1 drain diet) replaces the global
+    // relatedTags Map. Consume: snapshot subscribers, then clear IN PLACE —
+    // the Set object stays attached to the cell so re-executing formulas
+    // re-add into it without a fresh Set allocation (see Cell.relatedTags).
+    const subTags = cell.relatedTags;
+    if (subTags === null || subTags.size === 0) {
       return;
     }
-    relatedTags.delete((cell as Cell).id);
     const ordered = [...subTags];
     subTags.clear();
     if (ordered.length > 1) {
-      ordered.sort((a, b) => a.id - b.id);
+      // Skip-sort: subscribers iterate in insertion order, which commonly
+      // tracks formula creation (id) order already — O(n) check first.
+      let needsSort = false;
+      let prevId = ordered[0].id;
+      for (let i = 1; i < ordered.length; i++) {
+        const id = ordered[i].id;
+        if (id < prevId) {
+          needsSort = true;
+          break;
+        }
+        prevId = id;
+      }
+      if (needsSort) {
+        ordered.sort((a, b) => a.id - b.id);
+      }
     }
     for (const tag of ordered) {
       try {
@@ -381,9 +434,21 @@ export function applyCellUpdateSync<T>(cell: Cell<T>, value: T): void {
   }
 }
 
+// NB: keeps `Set.prototype.forEach` (NOT for..of) deliberately — the opt-in
+// reactive-collections patch instruments Set ITERATION APIs with consume(),
+// and this runs while the caller's tracker may still be installed (it is the
+// `$tracker` set itself in MergedCell.value's finally), so an instrumented
+// iteration would mutate the set being iterated. forEach is un-instrumented.
 function bindAllCellsToTag(cells: Set<Cell>, tag: MergedCell) {
   cells.forEach((cell) => {
-    const tags = relatedTagsForCell(cell);
+    // Inlined relatedTagsForCell: one field load (+ lazy Set allocation on
+    // first subscriber) + one idempotent Set.add. See the dep-stability note
+    // on MergedCell.value for why the unconditional add IS the fast path.
+    let tags = cell.relatedTags;
+    if (tags === null) {
+      tags = new Set<MergedCell>();
+      cell.relatedTags = tags;
+    }
     tags.add(tag);
     if (IS_DEV_MODE && (globalThis as any).__gxtDebugSync && tag._debugName?.includes('if-condition')) {
       console.log('[BIND] cell.id=' + cell.id + ' → formula=' + tag._debugName + ' (id=' + tag.id + ')');
@@ -418,6 +483,12 @@ export class MergedCell {
   }
   _debugName?: string | undefined;
   relatedCells: Set<Cell> | null = null;
+  // Subscriber-set field mirrored from Cell for shape compatibility with the
+  // `Cell | MergedCell` consumers (flushCellOpcodes, executeTag callers).
+  // Formulas never subscribe to OTHER formulas (trackers only ever collect
+  // raw Cells — a nested formula read forwards the inner cells instead), so
+  // this stays null in practice.
+  relatedTags: Set<MergedCell> | null = null;
   [isTag] = true;
   constructor(fn: Fn | Function, debugName?: string) {
     this.fn = fn;
@@ -431,12 +502,11 @@ export class MergedCell {
     opsForTag.delete(this.id);
     if (this.relatedCells !== null) {
       this.relatedCells.forEach((cell) => {
-        const related = relatedTags.get(cell.id);
-        if (related !== undefined) {
+        const related = cell.relatedTags;
+        if (related !== null) {
           related.delete(this);
-          if (related.size === 0) {
-            relatedTags.delete(cell.id);
-          }
+          // An emptied set stays attached to the cell (owned by it, dies with
+          // it) — no global map entry to reclaim anymore.
         }
       });
       this.relatedCells.clear();
@@ -471,6 +541,21 @@ export class MergedCell {
     // to each tracked cell's subscriber set idempotently (this path never
     // unbound dropped deps before either — a re-read with stable deps re-adds
     // the same cells).
+    //
+    // D1 dep-stability analysis (why there is NO "skip re-subscription when
+    // deps are unchanged" fast path): the drain CONSUMES (clears) the dirty
+    // cell's subscriber set before re-executing its formulas, so this formula
+    // MUST re-add itself to every dep that was consumed — membership is the
+    // only record of subscription. For NON-consumed deps the re-add is a
+    // no-op `Set.add`, and verifying "still subscribed" costs exactly the
+    // same hash lookup (`Set.has`) as the idempotent `Set.add` it would
+    // skip; distinguishing consumed from non-consumed deps with a per-cell
+    // stamp is unsound for NEW deps without a full old-vs-new set comparison
+    // (n× `Set.has`), which costs more than the n× `Set.add` it replaces.
+    // Invariant relied on instead: `cell.relatedTags ∋ formula` iff the
+    // formula's most recent execution read the cell AND the cell has not
+    // been consumed since; every consume site re-executes the affected
+    // formulas under `_isRendering` so they re-establish membership here.
     let $tracker = this.relatedCells;
     if ($tracker === null) {
       $tracker = tracker();

--- a/src/core/runtime.regression.test.ts
+++ b/src/core/runtime.regression.test.ts
@@ -6,7 +6,6 @@ import {
   executeTagSync,
   tagsToRevalidate,
   opsForTag,
-  relatedTags,
   setTracker,
   setIsRendering,
 } from './reactive';
@@ -16,7 +15,6 @@ import { syncDom } from './runtime';
 beforeEach(() => {
   tagsToRevalidate.clear();
   opsForTag.clear();
-  relatedTags.clear();
   setTracker(null);
   setIsRendering(false);
 });

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1,10 +1,10 @@
 import {
   setIsRendering,
+  type Cell,
   type MergedCell,
   executeTag,
   hasAsyncOpcodes,
   tagsToRevalidate,
-  relatedTags,
 } from '@/core/reactive';
 import { isRehydrationScheduled } from './ssr/rehydration-state';
 import { HOST_HOOKS } from '@/core/host-hooks';
@@ -13,25 +13,6 @@ let revalidateScheduled = false;
 let hasExternalUpdate = false;
 type voidFn = () => void;
 let resolveRender: undefined | voidFn = undefined;
-let executionEpoch = 0;
-let executedTagEpoch: WeakMap<MergedCell, number> = new WeakMap();
-
-function nextExecutionEpoch() {
-  executionEpoch++;
-  if (executionEpoch === Number.MAX_SAFE_INTEGER) {
-    executionEpoch = 1;
-    executedTagEpoch = new WeakMap();
-  }
-  return executionEpoch;
-}
-
-function shouldExecuteSharedTag(tag: MergedCell, epoch: number) {
-  if (executedTagEpoch.get(tag) === epoch) {
-    return false;
-  }
-  executedTagEpoch.set(tag, epoch);
-  return true;
-}
 
 export function setResolveRender(value: () => void) {
   resolveRender = value;
@@ -92,11 +73,32 @@ export function scheduleRevalidate() {
 }
 
 /**
- * Sort shared tags by creation order for deterministic evaluation.
+ * Establish creation (id) order for the shared-tag fan-out.
+ *
+ * D1: skip-sort fast path — the buffer is filled by walking dirty cells in
+ * ascending id order, and each cell's subscriber set iterates in insertion
+ * order (subscription order tracks formula creation order), so the combined
+ * buffer is very commonly already sorted. An O(n) sortedness scan is far
+ * cheaper than the O(n log n) comparator-driven sort it replaces.
+ *
+ * POST-CONDITION (relied on by the duplicate-skip in the drains): the buffer
+ * is non-decreasing by id, so duplicate entries (the same formula reached via
+ * several dirty dep cells) are ADJACENT. Ids are unique per tag (shared
+ * monotonic `tagId++`), so `a.id === b.id` implies `a === b`.
  */
 function sortSharedTags(sharedTags: MergedCell[]) {
-  if (sharedTags.length > 1) {
-    sharedTags.sort((a, b) => a.id - b.id);
+  const len = sharedTags.length;
+  if (len < 2) {
+    return;
+  }
+  let prevId = sharedTags[0].id;
+  for (let i = 1; i < len; i++) {
+    const id = sharedTags[i].id;
+    if (id < prevId) {
+      sharedTags.sort((a, b) => a.id - b.id);
+      return;
+    }
+    prevId = id;
   }
 }
 
@@ -109,36 +111,75 @@ function sortSharedTags(sharedTags: MergedCell[]) {
 // the buffer doesn't retain MergedCell references between ticks.
 const _sharedTagsScratch: MergedCell[] = [];
 
+// D1: scratch buffer for the primary dirty-cell snapshot, reused across
+// flushes instead of `Array.from(tagsToRevalidate)` allocating per drain.
+// Same non-reentrancy argument as `_sharedTagsScratch` above; only used by
+// the SYNC drain (the async drain keeps fresh allocations because it yields
+// between executions).
+const _primaryCellsScratch: Cell[] = [];
+
+/**
+ * Snapshot the dirty-cell set into the given buffer in creation (id) order.
+ *
+ * Parent-first rationale: parent opcodes must run before child opcodes. When
+ * two cells are dirtied in the same batch (e.g., outer each source + inner
+ * each source), Set iteration follows insertion order, which can cause a
+ * child effect (e.g., a nested {{#each}}'s syncList) to create items just
+ * before its parent tears it down. Id-ascending order gives parent-first
+ * because parent cells are allocated first during render.
+ *
+ * D1: cells are commonly dirtied in creation order, so the snapshot is
+ * usually already sorted — detect that with an O(n) scan during the copy and
+ * only fall back to the O(n log n) sort when out of order.
+ */
+function snapshotPrimaryCells(buffer: Cell[]): Cell[] {
+  buffer.length = 0;
+  let sorted = true;
+  let prevId = -1;
+  for (const cell of tagsToRevalidate) {
+    const id = cell.id;
+    if (id < prevId) {
+      sorted = false;
+    }
+    prevId = id;
+    buffer.push(cell);
+  }
+  if (!sorted) {
+    buffer.sort((a, b) => a.id - b.id);
+  }
+  return buffer;
+}
+
 /**
  * Fully synchronous DOM sync — no Promise allocation, no async/await overhead.
  */
 function syncDomSync() {
   let sharedTags: MergedCell[] | null = null;
   setIsRendering(true);
-  // Process primary cells in creation (id) order so that parent opcodes
-  // run before child opcodes. Without this, when two cells are dirtied
-  // in the same batch (e.g., outer each source + inner each source),
-  // iteration order follows insertion order, which can cause a child
-  // effect (e.g., a nested {{#each}}'s syncList) to create items just
-  // before its parent tears it down. Sorting by tag.id gives parent-first
-  // ordering because parent cells are allocated first during render.
+  // Process primary cells in creation (id) order (parent-first — see
+  // snapshotPrimaryCells). Size <= 1 keeps the live-set iteration: a single
+  // dirty cell needs no ordering, and live iteration preserves the existing
+  // semantics where a cell dirtied DURING that execution is still visited.
   const primaryCells =
     tagsToRevalidate.size > 1
-      ? Array.from(tagsToRevalidate).sort((a, b) => a.id - b.id)
+      ? snapshotPrimaryCells(_primaryCellsScratch)
       : tagsToRevalidate;
   for (const cell of primaryCells) {
     executeTag(cell, false);
-    const subTags = relatedTags.get(cell.id);
-    if (subTags !== undefined) {
+    const subTags = cell.relatedTags;
+    if (subTags !== null && subTags.size > 0) {
       if (IS_DEV_MODE && (globalThis as any).__gxtDebugSync) {
         const names: string[] = [];
         subTags.forEach(t => names.push(t._debugName || '?'));
-        console.log('[SYNC] cell.id=' + cell.id + ' DELETE relatedTags, had: [' + names.join(',') + ']');
+        console.log('[SYNC] cell.id=' + cell.id + ' CONSUME relatedTags, had: [' + names.join(',') + ']');
       }
-      relatedTags.delete(cell.id);
       // P8: reuse the module-level scratch buffer instead of allocating.
       if (sharedTags === null) { sharedTags = _sharedTagsScratch; sharedTags.length = 0; }
       for (const tag of subTags) sharedTags.push(tag);
+      // Consume the subscriber set: formulas that still depend on this cell
+      // re-add themselves when they re-execute below (dynamic dep pruning).
+      // The Set OBJECT stays attached to the cell for reuse (D1 — no fresh
+      // Set allocation per consumed cell per drain).
       subTags.clear();
     } else if (IS_DEV_MODE && (globalThis as any).__gxtDebugSync) {
       console.log('[SYNC] cell.id=' + cell.id + ' no relatedTags');
@@ -146,18 +187,26 @@ function syncDomSync() {
   }
   if (sharedTags !== null) {
     sortSharedTags(sharedTags);
-    const epoch = nextExecutionEpoch();
+    // D1: duplicate-skip replaces the epoch WeakMap. sortSharedTags
+    // guarantees non-decreasing id order, so duplicates of the same formula
+    // (collected via several dirty dep cells) are adjacent — one pointer
+    // compare dedupes with zero per-tag state and no wraparound concerns.
+    let prevTag: MergedCell | null = null;
     for (const tag of sharedTags) {
-      if (shouldExecuteSharedTag(tag, epoch)) {
-        if (IS_DEV_MODE && (globalThis as any).__gxtDebugSync) {
-          console.log('[SYNC] executeTag formula.id=' + tag.id + ' name=' + tag._debugName);
-        }
-        executeTag(tag, false);
+      if (tag === prevTag) {
+        continue;
       }
+      prevTag = tag;
+      if (IS_DEV_MODE && (globalThis as any).__gxtDebugSync) {
+        console.log('[SYNC] executeTag formula.id=' + tag.id + ' name=' + tag._debugName);
+      }
+      executeTag(tag, false);
     }
     // Release MergedCell refs so the scratch doesn't retain them across ticks.
     sharedTags.length = 0;
   }
+  // Release Cell refs from the primary snapshot for the same reason.
+  _primaryCellsScratch.length = 0;
   tagsToRevalidate.clear();
   setIsRendering(false);
 }
@@ -169,28 +218,33 @@ function syncDomSync() {
 async function syncDomAsync() {
   let sharedTags: MergedCell[] | null = null;
   setIsRendering(true);
-  // See syncDomSync for rationale: parent-first ordering by tag.id.
+  // See snapshotPrimaryCells for rationale: parent-first ordering by tag.id.
+  // Fresh array here (not the module scratch): the async drain yields between
+  // executions, so a shared buffer could be observed mid-flush.
   const primaryCells =
     tagsToRevalidate.size > 1
-      ? Array.from(tagsToRevalidate).sort((a, b) => a.id - b.id)
+      ? snapshotPrimaryCells([])
       : tagsToRevalidate;
   for (const cell of primaryCells) {
     await executeTag(cell, true);
-    const subTags = relatedTags.get(cell.id);
-    if (subTags !== undefined) {
-      relatedTags.delete(cell.id);
+    const subTags = cell.relatedTags;
+    if (subTags !== null && subTags.size > 0) {
       if (sharedTags === null) sharedTags = [];
       for (const tag of subTags) sharedTags.push(tag);
+      // Consume in place — see syncDomSync.
       subTags.clear();
     }
   }
   if (sharedTags !== null) {
     sortSharedTags(sharedTags);
-    const epoch = nextExecutionEpoch();
+    // Duplicate-skip: see syncDomSync (sorted order makes duplicates adjacent).
+    let prevTag: MergedCell | null = null;
     for (const tag of sharedTags) {
-      if (shouldExecuteSharedTag(tag, epoch)) {
-        await executeTag(tag, true);
+      if (tag === prevTag) {
+        continue;
       }
+      prevTag = tag;
+      await executeTag(tag, true);
     }
   }
   tagsToRevalidate.clear();

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -14,7 +14,6 @@ import {
   formula,
   tagsToRevalidate,
   opsForTag,
-  relatedTags,
   setTracker,
   setIsRendering,
 } from './reactive';
@@ -28,7 +27,6 @@ const settle = () => new Promise<void>((r) => setTimeout(r, 0));
 beforeEach(() => {
   tagsToRevalidate.clear();
   opsForTag.clear();
-  relatedTags.clear();
   setTracker(null);
   setIsRendering(false);
 });

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -23,7 +23,7 @@
  *
  * Lifecycle: `selector.destroy()` removes the source subscription (destroying
  * the internal formula when the source was a function), releases per-key
- * bookkeeping (`opsForTag` arrays, `relatedTags` entries) and clears the map.
+ * bookkeeping (`opsForTag` arrays, per-cell `relatedTags` sets) and clears the map.
  * Pass an `owner` to auto-destroy via `registerDestructor` when the owner
  * (e.g. a component) is destroyed. After destroy, reads return a plain
  * comparison against the last-known key and no longer materialize cells.
@@ -44,7 +44,6 @@ import {
   formula,
   applyCellUpdateSync,
   opsForTag,
-  relatedTags,
   releaseOpArray,
 } from '@/core/reactive';
 import { opcodeFor } from '@/core/vm';
@@ -64,8 +63,8 @@ export interface KeyedSelector<K> {
 // cell's relatedTags set. Ops-array emptiness — not absence — is the liveness
 // signal on the ops side (pooled arrays may linger empty).
 function isKeyCellUnused(keyCell: Cell<boolean>): boolean {
-  const subs = relatedTags.get(keyCell.id);
-  if (subs !== undefined && subs.size > 0) {
+  const subs = keyCell.relatedTags;
+  if (subs !== null && subs.size > 0) {
     return false;
   }
   const ops = opsForTag.get(keyCell.id);
@@ -78,7 +77,8 @@ function releaseKeyCell(keyCell: Cell<boolean>): void {
     opsForTag.delete(keyCell.id);
     releaseOpArray(ops);
   }
-  relatedTags.delete(keyCell.id);
+  // Drop the subscriber set with the cell (it lives ON the cell now).
+  keyCell.relatedTags = null;
 }
 
 // Don't sweep tiny maps — the walk costs more than the memory it frees.

--- a/src/core/static-block-fastpath.test.ts
+++ b/src/core/static-block-fastpath.test.ts
@@ -27,7 +27,7 @@ import {
   setupRuntimeTemplateGlobals,
   type HarnessItem,
 } from './__test-utils__/list-harness';
-import { cellFor, relatedTags } from './reactive';
+import { cellFor } from './reactive';
 import { template, compileTemplate } from '../../plugins/runtime-compiler';
 
 const LIST_TEMPLATE = `
@@ -200,26 +200,26 @@ describe('static-block fast path ({{#each}} cloneNode rows)', () => {
     (root as any)._items = items;
     await settle();
     // text binding formula is subscribed to the per-item label cell
-    expect(relatedTags.get(labelCell.id)?.size ?? 0).toBeGreaterThan(0);
-    const selectedSubsRendered = relatedTags.get(selectedCell.id)?.size ?? 0;
+    expect(labelCell.relatedTags?.size ?? 0).toBeGreaterThan(0);
+    const selectedSubsRendered = selectedCell.relatedTags?.size ?? 0;
     expect(selectedSubsRendered).toBeGreaterThan(0);
 
     (root as any)._items = [];
     await settle();
-    expect(relatedTags.get(labelCell.id)?.size ?? 0).toBe(0);
-    const selectedSubsCleared = relatedTags.get(selectedCell.id)?.size ?? 0;
+    expect(labelCell.relatedTags?.size ?? 0).toBe(0);
+    const selectedSubsCleared = selectedCell.relatedTags?.size ?? 0;
     expect(selectedSubsCleared).toBe(0);
 
     // repeated create/clear cycles stay bounded (no cumulative growth)
     for (let cycle = 0; cycle < 3; cycle++) {
       (root as any)._items = buildItems(5);
       await settle();
-      expect(relatedTags.get(selectedCell.id)?.size ?? 0).toBe(
+      expect(selectedCell.relatedTags?.size ?? 0).toBe(
         selectedSubsRendered,
       );
       (root as any)._items = [];
       await settle();
-      expect(relatedTags.get(selectedCell.id)?.size ?? 0).toBe(0);
+      expect(selectedCell.relatedTags?.size ?? 0).toBe(0);
     }
   });
 

--- a/src/core/vm.test.ts
+++ b/src/core/vm.test.ts
@@ -18,7 +18,6 @@ import {
   formula,
   tagsToRevalidate,
   opsForTag,
-  relatedTags,
   setTracker,
   getTracker,
   setIsRendering,
@@ -33,7 +32,6 @@ beforeEach(() => {
   // Clear reactive state between tests
   tagsToRevalidate.clear();
   opsForTag.clear();
-  relatedTags.clear();
   setTracker(null);
   setIsRendering(false);
 });


### PR DESCRIPTION
> **Draft — lands last.** All base PRs except #226 have merged; this branch now sits directly on master as a single refactor commit (the duplicate `cached()` fix dropped automatically when #224 merged). Rebase over #226 before merging — both touch `reactive.ts` internals.

## What

Code-health refactor of the drain/subscription internals:

- the `executedTagEpoch` WeakMap is **deleted** — the shared-tag buffer is guaranteed non-decreasing by id, so duplicates are adjacent and dedupe with a `tag === prevTag` compare (no per-tag state, no wraparound case);
- the global `relatedTags: Map<id, Set>` becomes a **per-cell field** (one property read vs Map hashing on every subscribe/consume/flush access; consume clears the Set in place — zero Set allocations on the re-subscribe cycle);
- per-drain `Array.from(dirty).sort()` → reusable scratch + O(n) sortedness scan, sorting only when actually out of order.

## Honest performance framing

Clean same-machine A/B (manager-verified; the original exploration's −50-83% claims came from a contaminated baseline and are retracted in the commit message): setup −17%; per-drain −18% (d=10), −12% (d=100), −8% (d=1000), flat at d=1 and d=10000; harness-level (ms-scale) metrics flat. **This is a simplification with a modest micro-level win**, not a perf headline — the value is fewer allocations, fewer global structures, and a simpler drain.

## Compatibility

The internal `relatedTags` module export is removed (all in-repo consumers migrated; it was never in the public index — out-of-tree deep importers of `@/core/reactive` would break).

## Testing

Full suite 3,860 passed (incl. the 3 `cached()` regression tests from #224); `tsc --noEmit` clean; drain micro-bench included (`RUN_LIST_PERF`-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
