### PR TITLE
feat: Redux DevTools extension integration (time-travel debugging)

### DIFF
--- a/docs/redux-devtools.md
+++ b/docs/redux-devtools.md
@@ -1,0 +1,115 @@
+# Redux DevTools integration
+
+gxt can stream its reactive state to the
+[Redux DevTools browser extension](https://github.com/reduxjs/redux-devtools)
+so you can inspect every live cell on a timeline and **time-travel** through past
+states while developing.
+
+It is **opt-in, development-only, and browser-only**. In production / library
+builds the whole feature tree-shakes away (it is gated on `IS_DEV_MODE`, which is
+inlined to `false`), so it has zero cost for shipped apps.
+
+## Enabling
+
+Install the Redux DevTools extension in your browser, then opt in once at app
+startup:
+
+```ts
+import { enableReduxDevtools } from '@lifeart/gxt';
+
+if (IS_DEV_MODE) {
+  enableReduxDevtools();
+}
+```
+
+`enableReduxDevtools(config?)` returns a disabler:
+
+```ts
+const disable = enableReduxDevtools({ name: 'My App', maxAge: 100 });
+// ...later
+disable();
+```
+
+It is safe to call unconditionally — when the extension is not installed, the
+code runs in SSR/Node, or the build is production, it simply returns a no-op
+disabler and installs nothing.
+
+The `config` argument accepts the standard
+[DevTools options](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md)
+(`name`, `maxAge`, `features`, `serialize`, …). gxt provides sensible defaults
+(`name: 'GXT Reactive State'`, `maxAge: 50`, `jump`/`skip` enabled).
+
+## What state is exposed
+
+State is read from the existing dev-only `DEBUG_CELLS` registry — the set of all
+live **data cells** (`cell(...)`, `cellFor(...)`, `@tracked` fields). It does
+**not** introduce a parallel registry. Each cell is keyed by a stable, unique
+`"<debugName>#<id>"` string (derived formulas / `MergedCell`s are not part of the
+serialized state; they are recomputed from their dependencies).
+
+Every cell change is coalesced per microtask (matching gxt's own
+`scheduleRevalidate` batching) and sent to the monitor as one `cells:changed`
+action carrying a full snapshot, so a 1000-row update is a single timeline entry.
+
+## Time-travel
+
+When you JUMP / ROLLBACK / RESET in the monitor, the integration restores each
+cell's `_value` and re-renders the bound DOM **synchronously**, via
+`applyCellUpdateSync`. That path bypasses `Cell.update`, so restoring does **not**
+re-dispatch back to the monitor (no feedback loop). An `isDevToolsRestoring()`
+guard provides defence-in-depth against a subscriber that writes back during
+restore.
+
+Handled monitor messages: `JUMP_TO_STATE`, `JUMP_TO_ACTION`, `ROLLBACK`, `RESET`,
+`COMMIT`, `IMPORT_STATE`.
+
+## Design / cost model
+
+- **Hot path.** The only reactive-core touchpoint is a single guarded call in
+  `Cell.update()` / `applyDeferredCellUpdate()`:
+
+  ```ts
+  if (IS_DEV_MODE && _devtoolsCellNotifier !== null && changed) {
+    _devtoolsCellNotifier(this);
+  }
+  ```
+
+  - Lib / production: `IS_DEV_MODE` → `false`, the branch (and every reference
+    that would pull the redux-devtools module into the bundle) is removed.
+  - Dev, DevTools off: a single predictable `!== null` check, no allocation.
+  - Dev, DevTools on: forwards the changed cell to the coalescing sender.
+
+- **No new registries.** Enumeration reuses `DEBUG_CELLS`.
+
+- **Tree-shakable.** Verified: a consumer bundle of `import { cell } from
+  '@lifeart/gxt'` contains none of the integration (no `__REDUX_DEVTOOLS_EXTENSION__`,
+  `supportChromeExtension`, `cells:changed`, …).
+
+## Lower-level / Freezer-style API
+
+For parity with classic redux-store bindings the `src/core/redux-devtools`
+module also exports a faithful port of the freezer-redux-devtools enhancer:
+`supportChromeExtension(state, config?)`, `FreezerMiddleware(state)`, and a
+`createCellState()` helper that returns a `FreezerState` backed by gxt cells.
+These are not re-exported from the package's public entry — import them from the
+module directly when working inside the framework. Most apps should prefer
+`enableReduxDevtools()`; the enhancer API is an escape hatch.
+
+```ts
+import {
+  supportChromeExtension,
+  createCellState,
+} from '@/core/redux-devtools';
+
+const store = supportChromeExtension(createCellState());
+```
+
+## Caveats
+
+- `DEBUG_CELLS` accumulates every cell created during a dev session (existing gxt
+  behaviour — data cells have no `destroy()` hook). The state tree therefore
+  grows over a long session and may include cells whose owning components were
+  torn down. This is a dev-only memory characteristic, not a correctness issue.
+- Only primitive-ish cell values serialize cleanly. Cells holding complex
+  objects/functions are subject to the extension's own serialization limits;
+  use the `serialize` config option to customise.

--- a/docs/redux-devtools.md
+++ b/docs/redux-devtools.md
@@ -39,6 +39,23 @@ The `config` argument accepts the standard
 (`name`, `maxAge`, `features`, `serialize`, …). gxt provides sensible defaults
 (`name: 'GXT Reactive State'`, `maxAge: 50`, `jump`/`skip` enabled).
 
+It also accepts a few **gxt-only** knobs (stripped before reaching the
+extension) that control snapshot size:
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `maxArrayItems` | `50` | Arrays longer than this are replaced in the snapshot with a compact `$summary` marker instead of dumping every element. |
+| `maxValueBytes` | `8192` | Rough byte budget for one cell value. Strings / objects / nested arrays whose estimated size exceeds it are summarized. |
+| `maxValueDepth` | `4` | Nesting depth past which a value is treated as too big. |
+| `cellsDenylist` | `[]` | Path globs/prefixes whose cells are **excluded entirely** from the snapshot *and* the action timeline (high-frequency / noisy cells). |
+
+```ts
+enableReduxDevtools({
+  maxArrayItems: 50,
+  cellsDenylist: ['*.animationFrame', 'Benchmark#*._items'],
+});
+```
+
 ## What state is exposed
 
 The state **mirrors the gxt component tree** — human-readable and diff-friendly,
@@ -120,6 +137,103 @@ Handled monitor messages: `JUMP_TO_STATE`, `JUMP_TO_ACTION`, `ROLLBACK`, `RESET`
 `COMMIT`, `IMPORT_STATE`. `COMMIT` resets the baseline to the current state;
 `RESET` restores the committed (initial) snapshot.
 
+## Big-value summaries (keeping the inspector light)
+
+A large cell value — e.g. a list's `_items: Array(1000)` — would otherwise dump
+every element into the state inspector and produce a huge diff on every change.
+Instead, any value over the configured caps is replaced **in the snapshot only**
+with a compact summary marker:
+
+```jsonc
+// _items: Array(1000)  ->
+{ "$summary": "Array(1000)", "$len": 1000, "$preview": [0, 1, 2, 3, 4] }
+// a big object ->
+{ "$summary": "Foo(120 keys)", "$keys": 120, "$preview": { /* first few */ } }
+// a big string ->
+{ "$summary": "String(40000)", "$len": 40000, "$preview": "first 64 chars…" }
+```
+
+The preview reuses gxt's existing `inspect()` formatter for non-primitive items,
+so it stays small and bounded. Summarization happens **only at snapshot time**
+(when DevTools is connected) — there is zero cost on the `Cell.update` hot path.
+
+**Restore trade-off (important).** A summarized value is *not* the real value, so
+it is **not restorable**. Time-travel (`restoreState`) **skips** any cell whose
+snapshot value is a `$summary` marker — it never writes the marker back into the
+cell, which would corrupt it. The practical effect:
+
+- Cells **under** the caps keep their real value and are **fully time-travel
+  restorable** (including small arrays/objects).
+- A summarized large collection becomes **inspect-only**: you can see its
+  shape/preview on the timeline, but a JUMP leaves its live runtime value
+  untouched (it keeps whatever the app currently holds, never a `{$summary}`
+  object). To make a specific big collection restorable again, raise
+  `maxArrayItems` / `maxValueBytes`, or keep it small.
+
+## Excluding noisy cells (`cellsDenylist`)
+
+In the spirit of the extension's `actionsDenylist`, `cellsDenylist` is a list of
+path globs/prefixes whose cells are excluded from the snapshot **and** the action
+timeline entirely. This is for high-frequency / noisy cells (e.g. an
+`animationFrame` counter that ticks every frame) that would otherwise flood the
+monitor.
+
+- `*` matches any run of characters; a prefix matches any deeper path
+  (`Benchmark#4` denylists every cell under it).
+- A cell's path is `<Class>#<id>.<prop>` (e.g. `Benchmark#7._items`); `$globals`
+  cells match on their `<debugName>#<id>` key.
+- A batch consisting *only* of denylisted cells emits **no** timeline entry at
+  all — that is the de-noising point.
+- Denylisted cells are absent from the snapshot, so (like summaries) they are
+  not restored by time-travel. Remove the pattern to bring a cell back.
+
+## Live edit + DOM highlight (Dispatcher actions)
+
+The DevTools "Dispatcher" panel lets you send custom actions to the page. Two
+are handled:
+
+### `SET` — write a cell live
+
+```jsonc
+{ "type": "SET", "path": "Benchmark#4._selected", "value": "7" }
+```
+
+Resolves `path` against the live component tree the same way time-travel does
+(matching `<Class>#<id>` nodes), then writes the cell via `applyCellUpdateSync`
+under the restore guard — so the app re-renders immediately and the write does
+**not** echo back as a new timeline action. `value` arrives as a string and is
+`JSON.parse`d (falling back to the raw string if it isn't valid JSON). A path
+that doesn't resolve, or an obvious type mismatch, is surfaced via a dev
+`console.warn` **and** the monitor's error channel — never silently swallowed.
+
+### `HIGHLIGHT` — flash a component's DOM
+
+```jsonc
+{ "type": "HIGHLIGHT", "path": "Row#5" }
+```
+
+Resolves the component and draws a temporary overlay (outline + subtle fill,
+`scrollIntoView` if offscreen) over its bounds — `getBounds(component)`, the same
+bridge gxt's Ember-inspector uses — that auto-removes after ~1s. A single overlay
+element is reused and is cleaned up on `disableReduxDevtools()`.
+
+### Auto-flash on change
+
+When a `SET` or a time-travel `JUMP` actually changes one or more components,
+their DOM is briefly flashed with the same overlay so you can SEE what moved in
+the page. It is debounced via the single overlay element and **skipped** when a
+change touches more than a handful of components (so a 1000-row batch never
+strobes the screen). Ordinary app-driven updates are **not** flashed.
+
+> **Honest limitation.** The Redux DevTools protocol does **not** notify the page
+> when you click a node in the state-tree inspector, so true
+> "select-in-tree → highlight" is impossible. gxt delivers the explicit
+> `HIGHLIGHT` dispatch action and auto-flash-on-change instead — there is no
+> click-to-highlight.
+
+All overlay/DOM code is browser- and dev-only (`typeof document !== 'undefined'`
++ `IS_DEV_MODE`) and tree-shakes out of the library build.
+
 ## Design / cost model
 
 - **Hot path.** The only reactive-core touchpoint is a single guarded call in
@@ -186,10 +300,12 @@ const store = supportChromeExtension(createCellState());
   captured for a component that was later destroyed *and whose id was reused by a
   different component* could in principle restore onto the wrong node. Restores
   onto stable (still-alive) components — the common time-travel case — are exact.
-- **List growth = diff noise.** An array-valued cell (e.g. `_items`) is included
-  in full in every snapshot, so growing a 1000-row list shows a large diff. The
-  trade is deliberate: the full value is the most useful thing to inspect and
-  restore.
+- **Big collections are inspect-only.** An array-valued cell over `maxArrayItems`
+  (or any value over `maxValueBytes`) is summarized in the snapshot
+  (`{ $summary: "Array(1000)", … }`) to keep the inspector light. Such a cell is
+  no longer time-travel-restorable (restore skips the marker; the live value is
+  kept intact, never corrupted). Raise the caps to make a specific collection
+  restorable again. Cells under the caps keep their real value and round-trip.
 - **Derived values are omitted.** `MergedCell` / `formula` / `cached` values are
   recomputed from their deps and aren't restorable, so they don't appear in the
   state. Inspect them via the component's data cells instead.

--- a/docs/redux-devtools.md
+++ b/docs/redux-devtools.md
@@ -41,27 +41,84 @@ The `config` argument accepts the standard
 
 ## What state is exposed
 
-State is read from the existing dev-only `DEBUG_CELLS` registry — the set of all
-live **data cells** (`cell(...)`, `cellFor(...)`, `@tracked` fields). It does
-**not** introduce a parallel registry. Each cell is keyed by a stable, unique
-`"<debugName>#<id>"` string (derived formulas / `MergedCell`s are not part of the
-serialized state; they are recomputed from their dependencies).
+The state **mirrors the gxt component tree** — human-readable and diff-friendly,
+not a flat cell dump:
+
+```jsonc
+{
+  "Application#1": {
+    "Benchmark#7": {
+      "$state": { "_selected": 5, "_items": [ /* ... */ ] },
+      "Row#42": { "$state": { "label": "foo" } },
+      "Row#43": { "$state": { "label": "bar" } }
+    }
+  },
+  "$globals": { "theme#3": "dark" }
+}
+```
+
+- Each node is labelled `<ClassName>#<id>`. The id is stable while the component
+  is alive, so key paths stay stable across snapshots and the extension's diff
+  view highlights exactly the changed leaf.
+- A node's **own** reactive cells live under `$state` (property name → value),
+  read from `cellsMap.get(node)` — the component's own data cells. Child
+  components are nested directly under the node.
+- The walk reads the live component tree (`TREE` / `CHILD` / `PARENT`) and each
+  node's `cellsMap`; it **never** reads the strong `DEBUG_CELLS` set for the
+  per-component path. Components removed from `TREE` by their destructor are
+  therefore **absent by construction** — no retention, no dead-component soup.
+- Cells with no live tree owner (module-level `cell()`, list-item cells,
+  `@tracked` on plain objects) go in a separate, labelled **`$globals`** bucket.
+  Cells owned by a component that is no longer in `TREE` are excluded from
+  `$globals` too, so a torn-down component leaves zero trace anywhere.
+- Derived `MergedCell`s recompute from their dependencies and are not restorable,
+  so they are intentionally **omitted** (data cells are the primary, restorable
+  state). `cellsMap` only ever holds data `Cell`s, so this falls out for free.
 
 Every cell change is coalesced per microtask (matching gxt's own
-`scheduleRevalidate` batching) and sent to the monitor as one `cells:changed`
-action carrying a full snapshot, so a 1000-row update is a single timeline entry.
+`scheduleRevalidate` batching) so a 1000-row update is a single timeline entry.
 
-## Time-travel
+## Action timeline
 
-When you JUMP / ROLLBACK / RESET in the monitor, the integration restores each
-cell's `_value` and re-renders the bound DOM **synchronously**, via
-`applyCellUpdateSync`. That path bypasses `Cell.update`, so restoring does **not**
+Each timeline entry's `type` tells the story of what changed instead of a generic
+`cells:changed`:
+
+| Scenario | Example `type` |
+| --- | --- |
+| one change | `set Benchmark._selected` |
+| several cells, one component | `update Row#42 (3 cells)` |
+| several components | `update Row#42 +2 more (3 cells)` |
+| large batch | `update: 100 cells` |
+
+The action carries a structured payload for the inspector:
+
+```jsonc
+{ "type": "set Benchmark._selected", "count": 1,
+  "changes": [{ "path": "Benchmark#7._selected", "from": 5, "to": 9 }] }
+```
+
+`from`/`to` are the start-of-batch → end-of-batch transition (non-primitive
+values are shown as a light summary like `Array(1000)`; the full value lives in
+the state snapshot). The `changes` array is capped (with a `truncated` count) so
+a huge batch stays light in the inspector.
+
+## Time-travel (backward **and** forward)
+
+When you JUMP / ROLLBACK / RESET in the monitor, the integration navigates the
+tree-shaped target state in parallel with the **live** component tree — matching
+nodes by their stable `#<id>` label — and restores each leaf via
+`applyCellUpdateSync`, re-rendering the bound DOM **synchronously**. Because the
+key paths are stable across the whole session, a JUMP to **any** index works
+whether you step backward (undo) or forward (redo).
+
+`applyCellUpdateSync` bypasses `Cell.update`, so restoring does **not**
 re-dispatch back to the monitor (no feedback loop). An `isDevToolsRestoring()`
 guard provides defence-in-depth against a subscriber that writes back during
 restore.
 
 Handled monitor messages: `JUMP_TO_STATE`, `JUMP_TO_ACTION`, `ROLLBACK`, `RESET`,
-`COMMIT`, `IMPORT_STATE`.
+`COMMIT`, `IMPORT_STATE`. `COMMIT` resets the baseline to the current state;
+`RESET` restores the committed (initial) snapshot.
 
 ## Design / cost model
 
@@ -70,20 +127,30 @@ Handled monitor messages: `JUMP_TO_STATE`, `JUMP_TO_ACTION`, `ROLLBACK`, `RESET`
 
   ```ts
   if (IS_DEV_MODE && _devtoolsCellNotifier !== null && changed) {
-    _devtoolsCellNotifier(this);
+    _devtoolsCellNotifier(this, prevValue);
   }
   ```
 
   - Lib / production: `IS_DEV_MODE` → `false`, the branch (and every reference
     that would pull the redux-devtools module into the bundle) is removed.
   - Dev, DevTools off: a single predictable `!== null` check, no allocation.
-  - Dev, DevTools on: forwards the changed cell to the coalescing sender.
+    `prevValue` is the same single `_value` read the change check already needs,
+    captured in a local — zero extra hot-path work.
+  - Dev, DevTools on: forwards the changed cell + its old value to the coalescing
+    sender. All tree-walking and label-building happen at snapshot time, never on
+    this path.
 
-- **No new registries.** Enumeration reuses `DEBUG_CELLS`.
+- **No new registries; no retention.** The per-component path walks the live
+  tree + `cellsMap` and reuses `DEBUG_CELLS` only for the `$globals` bucket. The
+  integration holds nothing across snapshots: the coalescing buffer (`_changed`)
+  is cleared on every flush, and `disableReduxDevtools()` detaches the notifier,
+  buffers, subscription, connection and committed baseline with zero residue.
 
-- **Tree-shakable.** Verified: a consumer bundle of `import { cell } from
-  '@lifeart/gxt'` contains none of the integration (no `__REDUX_DEVTOOLS_EXTENSION__`,
-  `supportChromeExtension`, `cells:changed`, …).
+- **Tree-shakable.** Verified by building the lib (`IS_DEV_MODE` inlined to
+  `false`) and grepping the dist: zero references to `__REDUX_DEVTOOLS_EXTENSION__`,
+  `$globals`, `supportChromeExtension`, the snapshot/restore walk, etc. A consumer
+  bundle of `import { cell } from '@lifeart/gxt'` therefore contains none of the
+  integration.
 
 ## Lower-level / Freezer-style API
 
@@ -106,10 +173,26 @@ const store = supportChromeExtension(createCellState());
 
 ## Caveats
 
-- `DEBUG_CELLS` accumulates every cell created during a dev session (existing gxt
-  behaviour — data cells have no `destroy()` hook). The state tree therefore
-  grows over a long session and may include cells whose owning components were
-  torn down. This is a dev-only memory characteristic, not a correctness issue.
+- **`$globals` is the one pre-existing dev-only unbounded set.** The per-component
+  tree is leak-free by construction (it reads the live `TREE`). `$globals` is
+  sourced from `DEBUG_CELLS`, which accumulates every cell created during a dev
+  session (existing gxt behaviour — data cells have no `destroy()` hook). The
+  bucket is *bounded relative to the old flat dump*: tree-owned cells and cells
+  owned by torn-down components are both excluded, so what remains is genuine
+  module-level / list-item / plain-object state. It can still grow over a long
+  session. This is a dev-only memory characteristic, not a correctness issue.
+- **Id reuse.** Node labels use the component id, which gxt recycles via
+  `releaseId` after destruction. Time-travel matches nodes by id, so a state
+  captured for a component that was later destroyed *and whose id was reused by a
+  different component* could in principle restore onto the wrong node. Restores
+  onto stable (still-alive) components — the common time-travel case — are exact.
+- **List growth = diff noise.** An array-valued cell (e.g. `_items`) is included
+  in full in every snapshot, so growing a 1000-row list shows a large diff. The
+  trade is deliberate: the full value is the most useful thing to inspect and
+  restore.
+- **Derived values are omitted.** `MergedCell` / `formula` / `cached` values are
+  recomputed from their deps and aren't restorable, so they don't appear in the
+  state. Inspect them via the component's data cells instead.
 - Only primitive-ish cell values serialize cleanly. Cells holding complex
   objects/functions are subject to the extension's own serialization limits;
   use the `serialize` config option to customise.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -96,6 +96,16 @@ export {
 
 export { configureGXT, type GXTConfig, type GXTConfigInput, type PoolConfig } from '@/core/config';
 
+// Redux DevTools integration (opt-in, dev-only, browser-only). The whole module
+// tree-shakes out of production/lib builds because `enableReduxDevtools`'s body
+// folds away when IS_DEV_MODE is inlined to false. See `@/core/redux-devtools`.
+export {
+  enableReduxDevtools,
+  disableReduxDevtools,
+  isDevToolsRestoring,
+  type DevToolsConfig,
+} from '@/core/redux-devtools';
+
 // Context API exports for Ember integration
 export {
   provideContext,

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -108,6 +108,15 @@ export function tracked(
             : descriptor?.value,
           `${klass.constructor.name}.${key}.@tracked`,
         );
+        if (IS_DEV_MODE) {
+          // Dev-only owner back-reference (folds out in production). The Redux
+          // DevTools integration uses it to recognise a cell as component-owned
+          // so a torn-down component's @tracked cells are excluded from the
+          // `$globals` bucket instead of lingering. Purely metadata; mirrors
+          // the back-reference `rawCellFor` already records.
+          value._relatedObj = this;
+          value._relatedKey = key;
+        }
         keys.set(key, value);
         return value.value;
       } else {
@@ -117,10 +126,15 @@ export function tracked(
     set(newValue: any) {
       const keys = keysFor(this);
       if (!keys.has(key)) {
-        keys.set(
-          key,
-          cell(newValue, `${klass.constructor.name}.${key}.@tracked`),
+        const created: any = cell(
+          newValue,
+          `${klass.constructor.name}.${key}.@tracked`,
         );
+        if (IS_DEV_MODE) {
+          created._relatedObj = this;
+          created._relatedKey = key;
+        }
+        keys.set(key, created);
         return;
       }
       const _cell = keys.get(key)!;
@@ -220,7 +234,11 @@ export class Cell<T extends unknown = unknown> {
     // spurious recomputes within a single render pass. We still schedule
     // revalidation to preserve observable side-effect semantics — callers
     // that update() a cell explicitly expect the opcode queue to flush.
-    const changed = this._value !== value;
+    // `prevValue` is the single read of `_value` we already needed for the
+    // change check; capturing it in a local is free and lets the dev-only
+    // DevTools notifier report the old→new transition (see below).
+    const prevValue = this._value;
+    const changed = prevValue !== value;
     this._value = value;
     if (changed) {
       this._revision = bumpGlobalRevision();
@@ -231,7 +249,7 @@ export class Cell<T extends unknown = unknown> {
     // Folds away entirely in lib builds (IS_DEV_MODE === false); a single
     // predictable null check when DevTools is off in dev.
     if (IS_DEV_MODE && _devtoolsCellNotifier !== null && changed) {
-      _devtoolsCellNotifier(this as unknown as Cell);
+      _devtoolsCellNotifier(this as unknown as Cell, prevValue);
     }
   }
 }
@@ -561,7 +579,7 @@ export function setCellUpdateDeferralHook(
 // restore (the restore path uses `applyCellUpdateSync`, which bypasses this
 // hook entirely, so it never fires in practice — but the module also keeps an
 // `isDevToolsRestoring()` guard as defence in depth).
-export type DevtoolsCellNotifier = (cell: Cell) => void;
+export type DevtoolsCellNotifier = (cell: Cell, oldValue: unknown) => void;
 let _devtoolsCellNotifier: DevtoolsCellNotifier | null = null;
 export function setDevtoolsCellNotifier(
   notifier: DevtoolsCellNotifier | null,
@@ -602,7 +620,8 @@ export function applyDeferredCellUpdate(
   // Same body as Cell.update's synchronous path, intentionally without the
   // deferral-hook check (the hook is the CALLER here — re-entering it would
   // loop forever).
-  const changed = cell._value !== value;
+  const prevValue = cell._value;
+  const changed = prevValue !== value;
   cell._value = value;
   if (changed) {
     cell._revision = bumpGlobalRevision();
@@ -612,7 +631,7 @@ export function applyDeferredCellUpdate(
   // Mirror Cell.update's dev-only DevTools notification for host-deferred
   // updates (e.g. Ember's runloop drain). Same zero-cost-when-off guard.
   if (IS_DEV_MODE && _devtoolsCellNotifier !== null && changed) {
-    _devtoolsCellNotifier(cell);
+    _devtoolsCellNotifier(cell, prevValue);
   }
 }
 

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -227,6 +227,12 @@ export class Cell<T extends unknown = unknown> {
     }
     tagsToRevalidate.add(this);
     scheduleRevalidate();
+    // Dev-only Redux DevTools notification — see `setDevtoolsCellNotifier`.
+    // Folds away entirely in lib builds (IS_DEV_MODE === false); a single
+    // predictable null check when DevTools is off in dev.
+    if (IS_DEV_MODE && _devtoolsCellNotifier !== null && changed) {
+      _devtoolsCellNotifier(this as unknown as Cell);
+    }
   }
 }
 
@@ -537,6 +543,34 @@ export function setCellUpdateDeferralHook(
   _cellUpdateDeferralHook = hook;
 }
 
+// Dev-only Redux DevTools cell-change notifier.
+// Null unless `enableReduxDevtools()` (see `@/core/redux-devtools`) has connected
+// to the browser extension. Every `Cell.update()` / `applyDeferredCellUpdate()`
+// that actually changes a value forwards the cell here so the integration can
+// snapshot reactive state for the DevTools timeline (time-travel debugging).
+//
+// The hot-path guard is `IS_DEV_MODE && _devtoolsCellNotifier !== null && changed`:
+//   * lib / production build — `IS_DEV_MODE` is inlined to `false`, so the whole
+//     branch (and every reference that would otherwise pull the redux-devtools
+//     module into the bundle) folds away. Tree-shaking verified.
+//   * dev, DevTools NOT connected — a single, perfectly-predictable null check;
+//     no allocation, no extra work on the tuned update path.
+//   * dev, DevTools connected — forwards the changed cell to the coalescing
+//     sender in the redux-devtools module.
+// The notifier itself is responsible for not re-entering during time-travel
+// restore (the restore path uses `applyCellUpdateSync`, which bypasses this
+// hook entirely, so it never fires in practice — but the module also keeps an
+// `isDevToolsRestoring()` guard as defence in depth).
+export type DevtoolsCellNotifier = (cell: Cell) => void;
+let _devtoolsCellNotifier: DevtoolsCellNotifier | null = null;
+export function setDevtoolsCellNotifier(
+  notifier: DevtoolsCellNotifier | null,
+): void {
+  if (IS_DEV_MODE) {
+    _devtoolsCellNotifier = notifier;
+  }
+}
+
 /**
  * Apply a deferred cell update from the host's drain phase.
  *
@@ -575,6 +609,11 @@ export function applyDeferredCellUpdate(
   }
   tagsToRevalidate.add(cell);
   scheduleRevalidate();
+  // Mirror Cell.update's dev-only DevTools notification for host-deferred
+  // updates (e.g. Ember's runloop drain). Same zero-cost-when-off guard.
+  if (IS_DEV_MODE && _devtoolsCellNotifier !== null && changed) {
+    _devtoolsCellNotifier(cell);
+  }
 }
 
 // Shared error handler for executeTag variants — avoids code duplication

--- a/src/core/redux-devtools.test.ts
+++ b/src/core/redux-devtools.test.ts
@@ -6,12 +6,24 @@ import {
   enableReduxDevtools,
   disableReduxDevtools,
   isDevToolsRestoring,
-  snapshotCells,
+  snapshotState,
+  devtoolsPendingCount,
   createCellState,
   type FreezerState,
 } from './redux-devtools';
-import { cell } from './reactive';
-import { opcodeFor } from './vm';
+import { Component } from './component';
+import { RENDERED_NODES_PROPERTY, addToTree, $template } from './shared';
+import { $_c, $_args, $_edp } from './dom';
+import { cell, cellFor } from './reactive';
+import { renderElement } from './render-core';
+import { runDestructors } from './destroy';
+import { TREE } from './tree';
+import { createDOMFixture, type DOMFixture } from './__test-utils__';
+import {
+  template,
+  setupGlobalScope,
+  GXT_RUNTIME_SYMBOLS,
+} from '../../plugins/runtime-compiler';
 
 // `IS_DEV_MODE` is inlined by the compiler: `false` under the default test mode
 // and `true` under `--mode development`. The reactive-core DevTools hook
@@ -291,7 +303,7 @@ describe('Redux DevTools Integration', () => {
       expect(fake.connection.subscribe).toHaveBeenCalledTimes(1);
     });
 
-    devTest('dispatches a snapshot when a cell changes', async () => {
+    devTest('dispatches a snapshot when a (global) cell changes', async () => {
       const fake = installFakeExtension();
       enableReduxDevtools();
 
@@ -300,10 +312,13 @@ describe('Redux DevTools Integration', () => {
       await flushMicrotasks();
 
       expect(fake.connection.send).toHaveBeenCalled();
-      const state = fake.lastSendState();
-      const key = Object.keys(state).find((k) => k.startsWith('devtools-dispatch#'));
+      const state = fake.lastSendState() as any;
+      const globals = state.$globals;
+      const key = Object.keys(globals).find((k) =>
+        k.startsWith('devtools-dispatch#'),
+      );
       expect(key).toBeTruthy();
-      expect(state[key!]).toBe(2);
+      expect(globals[key!]).toBe(2);
     });
 
     devTest('does NOT dispatch when DevTools is off (zero-cost guard)', async () => {
@@ -339,61 +354,23 @@ describe('Redux DevTools Integration', () => {
 
       expect(fake.connection.send).toHaveBeenCalledTimes(1);
       const [action] = fake.connection.send.mock.calls[0];
-      expect(action.type).toBe('cells:changed');
-    });
-
-    devTest('time-travel restores cells + re-renders without re-dispatching', async () => {
-      const fake = installFakeExtension();
-      enableReduxDevtools();
-
-      const c = cell(10, 'devtools-jump');
-      const rendered: unknown[] = [];
-      const teardown = opcodeFor(c as any, (value) => {
-        rendered.push(value);
-      });
-
-      c.update(20);
-      await flushMicrotasks();
-
-      // The opcode saw the initial value and the update.
-      expect(rendered).toContain(20);
-      expect(c.value).toBe(20);
-
-      // Locate the cell's key in the snapshot.
-      const snapshot = snapshotCells();
-      const key = Object.keys(snapshot).find((k) => k.startsWith('devtools-jump#'))!;
-      expect(key).toBeTruthy();
-
-      const sendCallsBeforeJump = fake.connection.send.mock.calls.length;
-
-      // Simulate a JUMP_TO_STATE from the monitor back to value 10.
-      fake.emit({
-        type: 'DISPATCH',
-        payload: { type: 'JUMP_TO_STATE' },
-        state: JSON.stringify({ [key]: 10 }),
-      });
-
-      // Cell restored + subscriber re-rendered synchronously.
-      expect(c.value).toBe(10);
-      expect(rendered[rendered.length - 1]).toBe(10);
-
-      // No re-dispatch as a result of the restore...
-      expect(fake.connection.send.mock.calls.length).toBe(sendCallsBeforeJump);
-      // ...even after pending microtasks flush.
-      await flushMicrotasks();
-      expect(fake.connection.send.mock.calls.length).toBe(sendCallsBeforeJump);
-
-      teardown();
+      // Two distinct cells changed -> a coalesced, informative batch label.
+      // Both are module-level (no tree owner) so they share the $globals owner.
+      expect(action.type).toBe('update $globals (2 cells)');
+      expect(action.count).toBe(2);
+      // Buffer fully drained after the flush — no retention across snapshots.
+      expect(devtoolsPendingCount()).toBe(0);
     });
 
     devTest('createCellState snapshots + restores via the freezer interface', () => {
       const c = cell(100, 'devtools-cellstate');
-      const state = createCellState();
-      const snap = state.get();
-      const key = Object.keys(snap).find((k) => k.startsWith('devtools-cellstate#'))!;
-      expect(snap[key]).toBe(100);
+      const snap = createCellState().get() as any;
+      const key = Object.keys(snap.$globals).find((k) =>
+        k.startsWith('devtools-cellstate#'),
+      )!;
+      expect(snap.$globals[key]).toBe(100);
 
-      state.set({ [key]: 200 });
+      createCellState().set({ $globals: { [key]: 200 } });
       expect(c.value).toBe(200);
     });
 
@@ -410,6 +387,321 @@ describe('Redux DevTools Integration', () => {
         });
       }).not.toThrow();
       expect(fake.connection.error).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tree-shaped state / informative actions / leak-by-construction / redo
+  // (dev-only — these mount a real component tree)
+  // -------------------------------------------------------------------------
+  describe('component-tree state (dev-only)', () => {
+    let fixture: DOMFixture;
+
+    beforeEach(() => {
+      fixture = createDOMFixture();
+      setupGlobalScope();
+      const g = globalThis as Record<string, unknown>;
+      Object.entries(GXT_RUNTIME_SYMBOLS).forEach(([name, value]) => {
+        g[name] = value;
+      });
+    });
+
+    afterEach(() => {
+      disableReduxDevtools();
+      fixture.cleanup();
+    });
+
+    /** Render a (class) component under a fresh parent and return the parent so
+     * the whole subtree can be torn down with `runDestructors`. */
+    function mount(Root: any, args: Record<string, unknown> = {}) {
+      const parent = new Component({});
+      (parent as any)[RENDERED_NODES_PROPERTY] = [];
+      addToTree(fixture.root, parent);
+      const rendered = $_c(
+        Root,
+        $_args(args, false, $_edp as any),
+        parent,
+      );
+      renderElement(fixture.api, parent, fixture.container, rendered);
+      return parent;
+    }
+
+    /** Depth-first search of the tree-shaped state for the first node whose
+     * label starts with `${classPrefix}#`. Skips the `$state`/`$globals` buckets. */
+    function findNode(state: any, classPrefix: string): any {
+      for (const key of Object.keys(state)) {
+        if (key === '$state' || key === '$globals') continue;
+        if (key.startsWith(`${classPrefix}#`)) return state[key];
+        const found = findNode(state[key], classPrefix);
+        if (found) return found;
+      }
+      return null;
+    }
+
+    function Counter() {
+      return class Counter extends Component {
+        _count = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_count');
+        }
+        [$template] = template('<span class="count">{{this._count}}</span>');
+      };
+    }
+
+    devTest('snapshot mirrors the mounted component tree (nested, readable)', () => {
+      const C = Counter();
+      class App extends Component {
+        _title = 'Hello';
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_title');
+        }
+        [$template] = template(
+          '<div><h1>{{this._title}}</h1><Counter /></div>',
+          { scope: { Counter: C } },
+        );
+      }
+
+      mount(App);
+      const state = snapshotState() as any;
+
+      const app = findNode(state, 'App');
+      expect(app).toBeTruthy();
+      expect(app.$state._title).toBe('Hello');
+
+      // Counter is NESTED under App (not a sibling, not flattened).
+      const counter = findNode(app, 'Counter');
+      expect(counter).toBeTruthy();
+      expect(counter.$state._count).toBe(0);
+    });
+
+    devTest('action label reflects the changed component/prop (single change)', async () => {
+      const fake = installFakeExtension();
+      class App extends Component {
+        _title = 'Hello';
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_title');
+        }
+        [$template] = template('<h1>{{this._title}}</h1>');
+      }
+      mount(App);
+      enableReduxDevtools();
+
+      (fixture.container.querySelector('h1') as any); // ensure rendered
+      // Mutate the tracked prop through its cell-backed accessor.
+      const app = TREE.get(
+        [...TREE.keys()].find(
+          (id) => TREE.get(id)?.constructor?.name === 'App',
+        )!,
+      ) as any;
+      app._title = 'World';
+      await flushMicrotasks();
+
+      const _calls = fake.connection.send.mock.calls;
+      const [action] = _calls[_calls.length - 1];
+      expect(action.type).toBe('set App._title');
+      expect(action.count).toBe(1);
+      expect(action.changes[0].from).toBe('Hello');
+      expect(action.changes[0].to).toBe('World');
+      expect(action.changes[0].path).toMatch(/^App#\d+\._title$/);
+    });
+
+    devTest('action label summarises a single-owner multi-cell batch', async () => {
+      const fake = installFakeExtension();
+      class Multi extends Component {
+        a = 0;
+        b = 0;
+        c = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, 'a');
+          cellFor(this as any, 'b');
+          cellFor(this as any, 'c');
+        }
+        [$template] = template('<i>{{this.a}}{{this.b}}{{this.c}}</i>');
+      }
+      mount(Multi);
+      enableReduxDevtools();
+
+      const node = TREE.get(
+        [...TREE.keys()].find(
+          (id) => TREE.get(id)?.constructor?.name === 'Multi',
+        )!,
+      ) as any;
+      node.a = 1;
+      node.b = 2;
+      node.c = 3;
+      await flushMicrotasks();
+
+      const _calls = fake.connection.send.mock.calls;
+      const [action] = _calls[_calls.length - 1];
+      expect(action.type).toMatch(/^update Multi#\d+ \(3 cells\)$/);
+      expect(action.count).toBe(3);
+    });
+
+    devTest('action label collapses a large batch', async () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+
+      const cells = Array.from({ length: 12 }, (_, i) =>
+        cell(0, `big-batch-${i}`),
+      );
+      cells.forEach((c, i) => c.update(i + 1));
+      await flushMicrotasks();
+
+      const _calls = fake.connection.send.mock.calls;
+      const [action] = _calls[_calls.length - 1];
+      expect(action.type).toBe('update: 12 cells');
+      expect(action.count).toBe(12);
+      // Payload capped, with a truncated count.
+      expect(action.changes.length).toBeLessThanOrEqual(12);
+      expect(action.truncated ?? 0).toBe(12 - action.changes.length);
+    });
+
+    // --- Axis 2: leak by construction -------------------------------------
+    devTest('destroyed components leave zero trace in the snapshot (no leak)', async () => {
+      const C = Counter();
+      class App extends Component {
+        _title = 'x';
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_title');
+        }
+        [$template] = template('<div>{{this._title}}<Counter /></div>', {
+          scope: { Counter: C },
+        });
+      }
+
+      const parent = mount(App);
+
+      // Present before destruction.
+      let state = snapshotState() as any;
+      expect(findNode(state, 'App')).toBeTruthy();
+      expect(findNode(state, 'Counter')).toBeTruthy();
+
+      // Tear the whole subtree down (runs the addToTree destructors that drop
+      // the nodes from TREE/CHILD/PARENT).
+      await Promise.all(runDestructors(parent, [], true, fixture.api));
+
+      // Absent after destruction — gone from TREE and from the snapshot, and
+      // NOT resurrected via the $globals bucket either (component-owned cells
+      // of dead components are excluded).
+      state = snapshotState() as any;
+      expect(findNode(state, 'App')).toBeNull();
+      expect(findNode(state, 'Counter')).toBeNull();
+      const globals = state.$globals ?? {};
+      expect(
+        Object.keys(globals).some((k) => k.includes('_title') || k.includes('_count')),
+      ).toBe(false);
+
+      // The integration itself holds nothing across snapshots.
+      expect(devtoolsPendingCount()).toBe(0);
+    });
+
+    // --- Axis 3: redo / forward time-travel -------------------------------
+    devTest('time-travel restores backward AND forward without re-dispatching', async () => {
+      const fake = installFakeExtension();
+      class App extends Component {
+        _count = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_count');
+        }
+        [$template] = template('<b class="c">{{this._count}}</b>');
+      }
+      mount(App);
+      enableReduxDevtools();
+
+      const node = TREE.get(
+        [...TREE.keys()].find(
+          (id) => TREE.get(id)?.constructor?.name === 'App',
+        )!,
+      ) as any;
+      const dom = () =>
+        fixture.container.querySelector('.c')!.textContent;
+
+      // Build a timeline: 0 -> 1 -> 2 -> 3, capturing each computed state as
+      // the monitor would.
+      const timeline: string[] = [JSON.stringify(snapshotState())]; // value 0
+      for (const v of [1, 2, 3]) {
+        node._count = v;
+        await flushMicrotasks();
+        timeline.push(JSON.stringify(snapshotState()));
+      }
+      expect(node._count).toBe(3);
+      expect(dom()).toBe('3');
+
+      const sendsBefore = fake.connection.send.mock.calls.length;
+      const jump = (i: number) =>
+        fake.emit({
+          type: 'DISPATCH',
+          payload: { type: 'JUMP_TO_STATE' },
+          state: timeline[i],
+        });
+
+      // Step BACKWARD: 3 -> 2 -> 1 -> 0, asserting cell + DOM at each.
+      for (const i of [2, 1, 0]) {
+        jump(i);
+        expect(node._count).toBe(i);
+        expect(dom()).toBe(String(i));
+      }
+
+      // Step FORWARD (redo): 0 -> 1 -> 2 -> 3.
+      for (const i of [1, 2, 3]) {
+        jump(i);
+        expect(node._count).toBe(i);
+        expect(dom()).toBe(String(i));
+      }
+
+      // A jump to an arbitrary index also works.
+      jump(1);
+      expect(node._count).toBe(1);
+      expect(dom()).toBe('1');
+
+      // No re-dispatch happened during ANY restore (notifier stayed silent).
+      expect(fake.connection.send.mock.calls.length).toBe(sendsBefore);
+      await flushMicrotasks();
+      expect(fake.connection.send.mock.calls.length).toBe(sendsBefore);
+      expect(isDevToolsRestoring()).toBe(false);
+    });
+
+    devTest('RESET and COMMIT manage the committed baseline', async () => {
+      const fake = installFakeExtension();
+      class App extends Component {
+        _count = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_count');
+        }
+        [$template] = template('<b class="c">{{this._count}}</b>');
+      }
+      mount(App);
+      enableReduxDevtools();
+
+      const node = TREE.get(
+        [...TREE.keys()].find(
+          (id) => TREE.get(id)?.constructor?.name === 'App',
+        )!,
+      ) as any;
+
+      node._count = 5;
+      await flushMicrotasks();
+      expect(node._count).toBe(5);
+
+      // RESET -> back to the connect-time baseline (0).
+      fake.emit({ type: 'DISPATCH', payload: { type: 'RESET' } });
+      expect(node._count).toBe(0);
+
+      // COMMIT at 7 -> RESET now returns to 7.
+      node._count = 7;
+      await flushMicrotasks();
+      fake.emit({ type: 'DISPATCH', payload: { type: 'COMMIT' } });
+      node._count = 9;
+      await flushMicrotasks();
+      fake.emit({ type: 'DISPATCH', payload: { type: 'RESET' } });
+      expect(node._count).toBe(7);
     });
   });
 });

