### PR TITLE
fix(reactive): keep tracker active in flushCellOpcodes for host integrations (→ 0.0.68)

### DIFF
--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -304,9 +304,23 @@ export function flushCellOpcodes(cell: Cell | MergedCell): void {
   //      going dead after a thunk-triggered flush).
   //   2. every leaf cell read by the executed opcodes would be tracked into
   //      the CALLER's frame, attributing foreign deps to it.
-  // Suspend the tracker for the duration of the flush; restore after.
+  // Suspend the tracker for the duration of the flush; restore after — EXCEPT
+  // when a host integration (Ember) is installed. A host drives
+  // flushCellOpcodes from its fine-grained double-read RE-TRACK path, which
+  // REQUIRES the tracker active so the re-evaluated getter re-entangles its
+  // deps into the live frame; suspending it drops the re-track and the host's
+  // binding loses an upstream invalidation (Ember's tracked-args double-read
+  // count regressed 3→2). The suspend exists for frame-mode slot probes, and
+  // frame mode bails for hosts via the same sentinel — so the two needs never
+  // overlap. Cross-instance sentinel (not an import — reactive.ts is a leaf).
+  const _g = globalThis as Record<string, unknown>;
+  const _hostInstalled =
+    _g.__gxtHostHooksInstalled === true ||
+    typeof _g.__gxtRegisterObjectValueOwner === 'function' ||
+    _g.__gxtCurrentTemplateThis !== undefined ||
+    typeof _g.__gxtRebindEachItem === 'function';
   const prevTracker = getTracker();
-  if (prevTracker !== null) setTracker(null);
+  if (!_hostInstalled && prevTracker !== null) setTracker(null);
   try {
     // Only execute the cell's own opcodes when it actually has some — for
     // cells that exist purely as subscription targets (selector key cells,


### PR DESCRIPTION
## Summary

Third and final 0.0.66 integration regression (after #228's two). The #226 tracker-suspend in `flushCellOpcodes` broke the Ember host's fine-grained **double-read**.

`flushCellOpcodes` suspends the active tracker so a frame-mode slot probe's flush doesn't attribute foreign deps / leave a source formula unsubscribed. But an Ember host drives `flushCellOpcodes` from its RE-TRACK path, which needs the tracker **active** so the re-evaluated getter re-entangles its deps into the live frame. Suspending it drops the re-track and the binding loses an upstream invalidation — Ember's tracked-args double-read getter-eval count regressed **3 → 2** (caught by emberjs/ember.js `tracked-test :: "downstream property changes do not invalidate upstream getters"`; the rendered output stays correct, only the eval count drops).

**Fix:** gate the suspend on the cross-instance host sentinel (`__gxtHostHooksInstalled` + legacy slots). Standalone keeps the suspend (frame-mode safety); hosts keep the tracker active — the pre-#226 behavior they were validated against. The two needs never overlap: frame mode bails for hosts via the same sentinel.

## Bisect

- `eef9aad` (#222 merge) / `e92c4d3` (#221): Args Proxy GREEN (count 3) — pre-#226.
- `5dfb725` (0.0.67, #226 present): Args Proxy RED (count 2).
- This fix: GREEN (count 3).

## Validation

- Full Ember GXT dev gate: **9460 / 9443 / 17 skip / 0 fail** (vs 1 fail on 0.0.67).
- No reactivity regressions: dynamic-component 67/0, if/Helpers 1391/0, each 575/0.
- gxt frame-mode + reactive suites 34/34; full functional suite 3905 pass.

## Release

Cut **0.0.68**; ember.js bumps its six exact pins 0.0.67 → 0.0.68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)