--- a/src/core/redux-devtools.test.ts
+++ b/src/core/redux-devtools.test.ts
@@ -438,6 +438,18 @@ describe('Redux DevTools Integration', () => {
       return null;
     }
 
+    /** Live component id for the first node whose class name matches. */
+    function idOf(name: string): number {
+      return [...TREE.keys()].find(
+        (id) => TREE.get(id)?.constructor?.name === name,
+      )!;
+    }
+
+    /** Live component instance for the first node whose class name matches. */
+    function nodeOf(name: string): any {
+      return TREE.get(idOf(name)) as any;
+    }
+
     function Counter() {
       return class Counter extends Component {
         _count = 0;
@@ -702,6 +714,212 @@ describe('Redux DevTools Integration', () => {
       await flushMicrotasks();
       fake.emit({ type: 'DISPATCH', payload: { type: 'RESET' } });
       expect(node._count).toBe(7);
+    });
+
+    // --- Feature A: big-value summaries + cell denylist --------------------
+    devTest('summarizes a big array cell; keeps a small one full + restorable', () => {
+      class List extends Component {
+        _big: number[] = [];
+        _small: number[] = [];
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_big');
+          cellFor(this as any, '_small');
+        }
+        [$template] = template('<u>{{this._big.length}}-{{this._small.length}}</u>');
+      }
+      mount(List);
+      const node = nodeOf('List');
+      node._big = Array.from({ length: 1000 }, (_, i) => i);
+      node._small = [1, 2, 3];
+
+      const state = snapshotState() as any;
+      const list = findNode(state, 'List');
+      // Big array -> compact summary marker (no 1000-element dump).
+      expect(list.$state._big).toEqual({
+        $summary: 'Array(1000)',
+        $len: 1000,
+        $preview: [0, 1, 2, 3, 4],
+      });
+      // The inspector value is genuinely small.
+      expect(JSON.stringify(list.$state._big).length).toBeLessThan(80);
+      // Small array kept in full (and therefore restorable).
+      expect(list.$state._small).toEqual([1, 2, 3]);
+    });
+
+    devTest('restore SKIPS a summarized cell (no corruption); restores small ones', () => {
+      const fake = installFakeExtension();
+      class List extends Component {
+        _big: number[] = [];
+        _small: number[] = [];
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_big');
+          cellFor(this as any, '_small');
+        }
+        [$template] = template('<u>{{this._small.length}}</u>');
+      }
+      mount(List);
+      enableReduxDevtools();
+      const node = nodeOf('List');
+
+      const bigA = Array.from({ length: 1000 }, (_, i) => i);
+      node._big = bigA;
+      node._small = [1, 2, 3];
+
+      // Timeline target: the big cell is a summary marker in this snapshot.
+      const target = JSON.stringify(snapshotState());
+      expect(target).toContain('"$summary":"Array(1000)"');
+
+      // Move on: swap the big array + change the small one.
+      const bigB = Array.from({ length: 1000 }, (_, i) => i + 1);
+      node._big = bigB;
+      node._small = [9];
+
+      // JUMP back to the captured target.
+      fake.emit({
+        type: 'DISPATCH',
+        payload: { type: 'JUMP_TO_STATE' },
+        state: target,
+      });
+
+      // Small (under-cap) cell IS restored.
+      expect(node._small).toEqual([1, 2, 3]);
+      // Big (summarized) cell is UNTOUCHED — it kept its real runtime value and
+      // was never overwritten with the `{$summary}` marker.
+      expect(node._big).toBe(bigB);
+      expect(Array.isArray(node._big)).toBe(true);
+      expect(node._big.length).toBe(1000);
+    });
+
+    devTest('cellsDenylist excludes matching cells from snapshot AND timeline', async () => {
+      const fake = installFakeExtension();
+      class Noisy extends Component {
+        _visible = 1;
+        animationFrame = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_visible');
+          cellFor(this as any, 'animationFrame');
+        }
+        [$template] = template('<u>{{this._visible}}</u>');
+      }
+      mount(Noisy);
+      enableReduxDevtools({ cellsDenylist: ['*.animationFrame'] });
+      const node = nodeOf('Noisy');
+
+      const state = snapshotState() as any;
+      const n = findNode(state, 'Noisy');
+      expect(n.$state._visible).toBe(1);
+      // Denylisted path is absent from the snapshot entirely.
+      expect('animationFrame' in n.$state).toBe(false);
+
+      // Updating ONLY a denylisted cell produces no timeline entry (de-noised).
+      const sendsBefore = fake.connection.send.mock.calls.length;
+      node.animationFrame = 42;
+      await flushMicrotasks();
+      expect(fake.connection.send.mock.calls.length).toBe(sendsBefore);
+    });
+
+    // --- Feature B: dispatch-to-set + DOM highlight ------------------------
+    devTest('SET dispatch writes a live cell + re-renders, with no echo action', async () => {
+      const fake = installFakeExtension();
+      class App extends Component {
+        _count = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_count');
+        }
+        [$template] = template('<b class="c">{{this._count}}</b>');
+      }
+      mount(App);
+      enableReduxDevtools();
+      const node = nodeOf('App');
+      const path = `App#${idOf('App')}._count`;
+      const sendsBefore = fake.connection.send.mock.calls.length;
+
+      // `value` arrives as a JSON string from the dispatcher.
+      fake.emit({
+        type: 'ACTION',
+        payload: JSON.stringify({ type: 'SET', path, value: '42' }),
+      });
+
+      expect(node._count).toBe(42);
+      expect(fixture.container.querySelector('.c')!.textContent).toBe('42');
+      // No echo: a SET must not re-dispatch back to the monitor.
+      await flushMicrotasks();
+      expect(fake.connection.send.mock.calls.length).toBe(sendsBefore);
+      expect(isDevToolsRestoring()).toBe(false);
+    });
+
+    devTest('SET with a bad path warns and does not throw', () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        expect(() => {
+          fake.emit({
+            type: 'ACTION',
+            payload: JSON.stringify({
+              type: 'SET',
+              path: 'Ghost#999._x',
+              value: '1',
+            }),
+          });
+        }).not.toThrow();
+        expect(warn).toHaveBeenCalled();
+        expect(fake.connection.error).toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    devTest('HIGHLIGHT creates then removes a DOM overlay; SET auto-flashes', () => {
+      const fake = installFakeExtension();
+      class App extends Component {
+        _count = 0;
+        constructor(args: any) {
+          super(args);
+          cellFor(this as any, '_count');
+        }
+        [$template] = template('<b class="c">{{this._count}}</b>');
+      }
+      mount(App);
+      enableReduxDevtools();
+      const id = idOf('App');
+      const overlay = () =>
+        document.querySelector('[data-gxt-devtools-overlay]');
+
+      expect(overlay()).toBeNull();
+
+      vi.useFakeTimers();
+      try {
+        // HIGHLIGHT -> overlay appears over the component's bounds...
+        fake.emit({
+          type: 'ACTION',
+          payload: JSON.stringify({ type: 'HIGHLIGHT', path: `App#${id}` }),
+        });
+        expect(overlay()).not.toBeNull();
+        // ...and auto-removes after ~1s. (getBounds is empty in happy-dom, so
+        // the overlay is 0-size — the lifecycle still runs without throwing.)
+        vi.advanceTimersByTime(1000);
+        expect(overlay()).toBeNull();
+
+        // A SET auto-flashes the owning component too.
+        fake.emit({
+          type: 'ACTION',
+          payload: JSON.stringify({
+            type: 'SET',
+            path: `App#${id}._count`,
+            value: '5',
+          }),
+        });
+        expect(overlay()).not.toBeNull();
+        vi.advanceTimersByTime(1000);
+        expect(overlay()).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/src/core/redux-devtools.test.ts
+++ b/src/core/redux-devtools.test.ts
@@ -1,0 +1,415 @@
+// @vitest-environment happy-dom
+import { expect, test, describe, beforeEach, afterEach, vi } from 'vitest';
+import {
+  FreezerMiddleware,
+  supportChromeExtension,
+  enableReduxDevtools,
+  disableReduxDevtools,
+  isDevToolsRestoring,
+  snapshotCells,
+  createCellState,
+  type FreezerState,
+} from './redux-devtools';
+import { cell } from './reactive';
+import { opcodeFor } from './vm';
+
+// `IS_DEV_MODE` is inlined by the compiler: `false` under the default test mode
+// and `true` under `--mode development`. The reactive-core DevTools hook
+// (`Cell.update` -> notifier) and `DEBUG_CELLS` population are gated on it, so
+// the cell-bridge tests only have observable behaviour in dev mode. Under the
+// standard `vitest run` they are skipped (mirrors slot.test.ts / component.test.ts).
+const devTest = IS_DEV_MODE ? test : test.skip;
+
+function clearExtension() {
+  delete (window as any).__REDUX_DEVTOOLS_EXTENSION__;
+}
+
+// A fake Redux DevTools extension exposing the modern `connect()` API plus the
+// classic enhancer call signature.
+function installFakeExtension() {
+  let listener: ((m: any) => void) | undefined;
+  const connection = {
+    init: vi.fn(),
+    send: vi.fn(),
+    subscribe: vi.fn((l: (m: any) => void) => {
+      listener = l;
+      return () => {
+        listener = undefined;
+      };
+    }),
+    unsubscribe: vi.fn(),
+    error: vi.fn(),
+  };
+  const extension: any = vi.fn(() => (createStore: any) => createStore);
+  extension.connect = vi.fn(() => connection);
+  (window as any).__REDUX_DEVTOOLS_EXTENSION__ = extension;
+  return {
+    extension,
+    connection,
+    emit: (message: any) => listener && listener(message),
+    lastSendState: () => {
+      const calls = connection.send.mock.calls;
+      return calls.length ? calls[calls.length - 1][1] : undefined;
+    },
+  };
+}
+
+const flushMicrotasks = () => Promise.resolve();
+
+describe('Redux DevTools Integration', () => {
+  afterEach(() => {
+    disableReduxDevtools();
+    clearExtension();
+  });
+
+  // -------------------------------------------------------------------------
+  // FreezerMiddleware (faithful port — runs in every mode)
+  // -------------------------------------------------------------------------
+  describe('FreezerMiddleware', () => {
+    let mockState: FreezerState;
+    let dispatchedActions: any[];
+
+    beforeEach(() => {
+      dispatchedActions = [];
+      mockState = {
+        get: vi.fn(() => ({ count: 0 })),
+        set: vi.fn(),
+        skipDispatch: 0,
+        trigger: vi.fn(),
+        on: vi.fn(),
+      };
+    });
+
+    function createMockStore() {
+      const mockDevToolsStore = {
+        dispatch: vi.fn((action) => {
+          dispatchedActions.push(action);
+          return action;
+        }),
+        getState: vi.fn(() => ({
+          computedStates: [{ state: { count: 0 } }, { state: { count: 1 } }],
+        })),
+      };
+
+      return {
+        dispatch: vi.fn((action) => {
+          dispatchedActions.push(action);
+          return action;
+        }),
+        getState: vi.fn(() => ({
+          computedStates: [{ state: { count: 0 } }, { state: { count: 1 } }],
+        })),
+        liftedStore: mockDevToolsStore,
+        devToolsStore: mockDevToolsStore,
+      };
+    }
+
+    test('creates a middleware function', () => {
+      expect(typeof FreezerMiddleware(mockState)).toBe('function');
+    });
+
+    test('middleware returns StoreEnhancer', () => {
+      const next = vi.fn(() => createMockStore());
+      expect(typeof FreezerMiddleware(mockState)(next)).toBe('function');
+    });
+
+    test('StoreEnhancer calls next with reducer', () => {
+      const next = vi.fn((_reducer: any) => createMockStore());
+      FreezerMiddleware(mockState)(next)(vi.fn(), {});
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(typeof next.mock.calls[0][0]).toBe('function');
+    });
+
+    test('sets up afterAll event listener on state', () => {
+      const next = vi.fn(() => createMockStore());
+      FreezerMiddleware(mockState)(next)(vi.fn(), {});
+      expect(mockState.on).toHaveBeenCalledWith('afterAll', expect.any(Function));
+    });
+
+    test('reducer handles INIT action', () => {
+      let capturedReducer: any;
+      const next = vi.fn((reducer) => {
+        capturedReducer = reducer;
+        return createMockStore();
+      });
+      FreezerMiddleware(mockState)(next)(vi.fn(), {});
+      capturedReducer({ count: 5 }, { type: '@@INIT' });
+      expect(mockState.set).toHaveBeenCalledWith({ count: 5 });
+      expect(mockState.get).toHaveBeenCalled();
+    });
+
+    test('reducer returns state from State.get()', () => {
+      mockState.get = vi.fn(() => ({ count: 42 }));
+      let capturedReducer: any;
+      const next = vi.fn((reducer) => {
+        capturedReducer = reducer;
+        return createMockStore();
+      });
+      FreezerMiddleware(mockState)(next)(vi.fn(), {});
+      expect(capturedReducer({}, { type: 'SOME_ACTION' })).toEqual({ count: 42 });
+    });
+
+    test('afterAll callback dispatches actions to store', () => {
+      const mockStore = createMockStore();
+      let afterAllCallback: any;
+      mockState.on = vi.fn((event, callback) => {
+        if (event === 'afterAll') afterAllCallback = callback;
+      });
+      FreezerMiddleware(mockState)(vi.fn(() => mockStore))(vi.fn(), {});
+      afterAllCallback.call(mockState, 'CUSTOM_EVENT', 'arg1', 'arg2');
+      expect(mockStore.dispatch).toHaveBeenCalledWith({
+        type: 'CUSTOM_EVENT',
+        args: ['arg1', 'arg2'],
+      });
+    });
+
+    test('afterAll callback skips dispatch when skipDispatch is set', () => {
+      const mockStore = createMockStore();
+      let afterAllCallback: any;
+      mockState.on = vi.fn((event, callback) => {
+        if (event === 'afterAll') afterAllCallback = callback;
+      });
+      FreezerMiddleware(mockState)(vi.fn(() => mockStore))(vi.fn(), {});
+      mockState.skipDispatch = 1;
+      afterAllCallback.call(mockState, 'CUSTOM_EVENT');
+      expect(mockStore.dispatch).not.toHaveBeenCalled();
+      expect(mockState.skipDispatch).toBe(0);
+    });
+
+    test('afterAll callback ignores update events', () => {
+      const mockStore = createMockStore();
+      let afterAllCallback: any;
+      mockState.on = vi.fn((event, callback) => {
+        if (event === 'afterAll') afterAllCallback = callback;
+      });
+      FreezerMiddleware(mockState)(vi.fn(() => mockStore))(vi.fn(), {});
+      afterAllCallback.call(mockState, 'update');
+      expect(mockStore.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // supportChromeExtension (enhancer transport — runs in every mode)
+  // -------------------------------------------------------------------------
+  describe('supportChromeExtension', () => {
+    function mockState(): FreezerState {
+      return {
+        get: vi.fn(() => ({ value: 'initial' })),
+        set: vi.fn(),
+        skipDispatch: 0,
+        trigger: vi.fn(),
+        on: vi.fn(),
+      };
+    }
+
+    test('returns a store with dispatch/getState/subscribe', () => {
+      clearExtension();
+      const store = supportChromeExtension(mockState());
+      expect(store).toHaveProperty('dispatch');
+      expect(store).toHaveProperty('getState');
+      expect(store).toHaveProperty('subscribe');
+    });
+
+    test('works with the enhancer-form extension', () => {
+      const mockEnhancer = vi.fn((createStore: any) => createStore);
+      (window as any).__REDUX_DEVTOOLS_EXTENSION__ = vi.fn(() => mockEnhancer);
+      const store = supportChromeExtension(mockState());
+      expect((window as any).__REDUX_DEVTOOLS_EXTENSION__).toHaveBeenCalled();
+      expect(store).toHaveProperty('dispatch');
+    });
+
+    test('subscribe / dispatch / unsubscribe behave like a redux store', () => {
+      clearExtension();
+      const store = supportChromeExtension(mockState());
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+      expect(typeof unsubscribe).toBe('function');
+
+      const action = { type: 'INCREMENT' };
+      expect(store.dispatch(action)).toEqual(action);
+      expect(listener).toHaveBeenCalled();
+
+      listener.mockClear();
+      unsubscribe();
+      store.dispatch({ type: 'INCREMENT' });
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('passes config through to the extension', () => {
+      let capturedConfig: any = null;
+      (window as any).__REDUX_DEVTOOLS_EXTENSION__ = vi.fn((config: any) => {
+        capturedConfig = config;
+        return (createStore: any) => createStore;
+      });
+      supportChromeExtension(mockState(), {
+        name: 'Test App',
+        maxAge: 100,
+        features: { jump: true, skip: true },
+      });
+      expect(capturedConfig).toEqual({
+        name: 'Test App',
+        maxAge: 100,
+        features: { jump: true, skip: true },
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // enableReduxDevtools — safety in production / extension-absent (every mode)
+  // -------------------------------------------------------------------------
+  describe('enableReduxDevtools safety', () => {
+    test('returns a no-op disabler when the extension is absent', () => {
+      clearExtension();
+      const disable = enableReduxDevtools();
+      expect(typeof disable).toBe('function');
+      expect(() => disable()).not.toThrow();
+    });
+
+    test('is safe to call repeatedly / disable when never enabled', () => {
+      clearExtension();
+      expect(() => {
+        enableReduxDevtools();
+        enableReduxDevtools();
+        disableReduxDevtools();
+      }).not.toThrow();
+    });
+
+    test('isDevToolsRestoring is false at rest', () => {
+      expect(isDevToolsRestoring()).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cell bridge — dev-only behaviour (skipped under default test mode)
+  // -------------------------------------------------------------------------
+  describe('cell bridge (dev-only)', () => {
+    devTest('connect initialises the monitor with current state', () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+      expect(fake.extension.connect).toHaveBeenCalledTimes(1);
+      expect(fake.connection.init).toHaveBeenCalledTimes(1);
+      expect(fake.connection.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    devTest('dispatches a snapshot when a cell changes', async () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+
+      const c = cell(1, 'devtools-dispatch');
+      c.update(2);
+      await flushMicrotasks();
+
+      expect(fake.connection.send).toHaveBeenCalled();
+      const state = fake.lastSendState();
+      const key = Object.keys(state).find((k) => k.startsWith('devtools-dispatch#'));
+      expect(key).toBeTruthy();
+      expect(state[key!]).toBe(2);
+    });
+
+    devTest('does NOT dispatch when DevTools is off (zero-cost guard)', async () => {
+      const fake = installFakeExtension();
+      // Note: enableReduxDevtools NOT called.
+      const c = cell(1, 'devtools-off');
+      c.update(2);
+      await flushMicrotasks();
+      expect(fake.connection.send).not.toHaveBeenCalled();
+
+      // After enabling it dispatches; after disabling it stops again.
+      enableReduxDevtools();
+      c.update(3);
+      await flushMicrotasks();
+      expect(fake.connection.send).toHaveBeenCalledTimes(1);
+
+      disableReduxDevtools();
+      c.update(4);
+      await flushMicrotasks();
+      expect(fake.connection.send).toHaveBeenCalledTimes(1);
+    });
+
+    devTest('coalesces a batch of updates into a single dispatch', async () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+
+      const a = cell(0, 'devtools-batch-a');
+      const b = cell(0, 'devtools-batch-b');
+      a.update(1);
+      b.update(1);
+      a.update(2);
+      await flushMicrotasks();
+
+      expect(fake.connection.send).toHaveBeenCalledTimes(1);
+      const [action] = fake.connection.send.mock.calls[0];
+      expect(action.type).toBe('cells:changed');
+    });
+
+    devTest('time-travel restores cells + re-renders without re-dispatching', async () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+
+      const c = cell(10, 'devtools-jump');
+      const rendered: unknown[] = [];
+      const teardown = opcodeFor(c as any, (value) => {
+        rendered.push(value);
+      });
+
+      c.update(20);
+      await flushMicrotasks();
+
+      // The opcode saw the initial value and the update.
+      expect(rendered).toContain(20);
+      expect(c.value).toBe(20);
+
+      // Locate the cell's key in the snapshot.
+      const snapshot = snapshotCells();
+      const key = Object.keys(snapshot).find((k) => k.startsWith('devtools-jump#'))!;
+      expect(key).toBeTruthy();
+
+      const sendCallsBeforeJump = fake.connection.send.mock.calls.length;
+
+      // Simulate a JUMP_TO_STATE from the monitor back to value 10.
+      fake.emit({
+        type: 'DISPATCH',
+        payload: { type: 'JUMP_TO_STATE' },
+        state: JSON.stringify({ [key]: 10 }),
+      });
+
+      // Cell restored + subscriber re-rendered synchronously.
+      expect(c.value).toBe(10);
+      expect(rendered[rendered.length - 1]).toBe(10);
+
+      // No re-dispatch as a result of the restore...
+      expect(fake.connection.send.mock.calls.length).toBe(sendCallsBeforeJump);
+      // ...even after pending microtasks flush.
+      await flushMicrotasks();
+      expect(fake.connection.send.mock.calls.length).toBe(sendCallsBeforeJump);
+
+      teardown();
+    });
+
+    devTest('createCellState snapshots + restores via the freezer interface', () => {
+      const c = cell(100, 'devtools-cellstate');
+      const state = createCellState();
+      const snap = state.get();
+      const key = Object.keys(snap).find((k) => k.startsWith('devtools-cellstate#'))!;
+      expect(snap[key]).toBe(100);
+
+      state.set({ [key]: 200 });
+      expect(c.value).toBe(200);
+    });
+
+    devTest('ignores malformed / non-DISPATCH messages without throwing', () => {
+      const fake = installFakeExtension();
+      enableReduxDevtools();
+      expect(() => {
+        fake.emit({ type: 'START' });
+        fake.emit({ type: 'DISPATCH', payload: { type: 'PAUSE_RECORDING' } });
+        fake.emit({
+          type: 'DISPATCH',
+          payload: { type: 'JUMP_TO_STATE' },
+          state: '{not valid json',
+        });
+      }).not.toThrow();
+      expect(fake.connection.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/core/redux-devtools.ts
+++ b/src/core/redux-devtools.ts
@@ -1,30 +1,69 @@
 /**
  * Redux DevTools browser-extension integration for gxt's reactive core.
  *
- * Bridges gxt `Cell`s to the Redux DevTools extension
- * (`window.__REDUX_DEVTOOLS_EXTENSION__`) so the whole reactive state tree shows
- * up on the DevTools timeline and supports time-travel debugging: a JUMP in the
- * monitor restores every tracked cell to its recorded value and re-renders the
- * bound DOM, WITHOUT re-dispatching back to the monitor.
+ * Bridges gxt's reactive state to the Redux DevTools extension
+ * (`window.__REDUX_DEVTOOLS_EXTENSION__`) so the whole COMPONENT TREE shows up on
+ * the DevTools timeline and supports time-travel debugging: a JUMP in the
+ * monitor restores every recorded data cell to its value and re-renders the
+ * bound DOM, WITHOUT re-dispatching back to the monitor — backward AND forward.
  *
- * Design / cost model
- * ===================
+ * What you see in the monitor
+ * ===========================
+ * Instead of a flat `"<debugName>#<id>": value` dump, the state mirrors the gxt
+ * component tree, human-readable and diff-friendly:
+ *
+ *   {
+ *     "Application#1": {
+ *       "Benchmark#7": {
+ *         "$state": { "_selected": 5, "_items": [ ... ] },
+ *         "Row#42": { "$state": { "label": "foo" } },
+ *         "Row#43": { "$state": { "label": "bar" } }
+ *       }
+ *     },
+ *     "$globals": { "theme#3": "dark" }
+ *   }
+ *
+ *   * Each node is labelled `<ClassName>#<id>` (id is stable while the component
+ *     is alive, so key paths stay stable across snapshots and the extension's
+ *     diff view highlights exactly the changed leaf).
+ *   * A node's OWN reactive cells live under `$state` (property name -> value),
+ *     read from `cellsMap.get(node)` — NOT from the strong `DEBUG_CELLS` set, so
+ *     destroyed components (removed from `TREE` by their destructor) are absent
+ *     by construction. No retention, no dead-component soup.
+ *   * Cells with no live tree owner (module-level `cell()`, list-item cells,
+ *     `@tracked` on plain objects) go in a separate, labelled `$globals` bucket.
+ *     Cells owned by a component that is no longer in `TREE` are excluded from
+ *     `$globals` too — a torn-down component leaves zero trace.
+ *   * Derived `MergedCell`s recompute from their deps and are not restorable, so
+ *     they are intentionally OMITTED from the state (`cellsMap` only ever holds
+ *     data `Cell`s, so this falls out for free). Data cells are the primary,
+ *     restorable state.
+ *
+ * Action timeline
+ * ===============
+ * Each timeline entry's `type` tells a story about what changed rather than a
+ * generic `cells:changed`:
+ *   * one change   -> `"set Benchmark._selected"`
+ *   * one owner    -> `"update Row#42 (3 cells)"`
+ *   * many owners  -> `"update Row#42 +2 more (3 cells)"`
+ *   * large batch  -> `"update: 100 cells"`
+ * with a structured payload (`{ count, changes: [{ path, from, to }] }`) so the
+ * action inspector is informative. Per-microtask coalescing is preserved (a
+ * 1000-row update is one entry), and the coalesced label still describes it.
+ *
+ * Cost model
+ * ==========
  * The feature is strictly DEV-ONLY and browser-only:
  *   * `enableReduxDevtools()` no-ops (returns a no-op disabler) unless
  *     `IS_DEV_MODE` is true, a `window` exists, and the extension is installed.
  *   * The only hot-path touchpoint — `Cell.update()`'s `_devtoolsCellNotifier`
- *     call — is guarded by `IS_DEV_MODE && notifier !== null`. In a lib /
- *     production build `IS_DEV_MODE` is inlined to `false`, so that branch (and
- *     hence every reference that would pull THIS module into the bundle) folds
- *     away. When DevTools is simply not enabled in dev it costs one predictable
- *     null check. Result: this whole module tree-shakes out of production
- *     consumer bundles.
- *
- * State source
- * ============
- * State is read from the existing dev-only `DEBUG_CELLS` registry (every live
- * data cell) — no parallel "ALIVE_CELLS" registry is introduced. Each cell is
- * keyed by a stable, unique `<debugName>#<id>` string.
+ *     call — is guarded by `IS_DEV_MODE && notifier !== null && changed`. In a
+ *     lib / production build `IS_DEV_MODE` is inlined to `false`, so that branch
+ *     (and hence every reference that would pull THIS module into the bundle)
+ *     folds away. When DevTools is simply not enabled in dev it costs one
+ *     predictable null check. The tree-walk + label-building happen ONLY at
+ *     snapshot time (DevTools connected), never on the cell-update hot path.
+ *     Result: this whole module tree-shakes out of production consumer bundles.
  *
  * Two transports
  * ==============
@@ -38,12 +77,23 @@
  */
 import {
   DEBUG_CELLS,
+  cellsMap,
   applyCellUpdateSync,
   setDevtoolsCellNotifier,
   type Cell,
 } from '@/core/reactive';
+import { TREE, CHILD, PARENT } from '@/core/tree';
+import { COMPONENT_ID_PROPERTY } from '@/core/types';
 
 const noop = () => {};
+
+// Reserved keys in the tree-shaped state. Component nodes are labelled
+// `<ClassName>#<id>` (always containing `#`), so these never collide.
+const STATE_KEY = '$state';
+const GLOBALS_KEY = '$globals';
+// Cap the per-action `changes` payload so a huge batch stays light in the
+// action inspector (the full state still carries every value).
+const CHANGE_CAP = 25;
 
 // ---------------------------------------------------------------------------
 // Public configuration / extension types
@@ -122,50 +172,258 @@ export function isDevToolsRestoring(): boolean {
   return isRestoringState;
 }
 
-/**
- * Stable, unique key for a cell. `id` guarantees uniqueness; the debug name is
- * prepended for human readability in the monitor.
- */
-function cellKey(cell: Cell): string {
-  const name = (cell as { _debugName?: string })._debugName;
+type AnyObj = Record<string, unknown>;
+type CellRecord = { _value: unknown; _debugName?: string; _relatedObj?: object };
+
+/** Human-readable class name for a component node. */
+function nodeClassName(node: unknown): string {
+  const ctorName = (node as { constructor?: { name?: string } })?.constructor
+    ?.name;
+  if (ctorName && ctorName !== 'Object') {
+    return ctorName;
+  }
+  const dbg = (node as { _debugName?: string })?._debugName;
+  return dbg || 'Component';
+}
+
+/** Stable node label, e.g. `BenchRoot#7`. */
+function nodeLabel(node: unknown, id: number): string {
+  return `${nodeClassName(node)}#${id}`;
+}
+
+/** Stable per-session key for a non-tree (global/detached) cell. */
+function globalKey(cell: Cell): string {
+  const name = (cell as CellRecord)._debugName;
   return name ? `${name}#${cell.id}` : `cell#${cell.id}`;
 }
 
-/** Snapshot every live data cell into a plain serializable object. */
-export function snapshotCells(): Record<string, unknown> {
-  const state: Record<string, unknown> = {};
-  DEBUG_CELLS.forEach((cell) => {
-    state[cellKey(cell)] = (cell as { _value: unknown })._value;
-  });
-  return state;
+/** Parse the trailing `#<id>` off a node label; null if not a node label. */
+function parseNodeId(label: string): number | null {
+  const i = label.lastIndexOf('#');
+  if (i === -1) {
+    return null;
+  }
+  const n = Number(label.slice(i + 1));
+  return Number.isInteger(n) ? n : null;
+}
+
+/** A component id is a root of the snapshot when its parent is not a live node. */
+function isRootId(id: number): boolean {
+  const parent = PARENT.get(id);
+  return parent === undefined || !TREE.has(parent);
+}
+
+/** Where a tree-owned cell lives, for action labelling. */
+interface CellPathInfo {
+  className: string;
+  ownerLabel: string;
+  key: string;
 }
 
 /**
- * Restore cell values from a previously snapshotted state (time-travel).
+ * One walk of the live component tree -> a serializable, nested state object
+ * plus a `cell -> path` index (used to label actions) and the set of cells the
+ * tree already covers (so `$globals` doesn't double-count them).
  *
- * Uses `applyCellUpdateSync` so subscribers re-render synchronously and the
- * DevTools-notifier hook in `Cell.update` is NOT triggered (no re-dispatch).
- * The `isRestoringState` guard additionally neutralises any synchronous
- * write-back a subscriber might perform.
+ * Reads each node's own cells from `cellsMap.get(node)` and NEVER from the
+ * strong `DEBUG_CELLS` set, so torn-down components — gone from `TREE` — are
+ * absent by construction. Nothing here is retained past the call.
  */
-export function restoreCells(
-  state: Record<string, unknown> | null | undefined,
+function buildSnapshot(): { state: AnyObj; index: Map<Cell, CellPathInfo> } {
+  const state: AnyObj = {};
+  const index = new Map<Cell, CellPathInfo>();
+  const treeOwned = new Set<Cell>();
+  const visited = new Set<number>();
+  for (const id of TREE.keys()) {
+    if (isRootId(id) && !visited.has(id)) {
+      visited.add(id);
+      const node = TREE.get(id)!;
+      state[nodeLabel(node, id)] = buildNode(node, id, index, treeOwned, visited);
+    }
+  }
+  const globals = buildGlobals(treeOwned);
+  if (globals !== null) {
+    state[GLOBALS_KEY] = globals;
+  }
+  return { state, index };
+}
+
+function buildNode(
+  node: unknown,
+  id: number,
+  index: Map<Cell, CellPathInfo>,
+  treeOwned: Set<Cell>,
+  visited: Set<number>,
+): AnyObj {
+  const obj: AnyObj = {};
+  const cells = cellsMap.get(node as object);
+  if (cells !== undefined && cells.size > 0) {
+    const className = nodeClassName(node);
+    const ownerLabel = `${className}#${id}`;
+    const own: AnyObj = {};
+    let any = false;
+    cells.forEach((cell, key) => {
+      if (typeof key === 'symbol') {
+        return; // symbol-keyed internals don't round-trip through JSON
+      }
+      const k = String(key);
+      own[k] = (cell as unknown as CellRecord)._value;
+      index.set(cell as unknown as Cell, { className, ownerLabel, key: k });
+      treeOwned.add(cell as unknown as Cell);
+      any = true;
+    });
+    if (any) {
+      obj[STATE_KEY] = own;
+    }
+  }
+  const children = CHILD.get(id);
+  if (children !== undefined) {
+    children.forEach((childId) => {
+      const childNode = TREE.get(childId);
+      if (childNode !== undefined && !visited.has(childId)) {
+        visited.add(childId);
+        obj[nodeLabel(childNode, childId)] = buildNode(
+          childNode,
+          childId,
+          index,
+          treeOwned,
+          visited,
+        );
+      }
+    });
+  }
+  return obj;
+}
+
+/**
+ * The `$globals` bucket: live cells with no live tree owner. Sourced from the
+ * dev-only `DEBUG_CELLS` set, but:
+ *   - cells already shown in the tree are skipped (no duplication);
+ *   - cells owned by a COMPONENT that is no longer in `TREE` are skipped — a
+ *     destroyed component leaves zero trace here either.
+ * What remains is module-level `cell()`, list-item cells and `@tracked` on plain
+ * (non-component) objects. `DEBUG_CELLS` is the one pre-existing dev-only set
+ * that grows over a session; the per-component path above never touches it.
+ */
+function buildGlobals(treeOwned: Set<Cell>): AnyObj | null {
+  const out: AnyObj = {};
+  let any = false;
+  DEBUG_CELLS.forEach((cell) => {
+    if (treeOwned.has(cell)) {
+      return;
+    }
+    const owner = (cell as unknown as CellRecord)._relatedObj;
+    if (
+      owner !== undefined &&
+      owner !== null &&
+      typeof owner === 'object' &&
+      (COMPONENT_ID_PROPERTY in owner)
+    ) {
+      // Component-owned but absent from the live TREE => torn down. Exclude.
+      return;
+    }
+    out[globalKey(cell)] = (cell as unknown as CellRecord)._value;
+    any = true;
+  });
+  return any ? out : null;
+}
+
+/** Public snapshot of the whole reactive tree (used by `createCellState`). */
+export function snapshotState(): AnyObj {
+  return buildSnapshot().state;
+}
+
+function stringKeyedCells(
+  cells: Map<string | number | symbol, unknown>,
+): Map<string, Cell> {
+  const m = new Map<string, Cell>();
+  cells.forEach((c, k) => m.set(String(k), c as Cell));
+  return m;
+}
+
+/**
+ * Restore reactive state from a previously snapshotted tree-shaped object
+ * (time-travel — backward OR forward). Navigates the nested state in parallel
+ * with the LIVE component tree, matching nodes by their stable `#<id>` label, and
+ * applies each leaf via `applyCellUpdateSync` (synchronous re-render, no
+ * re-dispatch). The `isRestoringState` guard neutralises any synchronous
+ * write-back a subscriber might perform.
+ *
+ * Entries whose component is no longer live are skipped (you cannot restore a
+ * destroyed component's cells); live nodes absent from the target state are left
+ * untouched. Stable across a session as long as component ids are stable.
+ */
+export function restoreState(
+  state: AnyObj | null | undefined,
 ): void {
   if (!state || typeof state !== 'object') {
     return;
   }
-  const byKey = new Map<string, Cell>();
-  DEBUG_CELLS.forEach((cell) => byKey.set(cellKey(cell), cell));
   isRestoringState = true;
   try {
     for (const key in state) {
-      const cell = byKey.get(key);
-      if (cell !== undefined) {
-        applyCellUpdateSync(cell as Cell<unknown>, state[key]);
+      if (key === GLOBALS_KEY) {
+        restoreGlobals(state[key] as AnyObj);
+        continue;
+      }
+      const id = parseNodeId(key);
+      if (id === null) {
+        continue;
+      }
+      const node = TREE.get(id);
+      if (node !== undefined) {
+        restoreNode(node, state[key] as AnyObj);
       }
     }
   } finally {
     isRestoringState = false;
+  }
+}
+
+function restoreNode(node: unknown, obj: AnyObj | null | undefined): void {
+  if (!obj || typeof obj !== 'object') {
+    return;
+  }
+  const cells = cellsMap.get(node as object);
+  for (const key in obj) {
+    if (key === STATE_KEY) {
+      if (cells === undefined) {
+        continue;
+      }
+      const byStr = stringKeyedCells(cells);
+      const own = obj[key] as AnyObj;
+      if (own && typeof own === 'object') {
+        for (const ck in own) {
+          const cell = byStr.get(ck);
+          if (cell !== undefined) {
+            applyCellUpdateSync(cell as Cell<unknown>, own[ck]);
+          }
+        }
+      }
+      continue;
+    }
+    const id = parseNodeId(key);
+    if (id === null) {
+      continue;
+    }
+    const child = TREE.get(id);
+    if (child !== undefined) {
+      restoreNode(child, obj[key] as AnyObj);
+    }
+  }
+}
+
+function restoreGlobals(globals: AnyObj | null | undefined): void {
+  if (!globals || typeof globals !== 'object') {
+    return;
+  }
+  const byKey = new Map<string, Cell>();
+  DEBUG_CELLS.forEach((cell) => byKey.set(globalKey(cell), cell));
+  for (const k in globals) {
+    const cell = byKey.get(k);
+    if (cell !== undefined) {
+      applyCellUpdateSync(cell as Cell<unknown>, globals[k]);
+    }
   }
 }
 
@@ -175,33 +433,152 @@ export function restoreCells(
 
 let _connection: DevToolsConnection | null = null;
 let _unsubscribe: (() => void) | null = null;
-let _initialSnapshot: Record<string, unknown> = {};
+let _initialSnapshot: AnyObj = {};
 
 // Coalesce per-microtask: one "action" per synchronous batch of cell updates
 // (mirrors gxt's own scheduleRevalidate batching) so a 1000-row update is a
-// single timeline entry instead of 1000.
-const _changedKeys = new Set<string>();
+// single timeline entry instead of 1000. `_changed` maps each changed cell to
+// its FIRST-seen value this batch (the "from"); the "to" is read live at flush.
+// Both the map and the scheduled flag are buffers, cleared every flush — the
+// integration holds nothing across snapshots.
+const _changed = new Map<Cell, unknown>();
 let _sendScheduled = false;
 
-function scheduleDevtoolsSend(cell: Cell): void {
+/** Dev-only introspection for the leak test: count of cells buffered for the
+ * next flush. The integration retains nothing else across snapshots. */
+export function devtoolsPendingCount(): number {
+  return _changed.size;
+}
+
+function isPrimitiveish(v: unknown): boolean {
+  return (
+    v === null ||
+    v === undefined ||
+    typeof v === 'string' ||
+    typeof v === 'number' ||
+    typeof v === 'boolean'
+  );
+}
+
+/** A light, JSON-safe stand-in for a non-primitive value in the action payload
+ * (the full state still carries the real value). */
+function summarizeValue(v: unknown): unknown {
+  if (isPrimitiveish(v)) {
+    return v;
+  }
+  if (Array.isArray(v)) {
+    return `Array(${v.length})`;
+  }
+  if (typeof v === 'function') {
+    return 'ƒ()';
+  }
+  const name = (v as { constructor?: { name?: string } })?.constructor?.name;
+  return `${name || 'Object'}{…}`;
+}
+
+interface ChangeEntry {
+  cell: Cell;
+  from: unknown;
+  to: unknown;
+  /** `Class.prop` (no id) — for the action `type`. */
+  shortLabel: string;
+  /** `Class#id.prop` (precise) — for the payload path. */
+  path: string;
+  /** `Class#id` — to count distinct owners. */
+  ownerLabel: string;
+}
+
+function describeChange(
+  cell: Cell,
+  from: unknown,
+  index: Map<Cell, CellPathInfo>,
+): ChangeEntry {
+  const info = index.get(cell);
+  const to = (cell as unknown as CellRecord)._value;
+  if (info !== undefined) {
+    return {
+      cell,
+      from,
+      to,
+      shortLabel: `${info.className}.${info.key}`,
+      path: `${info.ownerLabel}.${info.key}`,
+      ownerLabel: info.ownerLabel,
+    };
+  }
+  // Non-tree (global/detached) cell.
+  const name =
+    (cell as unknown as CellRecord)._debugName || `cell#${cell.id}`;
+  return {
+    cell,
+    from,
+    to,
+    shortLabel: name,
+    path: globalKey(cell),
+    ownerLabel: GLOBALS_KEY,
+  };
+}
+
+/** Build the timeline label that tells the story of this coalesced batch. */
+function buildActionType(entries: ChangeEntry[]): string {
+  const n = entries.length;
+  if (n === 1) {
+    return `set ${entries[0]!.shortLabel}`;
+  }
+  if (n > 8) {
+    return `update: ${n} cells`;
+  }
+  const owners = new Set(entries.map((e) => e.ownerLabel));
+  if (owners.size === 1) {
+    return `update ${entries[0]!.ownerLabel} (${n} cells)`;
+  }
+  return `update ${entries[0]!.ownerLabel} +${n - 1} more (${n} cells)`;
+}
+
+function scheduleDevtoolsSend(cell: Cell, oldValue: unknown): void {
   if (isRestoringState || _connection === null) {
     return;
   }
-  _changedKeys.add(cellKey(cell));
+  // First-seen old value wins so the coalesced action reports the true
+  // start-of-batch -> end-of-batch transition.
+  if (!_changed.has(cell)) {
+    _changed.set(cell, oldValue);
+  }
   if (_sendScheduled) {
     return;
   }
   _sendScheduled = true;
-  queueMicrotask(() => {
-    _sendScheduled = false;
-    if (_connection === null) {
-      _changedKeys.clear();
-      return;
-    }
-    const changed = Array.from(_changedKeys);
-    _changedKeys.clear();
-    _connection.send({ type: 'cells:changed', changed }, snapshotCells());
-  });
+  queueMicrotask(flushDevtoolsSend);
+}
+
+function flushDevtoolsSend(): void {
+  _sendScheduled = false;
+  if (_connection === null) {
+    _changed.clear();
+    return;
+  }
+  const pending = Array.from(_changed.entries());
+  _changed.clear();
+  if (pending.length === 0) {
+    return;
+  }
+  const { state, index } = buildSnapshot();
+  const entries = pending.map(([cell, from]) =>
+    describeChange(cell, from, index),
+  );
+  const changes = entries.slice(0, CHANGE_CAP).map((e) => ({
+    path: e.path,
+    from: summarizeValue(e.from),
+    to: summarizeValue(e.to),
+  }));
+  const action: DevToolsAction = {
+    type: buildActionType(entries),
+    count: entries.length,
+    changes,
+  };
+  if (entries.length > CHANGE_CAP) {
+    action.truncated = entries.length - CHANGE_CAP;
+  }
+  _connection.send(action, state);
 }
 
 function handleDevToolsMessage(
@@ -216,29 +593,32 @@ function handleDevToolsMessage(
     case 'JUMP_TO_STATE':
     case 'JUMP_TO_ACTION':
     case 'ROLLBACK': {
+      // Restores work for ANY target index — backward or forward — because the
+      // tree-shaped state carries stable `#<id>` key paths that `restoreState`
+      // navigates against the live tree.
       const parsed = parseDevToolsState(connection, message.state);
       if (parsed !== undefined) {
-        restoreCells(parsed);
+        restoreState(parsed);
       }
       break;
     }
     case 'RESET':
       // Revert to the state captured when DevTools connected.
-      restoreCells(_initialSnapshot);
-      connection.init(snapshotCells());
+      restoreState(_initialSnapshot);
+      connection.init(snapshotState());
       break;
     case 'COMMIT':
       // Make the current state the new committed base.
-      _initialSnapshot = snapshotCells();
+      _initialSnapshot = snapshotState();
       connection.init(_initialSnapshot);
       break;
     case 'IMPORT_STATE': {
       const lifted = message.payload.nextLiftedState as
-        | { computedStates?: Array<{ state?: Record<string, unknown> }> }
+        | { computedStates?: Array<{ state?: AnyObj }> }
         | undefined;
       const computed = lifted?.computedStates;
       if (Array.isArray(computed) && computed.length > 0) {
-        restoreCells(computed[computed.length - 1]!.state);
+        restoreState(computed[computed.length - 1]!.state);
       }
       break;
     }
@@ -251,13 +631,13 @@ function handleDevToolsMessage(
 function parseDevToolsState(
   connection: DevToolsConnection,
   state: string | undefined,
-): Record<string, unknown> | undefined {
+): AnyObj | undefined {
   if (typeof state !== 'string') {
     // Some monitors deliver an already-parsed object.
-    return state === undefined ? undefined : (state as Record<string, unknown>);
+    return state === undefined ? undefined : (state as AnyObj);
   }
   try {
-    return JSON.parse(state) as Record<string, unknown>;
+    return JSON.parse(state) as AnyObj;
   } catch (e) {
     // Never swallow: surface to the dev console AND the extension monitor.
     if (IS_DEV_MODE) {
@@ -314,7 +694,7 @@ export function enableReduxDevtools(config?: DevToolsConfig): () => void {
     ...config,
   });
 
-  _initialSnapshot = snapshotCells();
+  _initialSnapshot = snapshotState();
   connection.init(_initialSnapshot);
   const unsub = connection.subscribe((message) =>
     handleDevToolsMessage(connection, message),
@@ -329,10 +709,14 @@ export function enableReduxDevtools(config?: DevToolsConfig): () => void {
   return disableReduxDevtools;
 }
 
-/** Disconnect the DevTools integration and remove the cell-update hook. */
+/**
+ * Disconnect the DevTools integration and remove the cell-update hook. Fully
+ * detaches with zero residue: the notifier, the coalescing buffers, the
+ * subscription, the connection and the committed baseline are all cleared.
+ */
 export function disableReduxDevtools(): void {
   setDevtoolsCellNotifier(null);
-  _changedKeys.clear();
+  _changed.clear();
   _sendScheduled = false;
   if (_unsubscribe !== null) {
     _unsubscribe();
@@ -341,6 +725,7 @@ export function disableReduxDevtools(): void {
   }
   _connection = null;
   _unsubscribe = null;
+  _initialSnapshot = {};
 }
 
 // ---------------------------------------------------------------------------
@@ -368,17 +753,17 @@ export interface FreezerState {
 }
 
 /**
- * A `FreezerState` backed by gxt cells — read snapshots from `DEBUG_CELLS`,
- * write restores through `restoreCells`. Use with `supportChromeExtension` for
- * the enhancer-based transport.
+ * A `FreezerState` backed by gxt cells — read tree-shaped snapshots via
+ * `snapshotState`, write restores through `restoreState`. Use with
+ * `supportChromeExtension` for the enhancer-based transport.
  */
 export function createCellState(): FreezerState {
   return {
     get() {
-      return snapshotCells();
+      return snapshotState();
     },
     set(state: Record<string, unknown>) {
-      restoreCells(state);
+      restoreState(state);
     },
     skipDispatch: 0,
     trigger() {

--- a/src/core/redux-devtools.ts
+++ b/src/core/redux-devtools.ts
@@ -84,6 +84,8 @@ import {
 } from '@/core/reactive';
 import { TREE, CHILD, PARENT } from '@/core/tree';
 import { COMPONENT_ID_PROPERTY } from '@/core/types';
+import { getBounds, type ComponentLike } from '@/core/shared';
+import { inspect } from '@/core/inspector';
 
 const noop = () => {};
 
@@ -94,6 +96,47 @@ const GLOBALS_KEY = '$globals';
 // Cap the per-action `changes` payload so a huge batch stays light in the
 // action inspector (the full state still carries every value).
 const CHANGE_CAP = 25;
+
+// ---------------------------------------------------------------------------
+// Big-value summarization (Feature A)
+// ---------------------------------------------------------------------------
+// A cell value over a size threshold is replaced in the snapshot with a compact
+// summary marker (an object carrying `$summary`) instead of dumping the whole
+// thing into the state inspector. This keeps a list's `_items: Array(1000)`
+// from choking the UI and producing a huge diff on every change. The marker is
+// NOT restorable (the real value was replaced), so `restoreState` skips it — a
+// summarized cell becomes inspect-only and keeps its real runtime value across
+// time-travel. Cells UNDER the cap keep their real value and stay fully
+// restorable. Raise the cap or denylist-exempt a path to keep a big collection
+// restorable. Summarization happens ONLY at snapshot time — zero hot-path cost.
+const SUMMARY_KEY = '$summary';
+// How many leading items/keys/chars a summary marker previews.
+const ARRAY_PREVIEW_COUNT = 5;
+const OBJECT_PREVIEW_COUNT = 5;
+const STRING_PREVIEW_CHARS = 64;
+
+// Sensible defaults (documented in docs/redux-devtools.md).
+const DEFAULT_MAX_ARRAY_ITEMS = 50; // arrays longer than this are summarized
+const DEFAULT_MAX_VALUE_BYTES = 8 * 1024; // ~8KB rough budget for one cell value
+const DEFAULT_MAX_VALUE_DEPTH = 4; // nesting depth before a value is "too big"
+
+interface SummarizeOptions {
+  maxArrayItems: number;
+  maxValueBytes: number;
+  maxValueDepth: number;
+}
+
+function defaultSummarizeOptions(): SummarizeOptions {
+  return {
+    maxArrayItems: DEFAULT_MAX_ARRAY_ITEMS,
+    maxValueBytes: DEFAULT_MAX_VALUE_BYTES,
+    maxValueDepth: DEFAULT_MAX_VALUE_DEPTH,
+  };
+}
+
+// Active config (set on connect from `DevToolsConfig`, reset on disconnect).
+let _summarize: SummarizeOptions = defaultSummarizeOptions();
+let _denyGlobs: RegExp[] = [];
 
 // ---------------------------------------------------------------------------
 // Public configuration / extension types
@@ -119,6 +162,26 @@ export interface DevToolsConfig {
   };
   trace?: boolean;
   traceLimit?: number;
+  // --- gxt extensions (not part of the standard extension config) ---
+  /**
+   * Arrays longer than this are replaced in the snapshot with a compact
+   * `$summary` marker instead of dumping every element. Default `50`.
+   */
+  maxArrayItems?: number;
+  /**
+   * Rough byte budget for a single cell value. Strings / objects / nested
+   * arrays whose estimated size exceeds this are summarized. Default `8192`.
+   */
+  maxValueBytes?: number;
+  /** Nesting depth past which a value is treated as too big. Default `4`. */
+  maxValueDepth?: number;
+  /**
+   * Path globs/prefixes whose cells are excluded from the snapshot AND the
+   * action timeline entirely — for high-frequency / noisy cells (in the spirit
+   * of `actionsDenylist`). `*` matches any run of characters; a prefix matches
+   * any deeper path. E.g. `["*.animationFrame", "Benchmark#*._items"]`.
+   */
+  cellsDenylist?: string[];
 }
 
 /** Action shape we send to the monitor. */
@@ -167,6 +230,10 @@ declare global {
 // belt-and-braces in case a subscriber re-enters `update()` synchronously.
 let isRestoringState = false;
 
+/** Components whose cells actually changed during the most recent restore /
+ * SET — used to auto-flash their DOM so the dev sees what time-travel touched. */
+const _restoreTouched = new Set<object>();
+
 /** Whether the integration is currently restoring cell state (time-travel). */
 export function isDevToolsRestoring(): boolean {
   return isRestoringState;
@@ -213,6 +280,158 @@ function isRootId(id: number): boolean {
   return parent === undefined || !TREE.has(parent);
 }
 
+/** True when `v` is a summary marker produced by `summarizeForSnapshot`. */
+function isSummaryMarker(v: unknown): boolean {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    !Array.isArray(v) &&
+    SUMMARY_KEY in (v as object)
+  );
+}
+
+function isPrimitiveValue(v: unknown): boolean {
+  return (
+    v === null ||
+    v === undefined ||
+    typeof v === 'string' ||
+    typeof v === 'number' ||
+    typeof v === 'boolean' ||
+    typeof v === 'bigint'
+  );
+}
+
+/** A small, JSON-safe preview of one value: primitives raw, the rest via the
+ * existing `inspect` helper (bounded by its own depth/list limits). */
+function previewItem(v: unknown): unknown {
+  return isPrimitiveValue(v) ? v : inspect(v);
+}
+
+/**
+ * Cheap, short-circuiting size estimate. Returns as soon as the running total
+ * passes `maxValueBytes`, and treats an over-cap array / over-depth value as
+ * immediately "too big" without walking it — so a 1000-item array never gets
+ * fully traversed just to decide to summarize it.
+ */
+function roughSizeOf(value: unknown, depth: number, opts: SummarizeOptions): number {
+  if (value === null || value === undefined) return 4;
+  const t = typeof value;
+  if (t === 'string') return (value as string).length;
+  if (t === 'number' || t === 'boolean' || t === 'bigint') return 8;
+  if (t === 'function' || t === 'symbol') return 8;
+  if (depth >= opts.maxValueDepth) return opts.maxValueBytes + 1;
+  if (Array.isArray(value)) {
+    if (value.length > opts.maxArrayItems) return opts.maxValueBytes + 1;
+    let total = 2;
+    for (let i = 0; i < value.length; i++) {
+      total += roughSizeOf(value[i], depth + 1, opts);
+      if (total > opts.maxValueBytes) return total;
+    }
+    return total;
+  }
+  const keys = Object.keys(value as object);
+  let total = 2;
+  for (let i = 0; i < keys.length; i++) {
+    total += keys[i].length + 2 + roughSizeOf((value as AnyObj)[keys[i]], depth + 1, opts);
+    if (total > opts.maxValueBytes) return total;
+  }
+  return total;
+}
+
+function makeArraySummary(arr: unknown[]): AnyObj {
+  return {
+    [SUMMARY_KEY]: `Array(${arr.length})`,
+    $len: arr.length,
+    $preview: arr.slice(0, ARRAY_PREVIEW_COUNT).map(previewItem),
+  };
+}
+
+function makeObjectSummary(obj: object): AnyObj {
+  const keys = Object.keys(obj);
+  const ctorName = (obj as { constructor?: { name?: string } })?.constructor?.name;
+  const name = ctorName && ctorName !== 'Object' ? ctorName : 'Object';
+  const preview: AnyObj = {};
+  for (const k of keys.slice(0, OBJECT_PREVIEW_COUNT)) {
+    preview[k] = previewItem((obj as AnyObj)[k]);
+  }
+  return {
+    [SUMMARY_KEY]: `${name}(${keys.length} keys)`,
+    $keys: keys.length,
+    $preview: preview,
+  };
+}
+
+/**
+ * Snapshot-time value transform: pass small/primitive values through verbatim
+ * (so they stay fully time-travel-restorable), and replace anything over the
+ * configured caps with a compact `$summary` marker. Only the top level of a
+ * cell value is considered — a cell is therefore either fully restorable OR a
+ * single inspect-only marker, never a half-real hybrid.
+ */
+function summarizeForSnapshot(value: unknown, opts: SummarizeOptions): unknown {
+  if (value === null || value === undefined) return value;
+  const t = typeof value;
+  if (t === 'number' || t === 'boolean' || t === 'bigint') return value;
+  if (t === 'string') {
+    const s = value as string;
+    if (s.length > opts.maxValueBytes) {
+      return {
+        [SUMMARY_KEY]: `String(${s.length})`,
+        $len: s.length,
+        $preview: s.slice(0, STRING_PREVIEW_CHARS),
+      };
+    }
+    return value;
+  }
+  if (t === 'function') {
+    return { [SUMMARY_KEY]: inspect(value) };
+  }
+  if (t === 'symbol') {
+    return { [SUMMARY_KEY]: String(value) };
+  }
+  if (Array.isArray(value)) {
+    if (value.length > opts.maxArrayItems || roughSizeOf(value, 0, opts) > opts.maxValueBytes) {
+      return makeArraySummary(value);
+    }
+    return value; // small array — kept real, fully restorable
+  }
+  // Plain object / class instance.
+  if (roughSizeOf(value, 0, opts) > opts.maxValueBytes) {
+    return makeObjectSummary(value as object);
+  }
+  return value;
+}
+
+// --- Cell denylist (Feature A) ---------------------------------------------
+// In the spirit of the extension's `actionsDenylist`: a `cellsDenylist` of path
+// globs/prefixes whose cells are excluded from the snapshot AND from the action
+// timeline entirely (high-frequency / noisy cells like `*.animationFrame`).
+//   * `*` matches any run of characters.
+//   * a pattern also matches any deeper path (`Benchmark#4` denylists every
+//     cell under it, e.g. `Benchmark#4._items`).
+
+function compileGlob(pattern: string): RegExp {
+  let out = '';
+  for (const ch of pattern) {
+    if (ch === '*') out += '.*';
+    else if ('.+?^${}()|[]\\'.includes(ch)) out += '\\' + ch;
+    else out += ch;
+  }
+  return new RegExp(`^(?:${out})(?:\\..*)?$`);
+}
+
+function compileDenylist(patterns?: string[]): RegExp[] {
+  if (!Array.isArray(patterns) || patterns.length === 0) return [];
+  return patterns.map(compileGlob);
+}
+
+function isDenied(path: string): boolean {
+  for (let i = 0; i < _denyGlobs.length; i++) {
+    if (_denyGlobs[i].test(path)) return true;
+  }
+  return false;
+}
+
 /** Where a tree-owned cell lives, for action labelling. */
 interface CellPathInfo {
   className: string;
@@ -229,23 +448,35 @@ interface CellPathInfo {
  * strong `DEBUG_CELLS` set, so torn-down components — gone from `TREE` — are
  * absent by construction. Nothing here is retained past the call.
  */
-function buildSnapshot(): { state: AnyObj; index: Map<Cell, CellPathInfo> } {
+function buildSnapshot(): {
+  state: AnyObj;
+  index: Map<Cell, CellPathInfo>;
+  denied: Set<Cell>;
+} {
   const state: AnyObj = {};
   const index = new Map<Cell, CellPathInfo>();
   const treeOwned = new Set<Cell>();
+  const denied = new Set<Cell>();
   const visited = new Set<number>();
   for (const id of TREE.keys()) {
     if (isRootId(id) && !visited.has(id)) {
       visited.add(id);
       const node = TREE.get(id)!;
-      state[nodeLabel(node, id)] = buildNode(node, id, index, treeOwned, visited);
+      state[nodeLabel(node, id)] = buildNode(
+        node,
+        id,
+        index,
+        treeOwned,
+        denied,
+        visited,
+      );
     }
   }
-  const globals = buildGlobals(treeOwned);
+  const globals = buildGlobals(treeOwned, denied);
   if (globals !== null) {
     state[GLOBALS_KEY] = globals;
   }
-  return { state, index };
+  return { state, index, denied };
 }
 
 function buildNode(
@@ -253,6 +484,7 @@ function buildNode(
   id: number,
   index: Map<Cell, CellPathInfo>,
   treeOwned: Set<Cell>,
+  denied: Set<Cell>,
   visited: Set<number>,
 ): AnyObj {
   const obj: AnyObj = {};
@@ -260,6 +492,7 @@ function buildNode(
   if (cells !== undefined && cells.size > 0) {
     const className = nodeClassName(node);
     const ownerLabel = `${className}#${id}`;
+    const hasDenylist = _denyGlobs.length > 0;
     const own: AnyObj = {};
     let any = false;
     cells.forEach((cell, key) => {
@@ -267,9 +500,19 @@ function buildNode(
         return; // symbol-keyed internals don't round-trip through JSON
       }
       const k = String(key);
-      own[k] = (cell as unknown as CellRecord)._value;
-      index.set(cell as unknown as Cell, { className, ownerLabel, key: k });
-      treeOwned.add(cell as unknown as Cell);
+      const c = cell as unknown as Cell;
+      // Denylisted (noisy/high-frequency) cells are excluded from the snapshot
+      // entirely. Still mark them tree-owned so the `$globals` bucket doesn't
+      // resurface them, and record them in `denied` so the action timeline
+      // drops them too.
+      if (hasDenylist && isDenied(`${ownerLabel}.${k}`)) {
+        treeOwned.add(c);
+        denied.add(c);
+        return;
+      }
+      own[k] = summarizeForSnapshot((cell as unknown as CellRecord)._value, _summarize);
+      index.set(c, { className, ownerLabel, key: k });
+      treeOwned.add(c);
       any = true;
     });
     if (any) {
@@ -287,6 +530,7 @@ function buildNode(
           childId,
           index,
           treeOwned,
+          denied,
           visited,
         );
       }
@@ -305,8 +549,9 @@ function buildNode(
  * (non-component) objects. `DEBUG_CELLS` is the one pre-existing dev-only set
  * that grows over a session; the per-component path above never touches it.
  */
-function buildGlobals(treeOwned: Set<Cell>): AnyObj | null {
+function buildGlobals(treeOwned: Set<Cell>, denied: Set<Cell>): AnyObj | null {
   const out: AnyObj = {};
+  const hasDenylist = _denyGlobs.length > 0;
   let any = false;
   DEBUG_CELLS.forEach((cell) => {
     if (treeOwned.has(cell)) {
@@ -322,7 +567,12 @@ function buildGlobals(treeOwned: Set<Cell>): AnyObj | null {
       // Component-owned but absent from the live TREE => torn down. Exclude.
       return;
     }
-    out[globalKey(cell)] = (cell as unknown as CellRecord)._value;
+    const gk = globalKey(cell);
+    if (hasDenylist && isDenied(gk)) {
+      denied.add(cell);
+      return;
+    }
+    out[gk] = summarizeForSnapshot((cell as unknown as CellRecord)._value, _summarize);
     any = true;
   });
   return any ? out : null;
@@ -359,6 +609,7 @@ export function restoreState(
   if (!state || typeof state !== 'object') {
     return;
   }
+  _restoreTouched.clear();
   isRestoringState = true;
   try {
     for (const key in state) {
@@ -394,9 +645,19 @@ function restoreNode(node: unknown, obj: AnyObj | null | undefined): void {
       const own = obj[key] as AnyObj;
       if (own && typeof own === 'object') {
         for (const ck in own) {
+          const v = own[ck];
+          // A summarized value is NOT the real value — never write the
+          // `{$summary:…}` marker back into a cell (that would corrupt it).
+          // The cell keeps its live runtime value (inspect-only across travel).
+          if (isSummaryMarker(v)) {
+            continue;
+          }
           const cell = byStr.get(ck);
           if (cell !== undefined) {
-            applyCellUpdateSync(cell as Cell<unknown>, own[ck]);
+            if ((cell as unknown as CellRecord)._value !== v) {
+              _restoreTouched.add(node as object);
+            }
+            applyCellUpdateSync(cell as Cell<unknown>, v);
           }
         }
       }
@@ -420,9 +681,13 @@ function restoreGlobals(globals: AnyObj | null | undefined): void {
   const byKey = new Map<string, Cell>();
   DEBUG_CELLS.forEach((cell) => byKey.set(globalKey(cell), cell));
   for (const k in globals) {
+    const v = globals[k];
+    if (isSummaryMarker(v)) {
+      continue; // summarized — not restorable, leave the live value intact
+    }
     const cell = byKey.get(k);
     if (cell !== undefined) {
-      applyCellUpdateSync(cell as Cell<unknown>, globals[k]);
+      applyCellUpdateSync(cell as Cell<unknown>, v);
     }
   }
 }
@@ -561,8 +826,16 @@ function flushDevtoolsSend(): void {
   if (pending.length === 0) {
     return;
   }
-  const { state, index } = buildSnapshot();
-  const entries = pending.map(([cell, from]) =>
+  const { state, index, denied } = buildSnapshot();
+  // Drop denylisted (noisy/high-frequency) cells from the timeline entirely.
+  // If the whole batch was denylisted, emit no action at all (nothing the dev
+  // asked to see changed) — that is the de-noising point of `cellsDenylist`.
+  const visible =
+    denied.size === 0 ? pending : pending.filter(([cell]) => !denied.has(cell));
+  if (visible.length === 0) {
+    return;
+  }
+  const entries = visible.map(([cell, from]) =>
     describeChange(cell, from, index),
   );
   const changes = entries.slice(0, CHANGE_CAP).map((e) => ({
@@ -581,10 +854,382 @@ function flushDevtoolsSend(): void {
   _connection.send(action, state);
 }
 
+// ---------------------------------------------------------------------------
+// Component DOM highlight overlay (Feature B) — browser + dev only
+// ---------------------------------------------------------------------------
+// A single, reused, position-fixed div that flashes over a component's bounds
+// (outline + subtle fill) and auto-removes after ~1s. Used both for the
+// explicit `HIGHLIGHT` dispatch action and for auto-flash-on-change (SET / a
+// time-travel JUMP) so the dev SEES which component changed in the page.
+//
+// HONESTY: the Redux DevTools protocol does NOT notify the page when you click
+// a node in the state-tree inspector, so true "click-in-tree -> highlight" is
+// impossible. We deliver the `HIGHLIGHT` dispatch action plus auto-flash-on-
+// change instead. See docs/redux-devtools.md.
+const OVERLAY_MS = 1000;
+// Above this many distinct components a single change touches, skip the flash
+// entirely (a 1000-row batch should never strobe the screen).
+const MAX_FLASH_COMPONENTS = 8;
+const OVERLAY_ATTR = 'data-gxt-devtools-overlay';
+
+let _overlayEl: HTMLElement | null = null;
+let _overlayTimer: ReturnType<typeof setTimeout> | null = null;
+
+interface Rect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+function mergeRect(a: Rect | null, b: Rect | null): Rect | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return {
+    top: Math.min(a.top, b.top),
+    left: Math.min(a.left, b.left),
+    right: Math.max(a.right, b.right),
+    bottom: Math.max(a.bottom, b.bottom),
+  };
+}
+
+function elementForRect(node: Node): Element | null {
+  if (typeof Element !== 'undefined' && node instanceof Element) {
+    return node;
+  }
+  // Comment / text markers (list & if blocks) — approximate via the parent.
+  return (node as ChildNode).parentElement ?? null;
+}
+
+/** Union bounding rect of a component's rendered DOM (via `getBounds`). Returns
+ * null when nothing is measurable (e.g. happy-dom / detached / 0-size). */
+function componentRect(component: ComponentLike): Rect | null {
+  let rect: Rect | null = null;
+  const nodes = getBounds(component);
+  for (const node of nodes) {
+    const el = elementForRect(node);
+    if (el === null || typeof el.getBoundingClientRect !== 'function') {
+      continue;
+    }
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0 && r.top === 0 && r.left === 0) {
+      continue;
+    }
+    rect = mergeRect(rect, {
+      top: r.top,
+      left: r.left,
+      right: r.right,
+      bottom: r.bottom,
+    });
+  }
+  return rect;
+}
+
+function ensureOverlay(): HTMLElement | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  if (_overlayEl === null) {
+    const el = document.createElement('div');
+    el.setAttribute(OVERLAY_ATTR, '');
+    const s = el.style;
+    s.position = 'fixed';
+    s.zIndex = '2147483647';
+    s.pointerEvents = 'none';
+    s.boxSizing = 'border-box';
+    s.outline = '2px solid #c792ea';
+    s.background = 'rgba(199, 146, 234, 0.15)';
+    s.borderRadius = '2px';
+    s.transition = 'opacity 120ms ease-out';
+    s.opacity = '0';
+    _overlayEl = el;
+  }
+  if (!_overlayEl.isConnected && document.body) {
+    document.body.appendChild(_overlayEl);
+  }
+  return _overlayEl;
+}
+
+function removeOverlay(): void {
+  if (_overlayTimer !== null) {
+    clearTimeout(_overlayTimer);
+    _overlayTimer = null;
+  }
+  if (_overlayEl !== null && _overlayEl.isConnected) {
+    _overlayEl.remove();
+  }
+}
+
+function isOffscreen(rect: Rect): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    rect.bottom < 0 ||
+    rect.right < 0 ||
+    rect.top > (window.innerHeight || 0) ||
+    rect.left > (window.innerWidth || 0)
+  );
+}
+
+function scrollComponentIntoView(component: ComponentLike): void {
+  const nodes = getBounds(component);
+  for (const node of nodes) {
+    const el = elementForRect(node);
+    if (el !== null && typeof (el as HTMLElement).scrollIntoView === 'function') {
+      (el as HTMLElement).scrollIntoView({ block: 'center', inline: 'nearest' });
+      return;
+    }
+  }
+}
+
+/** Position + briefly show the (single) overlay over `rect`. A null rect still
+ * runs the show/hide lifecycle (0-size marker) so callers don't have to special
+ * case unmeasurable bounds — nothing visible, but no throw. */
+function flashRect(rect: Rect | null): void {
+  if (!IS_DEV_MODE || typeof document === 'undefined') {
+    return;
+  }
+  const overlay = ensureOverlay();
+  if (overlay === null) {
+    return;
+  }
+  const s = overlay.style;
+  if (rect !== null) {
+    s.top = `${rect.top}px`;
+    s.left = `${rect.left}px`;
+    s.width = `${Math.max(0, rect.right - rect.left)}px`;
+    s.height = `${Math.max(0, rect.bottom - rect.top)}px`;
+  } else {
+    s.top = '0px';
+    s.left = '0px';
+    s.width = '0px';
+    s.height = '0px';
+  }
+  s.opacity = '1';
+  if (_overlayTimer !== null) {
+    clearTimeout(_overlayTimer);
+  }
+  _overlayTimer = setTimeout(removeOverlay, OVERLAY_MS);
+}
+
+/** Flash a single component (used by `HIGHLIGHT`). */
+function flashComponent(component: ComponentLike): void {
+  if (!IS_DEV_MODE || typeof document === 'undefined') {
+    return;
+  }
+  const rect = componentRect(component);
+  if (rect !== null && isOffscreen(rect)) {
+    scrollComponentIntoView(component);
+  }
+  flashRect(rect);
+}
+
+/** Auto-flash the components a change touched. Capped + debounced via the
+ * single overlay/timer: many components -> one union flash; too many -> skip. */
+function flashAffectedComponents(nodes: Set<object>): void {
+  if (!IS_DEV_MODE || typeof document === 'undefined') {
+    return;
+  }
+  if (nodes.size === 0 || nodes.size > MAX_FLASH_COMPONENTS) {
+    return;
+  }
+  let union: Rect | null = null;
+  let scrollTarget: ComponentLike | null = null;
+  nodes.forEach((n) => {
+    const node = n as ComponentLike;
+    const r = componentRect(node);
+    if (r !== null) {
+      union = mergeRect(union, r);
+      if (scrollTarget === null) scrollTarget = node;
+    }
+  });
+  if (union !== null && scrollTarget !== null && isOffscreen(union)) {
+    scrollComponentIntoView(scrollTarget);
+  }
+  flashRect(union);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher custom actions (Feature B): SET a cell live, HIGHLIGHT a component
+// ---------------------------------------------------------------------------
+
+/** Parse the `value` field of a SET action: it arrives as a string/JSON from
+ * the dispatcher. JSON.parse it, falling back to the raw string on failure. */
+function parseSetValue(raw: unknown): unknown {
+  if (typeof raw !== 'string') {
+    return raw; // already a structured JSON value
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw; // not JSON — treat the literal string as the value
+  }
+}
+
+/** dev-only, non-swallowing: log to the console AND surface to the monitor. */
+function reportDispatchError(connection: DevToolsConnection, msg: string): void {
+  if (IS_DEV_MODE) {
+    console.warn(`[gxt redux-devtools] ${msg}`);
+  }
+  connection.error(`gxt: ${msg}`);
+}
+
+/** Resolve `Class#id.key` (or a full nested path) to its live cell + owner. */
+function resolveCellByPath(
+  path: string,
+): { cell: Cell; owner: ComponentLike | null } | undefined {
+  const parts = path.split('.');
+  const key = parts.pop();
+  if (key === undefined || key.length === 0) {
+    return undefined;
+  }
+  // Nearest preceding `Class#id` segment is the owner.
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const id = parseNodeId(parts[i]!);
+    if (id === null) continue;
+    const node = TREE.get(id);
+    if (node === undefined) continue;
+    const cells = cellsMap.get(node as object);
+    if (cells === undefined) continue;
+    const cell = stringKeyedCells(cells).get(key);
+    if (cell !== undefined) {
+      return { cell, owner: node };
+    }
+  }
+  // Fall back to a `$globals` key (e.g. `theme#3`).
+  let found: { cell: Cell; owner: ComponentLike | null } | undefined;
+  DEBUG_CELLS.forEach((c) => {
+    if (found === undefined && globalKey(c) === path) {
+      found = { cell: c, owner: null };
+    }
+  });
+  return found;
+}
+
+/** Resolve a path to its component (last `Class#id` segment). */
+function resolveComponentByPath(path: string): ComponentLike | undefined {
+  const parts = path.split('.');
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const id = parseNodeId(parts[i]!);
+    if (id === null) continue;
+    const node = TREE.get(id);
+    if (node !== undefined) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+/** `{ type: 'SET', path, value }` — write a live cell + re-render, then flash
+ * the owning component. Bad path / type mismatch is surfaced, never swallowed. */
+function handleSetAction(
+  connection: DevToolsConnection,
+  action: DevToolsAction,
+): void {
+  const path = action.path;
+  if (typeof path !== 'string' || path.length === 0) {
+    reportDispatchError(connection, 'SET requires a string "path"');
+    return;
+  }
+  const resolved = resolveCellByPath(path);
+  if (resolved === undefined) {
+    reportDispatchError(connection, `SET: could not resolve cell path "${path}"`);
+    return;
+  }
+  const value = parseSetValue(action.value);
+  const current = (resolved.cell as unknown as CellRecord)._value;
+  if (
+    current !== null &&
+    current !== undefined &&
+    value !== null &&
+    value !== undefined &&
+    typeof current !== typeof value
+  ) {
+    // Surface (don't swallow) an obvious type change; still apply — the dev
+    // explicitly asked to set this value.
+    reportDispatchError(
+      connection,
+      `SET: type mismatch for "${path}" (cell holds ${typeof current}, value is ${typeof value}); applying anyway`,
+    );
+  }
+  // Write under the restoring guard so it can never echo back as a new action
+  // (applyCellUpdateSync already bypasses the notifier; this is belt-and-braces).
+  isRestoringState = true;
+  try {
+    applyCellUpdateSync(resolved.cell as Cell<unknown>, value);
+  } finally {
+    isRestoringState = false;
+  }
+  if (resolved.owner !== null) {
+    flashAffectedComponents(new Set<object>([resolved.owner]));
+  }
+}
+
+/** `{ type: 'HIGHLIGHT', path }` — flash a component's DOM. */
+function handleHighlightAction(
+  connection: DevToolsConnection,
+  action: DevToolsAction,
+): void {
+  const path = action.path;
+  if (typeof path !== 'string' || path.length === 0) {
+    reportDispatchError(connection, 'HIGHLIGHT requires a string "path"');
+    return;
+  }
+  const component = resolveComponentByPath(path);
+  if (component === undefined) {
+    reportDispatchError(
+      connection,
+      `HIGHLIGHT: could not resolve component "${path}"`,
+    );
+    return;
+  }
+  flashComponent(component);
+}
+
+/** Custom action dispatched from the DevTools "Dispatcher" panel. The payload
+ * is the action the dev typed — usually a JSON string. */
+function handleCustomAction(
+  connection: DevToolsConnection,
+  payload: unknown,
+): void {
+  let action: DevToolsAction | undefined;
+  if (payload !== null && typeof payload === 'object') {
+    action = payload as DevToolsAction;
+  } else if (typeof payload === 'string') {
+    try {
+      action = JSON.parse(payload) as DevToolsAction;
+    } catch (e) {
+      if (IS_DEV_MODE) {
+        console.warn('[gxt redux-devtools] failed to parse dispatched action', e);
+      }
+      connection.error('gxt: failed to parse dispatched action');
+      return;
+    }
+  }
+  if (action === undefined || typeof action.type !== 'string') {
+    return;
+  }
+  switch (action.type) {
+    case 'SET':
+      handleSetAction(connection, action);
+      break;
+    case 'HIGHLIGHT':
+      handleHighlightAction(connection, action);
+      break;
+    default:
+      // Unknown custom action — ignore (it isn't ours).
+      break;
+  }
+}
+
 function handleDevToolsMessage(
   connection: DevToolsConnection,
   message: DevToolsMessage,
 ): void {
+  // Custom actions from the Dispatcher panel arrive as `type: 'ACTION'`.
+  if (message.type === 'ACTION') {
+    handleCustomAction(connection, (message as { payload?: unknown }).payload);
+    return;
+  }
   if (message.type !== 'DISPATCH' || !message.payload) {
     return;
   }
@@ -599,12 +1244,16 @@ function handleDevToolsMessage(
       const parsed = parseDevToolsState(connection, message.state);
       if (parsed !== undefined) {
         restoreState(parsed);
+        // Auto-flash the components the jump actually changed (capped/skipped
+        // for huge batches) so the dev sees what moved in the page.
+        flashAffectedComponents(_restoreTouched);
       }
       break;
     }
     case 'RESET':
       // Revert to the state captured when DevTools connected.
       restoreState(_initialSnapshot);
+      flashAffectedComponents(_restoreTouched);
       connection.init(snapshotState());
       break;
     case 'COMMIT':
@@ -675,6 +1324,22 @@ export function enableReduxDevtools(config?: DevToolsConfig): () => void {
     return disableReduxDevtools; // idempotent — already connected
   }
 
+  // Pull gxt-only knobs out of the config so we don't hand them to the
+  // extension's `connect`, and apply them to the snapshot summarizer/denylist.
+  const {
+    maxArrayItems,
+    maxValueBytes,
+    maxValueDepth,
+    cellsDenylist,
+    ...extensionConfig
+  } = config ?? {};
+  _summarize = {
+    maxArrayItems: maxArrayItems ?? DEFAULT_MAX_ARRAY_ITEMS,
+    maxValueBytes: maxValueBytes ?? DEFAULT_MAX_VALUE_BYTES,
+    maxValueDepth: maxValueDepth ?? DEFAULT_MAX_VALUE_DEPTH,
+  };
+  _denyGlobs = compileDenylist(cellsDenylist);
+
   const connection = extension.connect({
     name: 'GXT Reactive State',
     features: {
@@ -691,7 +1356,7 @@ export function enableReduxDevtools(config?: DevToolsConfig): () => void {
     },
     maxAge: 50,
     trace: false,
-    ...config,
+    ...extensionConfig,
   });
 
   _initialSnapshot = snapshotState();
@@ -726,6 +1391,13 @@ export function disableReduxDevtools(): void {
   _connection = null;
   _unsubscribe = null;
   _initialSnapshot = {};
+  // Reset Feature A/B state: summarizer caps, denylist, the reused DOM overlay
+  // (cleaned up here so nothing lingers in the page) and the flash buffer.
+  _summarize = defaultSummarizeOptions();
+  _denyGlobs = [];
+  removeOverlay();
+  _overlayEl = null;
+  _restoreTouched.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/redux-devtools.ts
+++ b/src/core/redux-devtools.ts
@@ -1,0 +1,564 @@
+/**
+ * Redux DevTools browser-extension integration for gxt's reactive core.
+ *
+ * Bridges gxt `Cell`s to the Redux DevTools extension
+ * (`window.__REDUX_DEVTOOLS_EXTENSION__`) so the whole reactive state tree shows
+ * up on the DevTools timeline and supports time-travel debugging: a JUMP in the
+ * monitor restores every tracked cell to its recorded value and re-renders the
+ * bound DOM, WITHOUT re-dispatching back to the monitor.
+ *
+ * Design / cost model
+ * ===================
+ * The feature is strictly DEV-ONLY and browser-only:
+ *   * `enableReduxDevtools()` no-ops (returns a no-op disabler) unless
+ *     `IS_DEV_MODE` is true, a `window` exists, and the extension is installed.
+ *   * The only hot-path touchpoint — `Cell.update()`'s `_devtoolsCellNotifier`
+ *     call — is guarded by `IS_DEV_MODE && notifier !== null`. In a lib /
+ *     production build `IS_DEV_MODE` is inlined to `false`, so that branch (and
+ *     hence every reference that would pull THIS module into the bundle) folds
+ *     away. When DevTools is simply not enabled in dev it costs one predictable
+ *     null check. Result: this whole module tree-shakes out of production
+ *     consumer bundles.
+ *
+ * State source
+ * ============
+ * State is read from the existing dev-only `DEBUG_CELLS` registry (every live
+ * data cell) — no parallel "ALIVE_CELLS" registry is introduced. Each cell is
+ * keyed by a stable, unique `<debugName>#<id>` string.
+ *
+ * Two transports
+ * ==============
+ *  1. `enableReduxDevtools()` — the recommended modern integration. Uses the
+ *     extension's `connect()` API (`init` / `send` / `subscribe`) which handles
+ *     JUMP_TO_STATE / JUMP_TO_ACTION / ROLLBACK / RESET / COMMIT cleanly.
+ *  2. `supportChromeExtension()` + `FreezerMiddleware` — a faithful port of the
+ *     classic Freezer-style redux-store enhancer binding. Kept for parity with
+ *     the original integration and as a lower-level escape hatch; wire it to the
+ *     cell state with `createCellState()`.
+ */
+import {
+  DEBUG_CELLS,
+  applyCellUpdateSync,
+  setDevtoolsCellNotifier,
+  type Cell,
+} from '@/core/reactive';
+
+const noop = () => {};
+
+// ---------------------------------------------------------------------------
+// Public configuration / extension types
+// ---------------------------------------------------------------------------
+
+export interface DevToolsConfig {
+  name?: string;
+  maxAge?: number;
+  serialize?: boolean | { replacer?: (key: string, value: unknown) => unknown };
+  actionsDenylist?: string[];
+  actionsAllowlist?: string[];
+  features?: {
+    pause?: boolean;
+    lock?: boolean;
+    persist?: boolean;
+    export?: boolean | 'custom';
+    import?: boolean | 'custom';
+    jump?: boolean;
+    skip?: boolean;
+    reorder?: boolean;
+    dispatch?: boolean;
+    test?: boolean;
+  };
+  trace?: boolean;
+  traceLimit?: number;
+}
+
+/** Action shape we send to the monitor. */
+export interface DevToolsAction {
+  type: string;
+  [key: string]: unknown;
+}
+
+/** A message delivered to the `connect()` subscriber (e.g. on time-travel). */
+export interface DevToolsMessage {
+  type: string; // 'DISPATCH' | 'ACTION' | 'START' | 'STOP' | ...
+  payload?: { type?: string; [key: string]: unknown };
+  // For DISPATCH/time-travel this is a JSON string of the target state.
+  state?: string;
+}
+
+/** The object returned by `__REDUX_DEVTOOLS_EXTENSION__.connect(config)`. */
+export interface DevToolsConnection {
+  init(state: unknown): void;
+  send(action: DevToolsAction | null, state: unknown): void;
+  subscribe(listener: (message: DevToolsMessage) => void): (() => void) | void;
+  unsubscribe(): void;
+  error(message: string): void;
+}
+
+/** The extension global: an enhancer factory that also carries `connect`. */
+export interface ReduxDevToolsExtension {
+  (config?: DevToolsConfig): (createStore: any) => any;
+  connect(config?: DevToolsConfig): DevToolsConnection;
+  disconnect?: () => void;
+}
+
+declare global {
+  interface Window {
+    __REDUX_DEVTOOLS_EXTENSION__?: ReduxDevToolsExtension;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cell <-> state bridge (shared by both transports)
+// ---------------------------------------------------------------------------
+
+// Guard that suppresses re-dispatch while we push state back into the cells
+// during time-travel. The restore path already bypasses `Cell.update` (it uses
+// `applyCellUpdateSync`), so the notifier never fires during restore — this is
+// belt-and-braces in case a subscriber re-enters `update()` synchronously.
+let isRestoringState = false;
+
+/** Whether the integration is currently restoring cell state (time-travel). */
+export function isDevToolsRestoring(): boolean {
+  return isRestoringState;
+}
+
+/**
+ * Stable, unique key for a cell. `id` guarantees uniqueness; the debug name is
+ * prepended for human readability in the monitor.
+ */
+function cellKey(cell: Cell): string {
+  const name = (cell as { _debugName?: string })._debugName;
+  return name ? `${name}#${cell.id}` : `cell#${cell.id}`;
+}
+
+/** Snapshot every live data cell into a plain serializable object. */
+export function snapshotCells(): Record<string, unknown> {
+  const state: Record<string, unknown> = {};
+  DEBUG_CELLS.forEach((cell) => {
+    state[cellKey(cell)] = (cell as { _value: unknown })._value;
+  });
+  return state;
+}
+
+/**
+ * Restore cell values from a previously snapshotted state (time-travel).
+ *
+ * Uses `applyCellUpdateSync` so subscribers re-render synchronously and the
+ * DevTools-notifier hook in `Cell.update` is NOT triggered (no re-dispatch).
+ * The `isRestoringState` guard additionally neutralises any synchronous
+ * write-back a subscriber might perform.
+ */
+export function restoreCells(
+  state: Record<string, unknown> | null | undefined,
+): void {
+  if (!state || typeof state !== 'object') {
+    return;
+  }
+  const byKey = new Map<string, Cell>();
+  DEBUG_CELLS.forEach((cell) => byKey.set(cellKey(cell), cell));
+  isRestoringState = true;
+  try {
+    for (const key in state) {
+      const cell = byKey.get(key);
+      if (cell !== undefined) {
+        applyCellUpdateSync(cell as Cell<unknown>, state[key]);
+      }
+    }
+  } finally {
+    isRestoringState = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Modern `connect()` transport — the recommended integration
+// ---------------------------------------------------------------------------
+
+let _connection: DevToolsConnection | null = null;
+let _unsubscribe: (() => void) | null = null;
+let _initialSnapshot: Record<string, unknown> = {};
+
+// Coalesce per-microtask: one "action" per synchronous batch of cell updates
+// (mirrors gxt's own scheduleRevalidate batching) so a 1000-row update is a
+// single timeline entry instead of 1000.
+const _changedKeys = new Set<string>();
+let _sendScheduled = false;
+
+function scheduleDevtoolsSend(cell: Cell): void {
+  if (isRestoringState || _connection === null) {
+    return;
+  }
+  _changedKeys.add(cellKey(cell));
+  if (_sendScheduled) {
+    return;
+  }
+  _sendScheduled = true;
+  queueMicrotask(() => {
+    _sendScheduled = false;
+    if (_connection === null) {
+      _changedKeys.clear();
+      return;
+    }
+    const changed = Array.from(_changedKeys);
+    _changedKeys.clear();
+    _connection.send({ type: 'cells:changed', changed }, snapshotCells());
+  });
+}
+
+function handleDevToolsMessage(
+  connection: DevToolsConnection,
+  message: DevToolsMessage,
+): void {
+  if (message.type !== 'DISPATCH' || !message.payload) {
+    return;
+  }
+  const action = message.payload.type;
+  switch (action) {
+    case 'JUMP_TO_STATE':
+    case 'JUMP_TO_ACTION':
+    case 'ROLLBACK': {
+      const parsed = parseDevToolsState(connection, message.state);
+      if (parsed !== undefined) {
+        restoreCells(parsed);
+      }
+      break;
+    }
+    case 'RESET':
+      // Revert to the state captured when DevTools connected.
+      restoreCells(_initialSnapshot);
+      connection.init(snapshotCells());
+      break;
+    case 'COMMIT':
+      // Make the current state the new committed base.
+      _initialSnapshot = snapshotCells();
+      connection.init(_initialSnapshot);
+      break;
+    case 'IMPORT_STATE': {
+      const lifted = message.payload.nextLiftedState as
+        | { computedStates?: Array<{ state?: Record<string, unknown> }> }
+        | undefined;
+      const computed = lifted?.computedStates;
+      if (Array.isArray(computed) && computed.length > 0) {
+        restoreCells(computed[computed.length - 1]!.state);
+      }
+      break;
+    }
+    default:
+      // PAUSE_RECORDING / LOCK_CHANGES / etc. — nothing to restore.
+      break;
+  }
+}
+
+function parseDevToolsState(
+  connection: DevToolsConnection,
+  state: string | undefined,
+): Record<string, unknown> | undefined {
+  if (typeof state !== 'string') {
+    // Some monitors deliver an already-parsed object.
+    return state === undefined ? undefined : (state as Record<string, unknown>);
+  }
+  try {
+    return JSON.parse(state) as Record<string, unknown>;
+  } catch (e) {
+    // Never swallow: surface to the dev console AND the extension monitor.
+    if (IS_DEV_MODE) {
+      console.error('[gxt redux-devtools] failed to parse time-travel state', e);
+    }
+    connection.error('gxt: failed to parse time-travel state');
+    return undefined;
+  }
+}
+
+/**
+ * Connect gxt's reactive state to the Redux DevTools extension.
+ *
+ * Opt-in, dev-only, browser-only. Returns a disabler that disconnects the
+ * integration and removes the cell-update hook. Safe to call when the extension
+ * is absent, in SSR, or in production — it simply returns a no-op disabler.
+ *
+ * @example
+ *   import { enableReduxDevtools } from '@lifeart/gxt';
+ *   if (IS_DEV_MODE) enableReduxDevtools();
+ */
+export function enableReduxDevtools(config?: DevToolsConfig): () => void {
+  // Production / lib builds: this whole body folds away (IS_DEV_MODE === false).
+  if (!IS_DEV_MODE) {
+    return noop;
+  }
+  if (typeof window === 'undefined') {
+    return noop; // SSR / non-browser
+  }
+  const extension = window.__REDUX_DEVTOOLS_EXTENSION__;
+  if (!extension || typeof extension.connect !== 'function') {
+    return noop; // extension not installed
+  }
+  if (_connection !== null) {
+    return disableReduxDevtools; // idempotent — already connected
+  }
+
+  const connection = extension.connect({
+    name: 'GXT Reactive State',
+    features: {
+      pause: true,
+      lock: false,
+      persist: false,
+      export: true,
+      import: true,
+      jump: true,
+      skip: true,
+      reorder: false,
+      dispatch: true,
+      test: false,
+    },
+    maxAge: 50,
+    trace: false,
+    ...config,
+  });
+
+  _initialSnapshot = snapshotCells();
+  connection.init(_initialSnapshot);
+  const unsub = connection.subscribe((message) =>
+    handleDevToolsMessage(connection, message),
+  );
+
+  _connection = connection;
+  _unsubscribe = typeof unsub === 'function' ? unsub : null;
+
+  // Install the reactive-core hot-path notifier (zero-cost when not installed).
+  setDevtoolsCellNotifier(scheduleDevtoolsSend);
+
+  return disableReduxDevtools;
+}
+
+/** Disconnect the DevTools integration and remove the cell-update hook. */
+export function disableReduxDevtools(): void {
+  setDevtoolsCellNotifier(null);
+  _changedKeys.clear();
+  _sendScheduled = false;
+  if (_unsubscribe !== null) {
+    _unsubscribe();
+  } else if (_connection !== null) {
+    _connection.unsubscribe();
+  }
+  _connection = null;
+  _unsubscribe = null;
+}
+
+// ---------------------------------------------------------------------------
+// Classic Freezer-style enhancer transport (faithful port)
+//   Inspired by https://www.npmjs.com/package/freezer-redux-devtools
+// ---------------------------------------------------------------------------
+
+const ActionTypes = {
+  INIT: '@@INIT',
+  PERFORM_ACTION: 'PERFORM_ACTION',
+  TOGGLE_ACTION: 'TOGGLE_ACTION',
+} as const;
+
+type Listener = () => void;
+
+export interface FreezerState {
+  get(): Record<string, unknown>;
+  set(state: any): void;
+  skipDispatch: number;
+  trigger(eventName: string, ...args: unknown[]): void;
+  on(
+    eventName: string,
+    callback: (this: FreezerState, reactionName: string, ...args: unknown[]) => void,
+  ): void;
+}
+
+/**
+ * A `FreezerState` backed by gxt cells — read snapshots from `DEBUG_CELLS`,
+ * write restores through `restoreCells`. Use with `supportChromeExtension` for
+ * the enhancer-based transport.
+ */
+export function createCellState(): FreezerState {
+  return {
+    get() {
+      return snapshotCells();
+    },
+    set(state: Record<string, unknown>) {
+      restoreCells(state);
+    },
+    skipDispatch: 0,
+    trigger() {
+      /* no-op: gxt cells push via the connect transport, not freezer events */
+    },
+    on() {
+      /* no-op */
+    },
+  };
+}
+
+/**
+ * Redux middleware that makes a `FreezerState` and the DevTools talk to each
+ * other (faithful port of the freezer-redux-devtools middleware).
+ */
+export function FreezerMiddleware(State: FreezerState) {
+  return function (next: any) {
+    return function StoreEnhancer(_someReducer: any, _someState: any) {
+      const commitedState = State.get();
+      let lastAction: string | number = 0;
+
+      // The freezer reducer triggers events on any devtool action to keep the
+      // freezer's and the devtool's states in sync.
+      const reducer = function (
+        state: any,
+        action: { type: string; arguments?: unknown[]; id?: number },
+      ) {
+        if (action.type === ActionTypes.INIT) {
+          State.set(state || commitedState);
+        } else if (lastAction !== ActionTypes.PERFORM_ACTION) {
+          // Flag that we're dispatching so we don't dispatch the same action
+          // twice.
+          State.skipDispatch = 1;
+          State.trigger(action.type, ...(action.arguments || []));
+        }
+        // The only valid state is the freezer's one.
+        return State.get();
+      };
+
+      const store = next(reducer);
+      const liftedStore = store.liftedStore;
+      const dtStore = store.devToolsStore || store.liftedStore;
+
+      if (dtStore) {
+        const toolsDispatcher = dtStore.dispatch;
+
+        // Override the devTools store's dispatch to set committedState on a
+        // Commit action.
+        dtStore.dispatch = function (action: { type: string; id?: number }) {
+          lastAction = action.type;
+
+          // With redux-devtools we must reset the state to the last valid one
+          // manually.
+          if (liftedStore && lastAction === ActionTypes.TOGGLE_ACTION) {
+            const states = dtStore.getState().computedStates;
+            const nextValue = states[action.id! - 1].state;
+            State.set(nextValue);
+          }
+
+          toolsDispatcher.call(dtStore, action);
+          return action;
+        };
+      }
+
+      // Forward any freezer event to the devTools.
+      State.on('afterAll', function (
+        this: FreezerState,
+        reactionName: string,
+        ...restArgs: unknown[]
+      ) {
+        if (reactionName === 'update') {
+          return;
+        }
+        if (this.skipDispatch) {
+          this.skipDispatch = 0;
+        } else {
+          store.dispatch({ type: reactionName, args: restArgs });
+        }
+      });
+
+      return store;
+    };
+  };
+}
+
+/**
+ * Bind a `FreezerState` to the Redux DevTools extension via the enhancer API.
+ */
+export function supportChromeExtension(
+  State: FreezerState,
+  config?: DevToolsConfig,
+) {
+  const devtools = window.__REDUX_DEVTOOLS_EXTENSION__
+    ? window.__REDUX_DEVTOOLS_EXTENSION__(config)
+    : (f: any) => f;
+
+  return compose(FreezerMiddleware(State), devtools)(createStore)(
+    (state: any) => state,
+  );
+}
+
+/**
+ * Creates a minimal valid redux store. Copied directly from redux.
+ * https://github.com/reduxjs/redux
+ */
+function createStore(reducer: any, initialState?: any) {
+  if (typeof reducer !== 'function') {
+    throw new Error('Expected the reducer to be a function.');
+  }
+
+  let currentReducer = reducer;
+  let currentState = initialState;
+  const listeners: Listener[] = [];
+  let isDispatching = false;
+  const ReduxActionTypes = {
+    INIT: '@@redux/INIT',
+  };
+
+  function getState() {
+    return currentState;
+  }
+
+  function subscribe(listener: Listener) {
+    listeners.push(listener);
+    let isSubscribed = true;
+
+    return function unsubscribe() {
+      if (!isSubscribed) {
+        return;
+      }
+      isSubscribed = false;
+      const index = listeners.indexOf(listener);
+      listeners.splice(index, 1);
+    };
+  }
+
+  function dispatch(action: { type: string }) {
+    if (typeof action.type === 'undefined') {
+      throw new Error(
+        'Actions may not have an undefined "type" property. Have you misspelled a constant?',
+      );
+    }
+    if (isDispatching) {
+      throw new Error('Reducers may not dispatch actions.');
+    }
+
+    try {
+      isDispatching = true;
+      currentState = currentReducer(currentState, action);
+    } finally {
+      isDispatching = false;
+    }
+
+    listeners.slice().forEach((listener) => listener());
+    return action;
+  }
+
+  function replaceReducer(nextReducer: any) {
+    currentReducer = nextReducer;
+    dispatch({ type: ReduxActionTypes.INIT });
+  }
+
+  // When a store is created, an "INIT" action is dispatched so that every
+  // reducer returns its initial state, populating the initial state tree.
+  dispatch({ type: ReduxActionTypes.INIT });
+
+  return {
+    dispatch,
+    subscribe,
+    getState,
+    replaceReducer,
+  };
+}
+
+/**
+ * Composes single-argument functions from right to left.
+ * Copied directly from redux. https://github.com/reduxjs/redux
+ */
+function compose(...funcs: Array<(arg: any) => any>) {
+  return function (arg: any) {
+    return funcs.reduceRight((composed, f) => f(composed), arg);
+  };
+}


### PR DESCRIPTION
# Redux DevTools integration for gxt

Bridges gxt's reactive core to the [Redux DevTools browser extension](https://github.com/reduxjs/redux-devtools) (`window.__REDUX_DEVTOOLS_EXTENSION__`) for state inspection and time-travel debugging. **Opt-in, dev-only, browser-only** — the whole feature tree-shakes out of production/lib builds (gated on `IS_DEV_MODE`).

```ts
import { enableReduxDevtools } from '@lifeart/gxt';
if (IS_DEV_MODE) enableReduxDevtools();
```

## DX-friendly, tree-shaped state

State **mirrors the gxt component tree** — human-readable and diff-friendly, not a flat cell dump:

```jsonc
{
  "Application#1": {
    "Benchmark#7": {
      "$state": { "_selected": 5, "_items": [ /* ... */ ] },
      "Row#42": { "$state": { "label": "foo" } },
      "Row#43": { "$state": { "label": "bar" } }
    }
  },
  "$globals": { "theme#3": "dark" }
}
```

- Each node is labelled `<ClassName>#<id>`. The id is stable while the component is alive, so **key paths stay stable across snapshots** and the extension's diff view highlights exactly the changed leaf.
- A node's own data cells live under `$state` (property name → value, from `cellsMap.get(node)`); child components nest directly under it.
- Cells with no live tree owner (module-level `cell()`, list-item cells, `@tracked` on plain objects) go in a separate **`$globals`** bucket.
- Derived `MergedCell`s recompute from deps and aren't restorable, so they're **omitted** (`cellsMap` only holds data cells).

## Informative action timeline

Each timeline entry's `type` tells the story of what changed:

| Scenario | Example `type` |
| --- | --- |
| one change | `set Benchmark._selected` |
| several cells, one component | `update Row#42 (3 cells)` |
| several components | `update Row#42 +2 more (3 cells)` |
| large batch | `update: 100 cells` |

…plus a structured payload `{ count, changes: [{ path, from, to }] }` (old→new captured cheaply). Per-microtask coalescing is preserved, so a 1000-row update is a single, still-informative entry.

## Big-value summaries (new)

A large cell value (e.g. a list's `_items: Array(1000)`) would otherwise dump every element into the state inspector and bloat every diff. Values over a configurable size cap are replaced **in the snapshot only** with a compact summary marker (reusing gxt's existing `inspect()` formatter for the preview):

```jsonc
// _items: Array(1000)  ->
{ "$summary": "Array(1000)", "$len": 1000, "$preview": [0, 1, 2, 3, 4] }
```

Big objects → `{ "$summary": "Foo(120 keys)", "$keys": 120, "$preview": {…} }`; big strings → `{ "$summary": "String(40000)", "$len": 40000, "$preview": "…" }`.

Config (all gxt-only; stripped before reaching the extension): `maxArrayItems` (50), `maxValueBytes` (8192), `maxValueDepth` (4).

**Restore trade (documented):** a summarized value is *not* the real value, so `restoreState` **skips** any `$summary` marker — it never writes the marker back into a cell (which would corrupt it). A summarized big collection becomes **inspect-only**: a JUMP leaves its live runtime value untouched. Cells **under** the caps keep their real value and stay **fully time-travel-restorable**. Raise the caps to make a specific collection restorable again. Summarization is snapshot-time only — the `Cell.update` hot path is unchanged.

## Excluding noisy cells — `cellsDenylist` (new)

In the spirit of the extension's `actionsDenylist`, `cellsDenylist` is a list of path globs/prefixes (e.g. `['*.animationFrame', 'Benchmark#*._items']`) whose cells are excluded from the snapshot **and** the action timeline entirely — for high-frequency / noisy cells. `*` matches any run of characters; a prefix matches any deeper path. A batch consisting *only* of denylisted cells emits no timeline entry at all.

## Live edit + DOM highlight — Dispatcher actions (new)

The DevTools "Dispatcher" panel can send custom actions to the page (`type: 'ACTION'`):

- **`{ type: 'SET', path, value }`** — resolves `path` against the live tree (same `<Class>#<id>` matching as time-travel) and writes the cell via `applyCellUpdateSync` under the restore guard, so the app re-renders and the write does **not** echo back as a new action. `value` arrives as a string and is `JSON.parse`d (string fallback). Unresolvable path / type mismatch is surfaced via dev `console.warn` **and** the monitor error channel — never silently swallowed.
- **`{ type: 'HIGHLIGHT', path }`** — flashes a reused overlay div over the component's bounds (`getBounds(component)` — the same bridge the Ember-inspector uses; `scrollIntoView` if offscreen), auto-removed after ~1s and cleaned up on `disableReduxDevtools()`.
- **Auto-flash on change** — a `SET` or a time-travel `JUMP` briefly flashes the touched component(s) with the same overlay so you SEE what moved. Debounced via the single overlay element and **skipped** when a change touches more than a handful of components (a 1000-row batch never strobes). Ordinary app-driven updates aren't flashed.

> **Honest protocol limitation.** Redux DevTools does **not** notify the page when you click a node in the state-tree inspector, so true "select-in-tree → highlight" is **impossible**. This PR delivers the explicit `HIGHLIGHT` dispatch action + auto-flash-on-change instead — there is no click-to-highlight.

All overlay/DOM code is browser- and dev-only (`typeof document !== 'undefined'` + `IS_DEV_MODE`) and tree-shakes out of the lib.

## Leak by construction

The per-component path walks the **live** `TREE`/`CHILD`/`PARENT` + `cellsMap`, never the strong `DEBUG_CELLS` set. Components removed from `TREE` by their destructor are **absent by construction** — no retention, no dead-component soup. `$globals` excludes tree-owned cells *and* cells owned by components no longer in `TREE`, so a torn-down component leaves zero trace anywhere. The integration holds nothing across snapshots (the coalescing buffer clears every flush; `disableReduxDevtools()` detaches everything — including the reused overlay — with zero residue).

## Redo / forward time-travel

`restoreState` navigates the tree-shaped target in parallel with the live tree, matching nodes by stable `#<id>`, and applies each leaf via `applyCellUpdateSync` under the `isDevToolsRestoring()` guard. A JUMP to **any** index works whether you step backward (undo) or **forward (redo)** — no re-dispatch loop. Handles `JUMP_TO_STATE` / `JUMP_TO_ACTION` / `ROLLBACK` / `RESET` / `COMMIT` / `IMPORT_STATE` (COMMIT resets the baseline to current; RESET restores the committed/initial snapshot).

## Invariants

- **Zero-cost when off / in prod.** Hot-path guard **unchanged**: `IS_DEV_MODE && _devtoolsCellNotifier !== null && changed`. Summarization, denylist filtering and DOM flashing all happen only at snapshot/dispatch time — never on `Cell.update`.
- **Tree-shakable.** Verified by building the lib and bundling a consumer that imports **and calls** `enableReduxDevtools` (consumer `define: IS_DEV_MODE=false`): the result is a **111-byte no-op stub** with **0** feature markers (`$summary` / `HIGHLIGHT` / `getBounds` / overlay / `__REDUX_DEVTOOLS_EXTENSION__` / `restoreState` / `snapshotState`).
- Idiomatic gxt, no silent catches.

## Caveats (honest)

- `$globals` is sourced from `DEBUG_CELLS` (the one pre-existing dev-only unbounded set); the bucket is bounded relative to the old flat dump but can still grow over a long session.
- **Id reuse:** node labels use the component id, which gxt recycles via `releaseId`. A state captured for a destroyed component whose id was later reused could restore onto the wrong node. Restores onto stable (alive) components — the common case — are exact.
- **Big collections are inspect-only:** an array over `maxArrayItems` (or any value over `maxValueBytes`) is summarized and therefore not time-travel-restorable (its live value is kept intact, never corrupted). Raise the caps to restore a specific one.
- **happy-dom bounds:** `getBounds` / `getBoundingClientRect` return zeros in happy-dom, so the highlight overlay is 0-size there — the overlay lifecycle (create → auto-remove) still runs correctly; in a real browser it draws over the component's real bounds.

## Verification

- `npx tsc --noEmit` clean.
- Full suite green: **3921 passed / 26 skipped** (`rm -rf dist; npx vitest run`) — matches the 3921 baseline; the +6 new tests are dev-only and show as skips in standard mode.
- Dev-mode functional suite: **35 passed** (`npx vitest run --mode development src/core/redux-devtools.test.ts`).
- New tests: big-array summary shape + small inspector value, under-cap full value, restore-skip (big cell keeps real runtime value after JUMP — no corruption), denylist absence + no timeline entry, SET live-write/re-render/no-echo + bad-path warn, HIGHLIGHT + SET-auto-flash overlay lifecycle.
- Tree-shake probe: lib built (`IS_DEV_MODE`→false), consumer bundle = **111 bytes, 0 markers**; `dist` removed afterwards (package-json-contract test asserts against dist).
- Perf: `Cell.update` guard untouched — no hot-path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
