### PR TITLE
Land Ember-integration seams: (hash)/(array) identity memo, {{#each}} row-item cell tap, each/if host hooks

### DIFF
--- a/plugins/compiler/__tests__/compile.test.ts
+++ b/plugins/compiler/__tests__/compile.test.ts
@@ -2741,10 +2741,28 @@ describe('Hash helper advanced', () => {
     expect(result.code).toContain('multiply');
   });
 
-  test('nested hash helpers wrap all levels', () => {
+  test('nested hash helpers wrap all levels (Ember dialect memoizes nested hash)', () => {
+    // The $__cached identity memo is gated to the Ember dialect
+    // (WITH_EMBER_INTEGRATION), so opt the raw `compile()` into it here.
+    const result = compile('{{log (hash outer=(hash inner=1))}}', {
+      flags: { IS_GLIMMER_COMPAT_MODE: true, WITH_EMBER_INTEGRATION: true },
+    });
+    expect(result.code).toContain(SYMBOLS.HASH);
+    // Both outer and inner should be lazily wrapped in getters. A nested
+    // (hash)/(array) prop is additionally memoized through $__cached so reading
+    // `outerHash.outer` yields an identity-stable reference (classic
+    // compute-ref contract); plain literal props stay as bare getters.
+    expect(result.code).toContain('outer: $__cached(() =>');
+    expect(result.code).toContain('inner: () =>');
+  });
+
+  test('nested hash helpers are NOT memoized without WITH_EMBER_INTEGRATION (byte-identical compat)', () => {
+    // Default `compile()` is non-Ember glimmer-compat (WITH_EMBER_INTEGRATION
+    // off). The $__cached identity memo must NOT fire — gxt-standalone and
+    // plain glimmer-compat output stay byte-identical (bare `() =>` getters).
     const result = compile('{{log (hash outer=(hash inner=1))}}');
     expect(result.code).toContain(SYMBOLS.HASH);
-    // Both outer and inner should have getters
+    expect(result.code).not.toContain('$__cached');
     expect(result.code).toContain('outer: () =>');
     expect(result.code).toContain('inner: () =>');
   });

--- a/plugins/compiler/__tests__/each-item-cell-tap.test.ts
+++ b/plugins/compiler/__tests__/each-item-cell-tap.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect } from 'vitest';
+import { compile } from '../compile';
+import { SYMBOLS } from '../serializers';
+
+/**
+ * Ember-dialect {{#each}} row-item reactive tap.
+ *
+ * A reactive member read whose head is a block param (the {{#each as |item|}}
+ * row item, or a component-yielded value) is rewritten at compile time into a
+ * host `$__cellFor(item, 'key').value` tap, so the read stays reactive on
+ * item-property mutation WITHOUT a runtime per-row tracking Proxy. Gated by
+ * WITH_EMBER_INTEGRATION + IS_GLIMMER_COMPAT_MODE; gxt-standalone compilation
+ * is byte-identical.
+ */
+describe('{{#each}} row-item cell tap (WITH_EMBER_INTEGRATION)', () => {
+  const ember = {
+    flags: { IS_GLIMMER_COMPAT_MODE: true, WITH_EMBER_INTEGRATION: true },
+  };
+  const compat = { flags: { IS_GLIMMER_COMPAT_MODE: true } };
+
+  test('top-level single-segment read taps the host cell', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{item.text}}{{/each}}',
+      ember
+    ).code;
+    expect(code).toContain(`${SYMBOLS.CELL_FOR}(item, "text")`);
+    // No bare `item.text` member read remains for the tapped position.
+    expect(code).not.toMatch(/\(\)\s*=>\s*item\.text\b/);
+  });
+
+  test('standalone compat compilation is unchanged (bare read, no tap)', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{item.text}}{{/each}}',
+      compat
+    ).code;
+    expect(code).toContain('() => item.text');
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+  });
+
+  test('WITHOUT WITH_EMBER_INTEGRATION there is no tap', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{item.text}}{{/each}}',
+      { flags: { IS_GLIMMER_COMPAT_MODE: true, WITH_EMBER_INTEGRATION: false } }
+    ).code;
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+    expect(code).toContain('() => item.text');
+  });
+
+  test('deep path taps each reactive segment', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{item.v.x}}{{/each}}',
+      ember
+    ).code;
+    // Nested: $__cellFor($__cellFor(item, "v"), "x")
+    expect(code).toContain(
+      `${SYMBOLS.CELL_FOR}(${SYMBOLS.CELL_FOR}(item, "v"), "x")`
+    );
+  });
+
+  test('the {{#each}} index param is never tapped (it is a reactive Cell)', () => {
+    const code = compile(
+      '{{#each this.items as |item idx|}}{{idx.foo}}{{/each}}',
+      ember
+    ).code;
+    // idx is a Cell read via `.value`; a member read on it stays a plain read.
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+    expect(code).toContain('idx.foo');
+  });
+
+  test('the item param is still tapped when an index param is present', () => {
+    const code = compile(
+      '{{#each this.items as |item idx|}}{{item.text}}-{{idx}}{{/each}}',
+      ember
+    ).code;
+    expect(code).toContain(`${SYMBOLS.CELL_FOR}(item, "text")`);
+    // The bare index still reads through `.value`.
+    expect(code).toContain('idx.value');
+  });
+
+  test('bare block-param read ({{item}}) is left untapped', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{item}}{{/each}}',
+      ember
+    ).code;
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+    expect(code).toContain('() => item');
+  });
+
+  test('numeric / bracket index segments fall back to the plain read', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{item.list.0.name}}{{/each}}',
+      ember
+    ).code;
+    // Array-index reactivity is owned by gxt's tracked-array machinery, so the
+    // tap bails the whole path to the plain optional-chained read.
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+    expect(code).toContain('item.list?.["0"]?.name');
+  });
+
+  test('component-yielded block params are tapped (raw values)', () => {
+    const code = compile('<Comp as |a b|>{{a.text}}-{{b.label}}</Comp>', {
+      flags: { IS_GLIMMER_COMPAT_MODE: true, WITH_EMBER_INTEGRATION: true },
+      bindings: new Set(['Comp']),
+    }).code;
+    expect(code).toContain(`${SYMBOLS.CELL_FOR}(a, "text")`);
+    expect(code).toContain(`${SYMBOLS.CELL_FOR}(b, "label")`);
+  });
+
+  test('{{#let}} bindings are NOT tapped (they are thunks, not raw values)', () => {
+    const code = compile(
+      '{{#let this.foo as |y|}}{{y.text}}{{/let}}',
+      ember
+    ).code;
+    // let-binding `y` is emitted as a getter thunk `() => this.foo`; tapping it
+    // would be wrong, so it is excluded.
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+    expect(code).toContain('y().text');
+  });
+
+  test('recycled rows (key="@recycle") are NOT tapped (state-object channel)', () => {
+    // Recycled rows bind `item` to a per-row state object whose props are
+    // forwarding accessors over a re-pointable holder; a cellFor tap would
+    // clobber that reference-swap channel.
+    const code = compile(
+      '{{#each this.items key="@recycle" as |item|}}<td>{{item.label}}</td>{{/each}}',
+      ember
+    ).code;
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+    expect(code).toContain('item.label');
+  });
+
+  test('this.* and @arg reads are not tapped', () => {
+    const code = compile(
+      '{{#each this.items as |item|}}{{this.title}}-{{@label}}{{/each}}',
+      ember
+    ).code;
+    // Heads that are not block params keep their existing emission.
+    expect(code).not.toContain(SYMBOLS.CELL_FOR);
+  });
+});

--- a/plugins/compiler/serializers/control.ts
+++ b/plugins/compiler/serializers/control.ts
@@ -240,7 +240,7 @@ function buildEach(
 
   // Build the callback body with index replacement
   // Pass all param names so they can be tracked as known bindings during serialization
-  const bodyExpr = buildEachBody(ctx, control.children, newCtxName, paramNames, hasStable);
+  const bodyExpr = buildEachBody(ctx, control.children, newCtxName, paramNames, hasStable, isRecycled);
 
   // Static-block fast path (RESEARCH_LIST_TRACKING_OPTIMIZATION.md §2.A1/§4):
   // when the body is a single qualifying inline element, ALSO emit a
@@ -258,9 +258,13 @@ function buildEach(
     // Same scope frame discipline as buildEachBody, so slot-value expressions
     // resolve block params exactly like the normal body emission.
     ctx.scopeTracker.enterScope('control-block');
-    for (const param of paramNames) {
-      ctx.scopeTracker.addBinding(param, { kind: 'block-param', name: param });
-    }
+    paramNames.forEach((param, i) => {
+      ctx.scopeTracker.addBinding(param, {
+        kind: 'block-param',
+        name: param,
+        isEachIndex: i === 1,
+      });
+    });
     let valueExprs = buildStaticBlockValueExprs(ctx, staticBlockParts, newCtxName);
     ctx.scopeTracker.exitScope();
     if (hasIndex) {
@@ -373,7 +377,8 @@ function buildEachBody(
   children: readonly HBSChild[],
   ctxName: string,
   paramNames: string[],
-  hasStable: boolean
+  hasStable: boolean,
+  isRecycled = false
 ): JSExpression {
   const indexParam = paramNames[1] ?? '$index';
   const usesIndex = childrenUseIndex(children, indexParam);
@@ -381,9 +386,19 @@ function buildEachBody(
   // Add block params in a dedicated scope frame so nested each/if blocks with
   // matching block-param names shadow rather than clobber outer bindings.
   ctx.scopeTracker.enterScope('control-block');
-  for (const param of paramNames) {
-    ctx.scopeTracker.addBinding(param, { kind: 'block-param', name: param });
-  }
+  paramNames.forEach((param, i) => {
+    ctx.scopeTracker.addBinding(param, {
+      kind: 'block-param',
+      name: param,
+      // The 2nd each param is the reactive index Cell (read via `.value`),
+      // not a raw value — exclude it from the row-item cell tap.
+      isEachIndex: i === 1,
+      // Recycled rows (key="@recycle") bind to a per-row STATE object whose
+      // props are forwarding accessors over a re-pointable holder; a cellFor
+      // tap would clobber that channel, so recycled params are never tapped.
+      recycledRow: isRecycled,
+    });
+  });
 
   const childCtxName = hasStable ? ctxName : nextCtxName(ctx);
   const childExprs = buildChildrenExprs(ctx, children, childCtxName);

--- a/plugins/compiler/serializers/symbols.ts
+++ b/plugins/compiler/serializers/symbols.ts
@@ -77,6 +77,10 @@ export const SYMBOLS = {
   // Identity memoization wrapper for (hash)/(array). Emitted around the arg
   // getter so the produced object/array reference stays stable across reads.
   CACHED: '$__cached',
+  // Ember-dialect {{#each}} row-item reactive tap. Emitted by the value
+  // serializer for a member read whose head is a block param, gated by
+  // WITH_EMBER_INTEGRATION + IS_GLIMMER_COMPAT_MODE.
+  CELL_FOR: '$__cellFor',
 
   // Unstable child wrapper
   UCW: '$_ucw',

--- a/plugins/compiler/serializers/symbols.ts
+++ b/plugins/compiler/serializers/symbols.ts
@@ -74,6 +74,9 @@ export const SYMBOLS = {
   FN: '$__fn',
   DEBUGGER: '$__debugger',
   LOG: '$__log',
+  // Identity memoization wrapper for (hash)/(array). Emitted around the arg
+  // getter so the produced object/array reference stays stable across reads.
+  CACHED: '$__cached',
 
   // Unstable child wrapper
   UCW: '$_ucw',

--- a/plugins/compiler/serializers/value.ts
+++ b/plugins/compiler/serializers/value.ts
@@ -248,6 +248,29 @@ export function buildPathExpression(
     return buildLiteral(staticLiteral, value.sourceRange);
   }
 
+  // Ember-dialect {{#each}} row-item reactive tap.
+  //
+  // A member read whose head is a block param — `{{item.text}}` inside
+  // `{{#each items as |item|}}` — is rewritten to a host cell tap
+  // `$__cellFor(item, "text")` so the read stays reactive on item-property
+  // mutation WITHOUT wrapping every row item in a runtime tracking Proxy
+  // (the ember-side `wrapEachItemForTracking`). Deep paths tap each segment:
+  // `{{item.v.x}}` → `$__cellFor($__cellFor(item, "v"), "x")`.
+  //
+  // Gated to the Ember dialect (WITH_EMBER_INTEGRATION + IS_GLIMMER_COMPAT_MODE)
+  // so gxt-standalone compilation is byte-identical. Same wrap-in-getter
+  // discipline as the surrounding path emission.
+  if (
+    ctx.flags.IS_GLIMMER_COMPAT_MODE &&
+    ctx.flags.WITH_EMBER_INTEGRATION &&
+    !value.isArg
+  ) {
+    const tap = buildBlockParamCellTap(ctx, value);
+    if (tap) {
+      return wrapInGetter ? B.reactiveGetter(tap, value.sourceRange) : tap;
+    }
+  }
+
   let pathExpr = buildPathBase(ctx, value);
 
   if (
@@ -341,6 +364,84 @@ function buildPathBase(
       : B.member(expr, name, undefined, range);
   }
 
+  return expr;
+}
+
+/**
+ * Decompose a path into ordered segments (head + members), preferring the
+ * lowered `parts` (which carry sourcemap ranges) and falling back to splitting
+ * the dotted expression. Returns null for shapes the row-item tap must not
+ * touch (bracket / numeric-index / optional-chaining access).
+ */
+function getPathSegments(
+  value: PathValue
+): Array<{ name: string; range?: SourceRange }> | null {
+  // Prefer the lowered `parts`: they carry clean per-segment names (the head
+  // expression string may have `?.` baked in by toOptionalChaining for deep
+  // paths) plus sourcemap ranges. Non-identifier segments (numeric/bracket
+  // index) are rejected by the caller's per-segment identifier check.
+  if (value.parts && value.parts.length > 0) {
+    return value.parts.map((p) => ({ name: p.name, range: p.range }));
+  }
+  // Fallback: split the dotted expression. Bail on bracket / optional-chaining
+  // shapes the row-item tap must not touch.
+  if (value.expression.includes('[') || value.expression.includes('?')) {
+    return null;
+  }
+  const tokens = value.expression.split('.');
+  if (tokens.length === 0) return null;
+  return tokens.map((name) => ({ name }));
+}
+
+/**
+ * Ember-dialect row-item cell tap.
+ *
+ * For a member read whose head is a block param (e.g. the `{{#each as |item|}}`
+ * row item, or a component-yielded value `<Comp as |row|>`), emit a nested
+ * `$__cellFor(...)` chain that taps each reactive segment through the host
+ * cell. Returns null (caller falls back to the plain read) when the path is not
+ * a tappable shape:
+ *   - head is not a block param (this.*, @args, components, helpers, let-bindings),
+ *   - head is the {{#each}} index param (a reactive Cell, read via `.value`),
+ *   - the path is a bare block param with no member (`{{item}}`),
+ *   - any member segment is not a simple identifier (numeric/bracket index,
+ *     optional chaining) — gxt's tracked-array machinery owns index reactivity.
+ */
+function buildBlockParamCellTap(
+  ctx: CompilerContext,
+  value: PathValue
+): JSExpression | null {
+  const segs = getPathSegments(value);
+  if (!segs || segs.length < 2) return null; // need head + >=1 member
+
+  const head = segs[0].name;
+  const binding = ctx.scopeTracker.resolve(head);
+  if (!binding || binding.kind !== 'block-param') return null;
+  // The {{#each}} index is a reactive Cell (read via `.value`), not a raw
+  // value — never cellFor-tap it.
+  if (binding.isEachIndex) return null;
+  // Recycled rows bind to a per-row state object with forwarding accessors;
+  // a cellFor tap would clobber that reference-swap channel.
+  if (binding.recycledRow) return null;
+
+  // Only simple identifier member segments are tapped; anything else (numeric
+  // index, bracket access) bails the whole path to the plain read.
+  for (let i = 1; i < segs.length; i++) {
+    if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(segs[i].name)) return null;
+  }
+
+  // $__cellFor($__cellFor(item, "v"), "x")
+  let expr: JSExpression = B.runtimeRef(
+    head,
+    segs[0].range ?? value.rootRange ?? value.sourceRange
+  );
+  for (let i = 1; i < segs.length; i++) {
+    expr = B.call(
+      SYMBOLS.CELL_FOR,
+      [expr, B.string(segs[i].name, segs[i].range)],
+      value.sourceRange
+    );
+  }
   return expr;
 }
 

--- a/plugins/compiler/serializers/value.ts
+++ b/plugins/compiler/serializers/value.ts
@@ -48,6 +48,51 @@ export function serializeValue(
 }
 
 /**
+ * `(hash)` / `(array)` are the keyword helpers whose produced object/array
+ * identity must be memoized. Classic Glimmer returns a stable compute-ref for
+ * them; GXT otherwise rebuilds a fresh identity on every read of the arg getter,
+ * which makes reference-comparing consumers (Ember child components, modifiers)
+ * over-invalidate. See `cachedHelper` in src/core/reactive.ts.
+ */
+function isMemoizableIdentityHelper(
+  ctx: CompilerContext,
+  value: SerializedValue
+): boolean {
+  if (value.kind !== 'helper') return false;
+  if (value.name !== 'hash' && value.name !== 'array') return false;
+  // Respect a local binding that shadows the built-in (e.g. block param `hash`).
+  return !ctx.scopeTracker.hasBinding(value.name);
+}
+
+/**
+ * Wrap an already-built value expression in an arg getter, memoizing the
+ * identity when the value is a `(hash)` / `(array)` helper so the produced
+ * reference stays stable across reads. `$__cached` returns a getter, so the
+ * `() => value` calling convention is preserved either way.
+ *
+ * Gated to the Ember dialect (IS_GLIMMER_COMPAT_MODE + WITH_EMBER_INTEGRATION):
+ * the identity-stability contract matters for reference-comparing Ember
+ * consumers (child components, modifiers). gxt-standalone AND non-Ember
+ * glimmer-compat compilation stay byte-identical (plain `() => value` getter,
+ * no `$__cached`).
+ */
+function buildMaybeMemoizedGetter(
+  ctx: CompilerContext,
+  value: SerializedValue,
+  builtVal: JSExpression,
+  sourceRange?: SourceRange
+): JSExpression {
+  if (
+    ctx.flags.IS_GLIMMER_COMPAT_MODE &&
+    ctx.flags.WITH_EMBER_INTEGRATION &&
+    isMemoizableIdentityHelper(ctx, value)
+  ) {
+    return B.call(SYMBOLS.CACHED, [B.getter(builtVal, sourceRange)], sourceRange);
+  }
+  return B.getter(builtVal, sourceRange);
+}
+
+/**
  * Build a JSExpression from a SerializedValue.
  * This is the core transformation that converts the intermediate representation
  * to a CodeBuilder AST node for code generation.
@@ -92,7 +137,18 @@ export function buildValue(
       // Wrap the inner value in an arrow function: () => innerValue
       // Use buildValueNoGetter to avoid double-wrapping: getter(path) should
       // produce () => this.x, NOT () => () => this.x
-      return B.getter(buildValueNoGetter(ctx, value.value, ctxName), value.sourceRange);
+      //
+      // For (hash)/(array) the wrap goes through $__cached so the produced
+      // object/array reference is identity-stable across reads/re-renders (the
+      // arg-access layer re-invokes this getter on every read; a bare arrow
+      // would rebuild a fresh identity each time and over-invalidate
+      // reference-comparing consumers).
+      return buildMaybeMemoizedGetter(
+        ctx,
+        value.value,
+        buildValueNoGetter(ctx, value.value, ctxName),
+        value.sourceRange
+      );
 
     case 'concat':
       // Build [part1, part2, ...].join('') with source mapping for paths.
@@ -763,8 +819,10 @@ function buildBuiltInHelper(
       if (builtVal.type === 'reactiveGetter') {
         builtVal = builtVal.expression;
       }
-      // Use B.getter() to preserve AST structure for sourcemaps
-      hashProps.push(B.prop(key, B.getter(builtVal, val.sourceRange), false, val.sourceRange));
+      // Use B.getter() to preserve AST structure for sourcemaps. A nested
+      // (hash)/(array) prop is memoized through $__cached so reading
+      // `outerHash.nested` returns an identity-stable reference too.
+      hashProps.push(B.prop(key, buildMaybeMemoizedGetter(ctx, val, builtVal, val.sourceRange), false, val.sourceRange));
     }
     return B.call(helperId, [B.object(hashProps)], sourceRange);
   }

--- a/plugins/compiler/types.ts
+++ b/plugins/compiler/types.ts
@@ -142,6 +142,19 @@ export interface BindingInfo {
   readonly name: string;
   readonly originalName?: string;  // For renamed bindings
   readonly sourceRange?: SourceRange;
+  /**
+   * True for the `{{#each}}` index block param (the 2nd param). Unlike the
+   * item param (a raw value), the index is a reactive Cell read via `.value`,
+   * so the Ember-dialect row-item cell tap must NOT `cellFor`-tap it.
+   */
+  readonly isEachIndex?: boolean;
+  /**
+   * True for block params of a recycled `{{#each ... key="@recycle"}}`. Those
+   * params bind to a per-row STATE object whose props are forwarding accessors
+   * over a re-pointable holder; a `cellFor` tap would clobber that reference-
+   * swap channel, so recycled-row params are excluded from the row-item tap.
+   */
+  readonly recycledRow?: boolean;
 }
 
 // ============================================================================

--- a/plugins/runtime-compiler.ts
+++ b/plugins/runtime-compiler.ts
@@ -109,6 +109,7 @@ import {
   $__or,
   $__and,
   $__cached,
+  $__cellFor,
 } from '../src/core/helpers/index';
 
 /**
@@ -153,6 +154,7 @@ export const GXT_RUNTIME_SYMBOLS = {
   $__or,
   $__and,
   $__cached,
+  $__cellFor,
   $_HTMLProvider,
   $_SVGProvider,
   $_MathMLProvider,

--- a/plugins/runtime-compiler.ts
+++ b/plugins/runtime-compiler.ts
@@ -108,6 +108,7 @@ import {
   $__fn,
   $__or,
   $__and,
+  $__cached,
 } from '../src/core/helpers/index';
 
 /**
@@ -151,6 +152,7 @@ export const GXT_RUNTIME_SYMBOLS = {
   $__fn,
   $__or,
   $__and,
+  $__cached,
   $_HTMLProvider,
   $_SVGProvider,
   $_MathMLProvider,

--- a/plugins/symbols.ts
+++ b/plugins/symbols.ts
@@ -48,6 +48,10 @@ export const SYMBOLS = {
   // Identity memoization for (hash)/(array) — keeps the produced object/array
   // reference stable across reads/re-renders (classic compute-ref contract).
   $__cached: '$__cached',
+  // Ember-dialect {{#each}} row-item reactive tap (compile-time replacement
+  // for the runtime per-row tracking Proxy). Only emitted under
+  // WITH_EMBER_INTEGRATION; auto-imported here so AOT output resolves it.
+  $__cellFor: '$__cellFor',
 };
 
 export const CONSTANTS = {

--- a/plugins/symbols.ts
+++ b/plugins/symbols.ts
@@ -45,6 +45,9 @@ export const SYMBOLS = {
   $__fn: '$__fn',
   $__or: '$__or',
   $__and: '$__and',
+  // Identity memoization for (hash)/(array) — keeps the produced object/array
+  // reference stable across reads/re-renders (classic compute-ref contract).
+  $__cached: '$__cached',
 };
 
 export const CONSTANTS = {

--- a/src/core/control-flow/host-seams.test.ts
+++ b/src/core/control-flow/host-seams.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Focused coverage for the host-integration SEAMS added so an Ember host can
+ * delegate row/branch teardown ordering + render-scope tracking to GXT natively:
+ *
+ *   1. `onRowContextCreated` — a destructor the host registers on a per-row /
+ *      per-branch render ctx fires BEFORE that row's DOM is removed, in BOTH the
+ *      per-row (`destroyItem`) and the bulk (`fastCleanup`) teardown paths.
+ *   2. `onEnterRenderScope` / `onLeaveRenderScope` — fire in balanced order as
+ *      GXT pushes/pops its render-scope (parent-context) stack.
+ *   3. TREE-entry fix — a live `IfCondition` carries the `gxt-block-wrapper`
+ *      marker, so a host renderer that re-stamps COMPONENT_IDs skips it and the
+ *      IfCondition keeps its own id + TREE entry across a branch/sibling cascade.
+ *
+ * Every hook is no-op by default; these tests register stubs to exercise them.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { Component } from '../component';
+import { createDOMFixture, type DOMFixture } from '../__test-utils__';
+import {
+  buildItems,
+  settle,
+  mountRoot,
+  setupRuntimeTemplateGlobals,
+  defineBenchRoot,
+} from '../__test-utils__/list-harness';
+import { registerHostHooks, HOST_HOOKS } from '../host-hooks';
+import { registerDestructor } from '../glimmer/destroyable';
+import { setParentContext, pushParentContext, popParentContext } from '../tracking';
+import { IfCondition } from './if';
+import { cell } from '../reactive';
+import {
+  COMPONENT_ID_PROPERTY,
+  RENDERED_NODES_PROPERTY,
+  addToTree,
+  TREE,
+} from '../shared';
+
+const BLOCK_WRAPPER_SYMBOL = Symbol.for('gxt-block-wrapper');
+
+function resetHooks(): void {
+  for (const key of Object.keys(HOST_HOOKS)) {
+    delete (HOST_HOOKS as Record<string, unknown>)[key];
+  }
+  delete (globalThis as Record<string, unknown>).__gxtHostHooksInstalled;
+}
+
+describe('onRowContextCreated — row destructors fire before DOM removal', () => {
+  let fixture: DOMFixture;
+
+  afterEach(() => {
+    fixture?.cleanup();
+    resetHooks();
+  });
+
+  // Register a stub `onRowContextCreated` that pushes a destructor recording how
+  // many `<tr>` are still in the DOM at the moment it fires. Installing a host
+  // hook also disables the static-frame fast path, so rows take the rowCtx path.
+  function setup() {
+    fixture = createDOMFixture();
+    setupRuntimeTemplateGlobals();
+    const connectedCounts: number[] = [];
+    const trCount = () =>
+      fixture.container.querySelectorAll('tbody tr').length;
+    registerHostHooks({
+      onRowContextCreated: (ctx) => {
+        registerDestructor(ctx, () => {
+          connectedCounts.push(trCount());
+        });
+      },
+    });
+    const Root = defineBenchRoot('id');
+    const root = mountRoot(fixture, Root) as unknown as {
+      _items: ReturnType<typeof buildItems>;
+    };
+    return { root, connectedCounts, trCount };
+  }
+
+  test('per-row removal: the removed row destructor sees its <tr> still connected', async () => {
+    const { root, connectedCounts, trCount } = setup();
+    const items = buildItems(3);
+    root._items = items;
+    await settle();
+    expect(trCount()).toBe(3);
+    expect(connectedCounts).toEqual([]); // nothing torn down yet
+
+    // Remove the middle row (keyed by id → only that row is destroyed).
+    root._items = [items[0], items[2]];
+    await settle();
+
+    expect(trCount()).toBe(2);
+    // destroyItem → destroyRowCtx runs the row's destructors BEFORE removing the
+    // row node, so the destructor observed all 3 rows still in the DOM.
+    expect(connectedCounts).toEqual([3]);
+  });
+
+  test('bulk clear: every row destructor fires before the bulk DOM clear', async () => {
+    const { root, connectedCounts, trCount } = setup();
+    root._items = buildItems(3);
+    await settle();
+    expect(trCount()).toBe(3);
+    expect(connectedCounts).toEqual([]);
+
+    // Empty the list → fastCleanup bulk path. teardownAllRowCtxs now runs BEFORE
+    // clearChildren, so all 3 row destructors fire while all 3 <tr> are still
+    // connected. (Pre-reorder they would have observed 0.)
+    root._items = [];
+    await settle();
+
+    expect(trCount()).toBe(0);
+    expect(connectedCounts).toEqual([3, 3, 3]);
+  });
+});
+
+describe('onEnterRenderScope / onLeaveRenderScope', () => {
+  afterEach(resetHooks);
+
+  test('fire in balanced order as the render-scope stack is pushed/popped', () => {
+    const events: string[] = [];
+    registerHostHooks({
+      onEnterRenderScope: (ctx) =>
+        events.push(`enter:${(ctx as Record<symbol, number>)[COMPONENT_ID_PROPERTY]}`),
+      onLeaveRenderScope: () => events.push('leave'),
+    });
+
+    const a = { [COMPONENT_ID_PROPERTY]: 101 } as Record<symbol, number>;
+    const b = { [COMPONENT_ID_PROPERTY]: 202 } as Record<symbol, number>;
+
+    // setParentContext(x) and pushParentContext(x) both enter; the null form and
+    // popParentContext both leave. Keep the calls balanced so the global stack is
+    // restored at the end.
+    setParentContext(a as never);
+    pushParentContext(b as never);
+    popParentContext();
+    setParentContext(null);
+
+    expect(events).toEqual(['enter:101', 'enter:202', 'leave', 'leave']);
+  });
+
+  test('are inert (no throw, no events) when no host hook is registered', () => {
+    const a = { [COMPONENT_ID_PROPERTY]: 303 } as Record<symbol, number>;
+    expect(() => {
+      setParentContext(a as never);
+      setParentContext(null);
+    }).not.toThrow();
+  });
+});
+
+describe('TREE-entry fix — live IfCondition keeps its TREE entry', () => {
+  let fixture: DOMFixture;
+
+  beforeEach(() => {
+    fixture = createDOMFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+    resetHooks();
+  });
+
+  function makeIf(): IfCondition {
+    const baseParent = new Component({});
+    (baseParent as unknown as Record<symbol, unknown>)[RENDERED_NODES_PROPERTY] =
+      [];
+    addToTree(fixture.root as never, baseParent as never);
+
+    const placeholder = fixture.api.comment('if-tree-test');
+    const target = fixture.api.fragment();
+    fixture.api.insert(target as never, placeholder);
+
+    return new IfCondition(
+      baseParent as never,
+      cell(true) as never,
+      target as never,
+      placeholder,
+      () => null,
+      () => null,
+    );
+  }
+
+  test('IfCondition advertises the gxt-block-wrapper marker', () => {
+    const ifCond = makeIf();
+    expect((ifCond as unknown as Record<symbol, unknown>)[BLOCK_WRAPPER_SYMBOL]).toBe(
+      true,
+    );
+  });
+
+  test('a host COMPONENT_ID re-stamp skips the IfCondition, so its TREE entry survives', () => {
+    const ifCond = makeIf();
+    const originalId = (ifCond as unknown as Record<symbol, number>)[
+      COMPONENT_ID_PROPERTY
+    ];
+    expect(TREE.get(originalId)).toBe(ifCond);
+
+    // Reproduce the ember host's `$_tag` COMPONENT_ID re-stamp: it collapses a
+    // render ctx's id into the shared gxt-root id UNLESS the block-wrapper marker
+    // is present. Before the fix the IfCondition lacked the marker, so it WAS
+    // re-stamped — aliasing/dropping its TREE entry when a branch tore down.
+    const fakeRootId = 999999;
+    const sym = (ifCond as unknown as Record<symbol, unknown>)[BLOCK_WRAPPER_SYMBOL];
+    if (!sym) {
+      (ifCond as unknown as Record<symbol, number>)[COMPONENT_ID_PROPERTY] =
+        fakeRootId;
+    }
+
+    // Marker present → re-stamp skipped → id unchanged → TREE entry intact.
+    expect(
+      (ifCond as unknown as Record<symbol, number>)[COMPONENT_ID_PROPERTY],
+    ).toBe(originalId);
+    expect(TREE.get(originalId)).toBe(ifCond);
+  });
+
+  test('control: WITHOUT the marker the same re-stamp would drop the live entry', () => {
+    // Proves the marker is load-bearing: a wrapper-less ctx with the same shape
+    // gets re-stamped, and a teardown keyed off the original id no longer finds
+    // it — the exact failure the marker prevents for IfCondition.
+    const plain = {
+      [COMPONENT_ID_PROPERTY]: 4242,
+      [RENDERED_NODES_PROPERTY]: [],
+    } as Record<symbol, unknown>;
+    addToTree(fixture.root as never, plain as never);
+    const originalId = plain[COMPONENT_ID_PROPERTY] as number;
+    expect(TREE.get(originalId)).toBe(plain);
+
+    const fakeRootId = 888888;
+    if (!plain[BLOCK_WRAPPER_SYMBOL]) {
+      plain[COMPONENT_ID_PROPERTY] = fakeRootId;
+    }
+    // The live node's id moved out from under its TREE entry — a destroy keyed by
+    // the new id would never reach the original registration.
+    expect(plain[COMPONENT_ID_PROPERTY]).toBe(fakeRootId);
+    expect(TREE.get(fakeRootId as number)).toBeUndefined();
+  });
+});

--- a/src/core/control-flow/if.ts
+++ b/src/core/control-flow/if.ts
@@ -33,6 +33,21 @@ import { HOST_HOOKS } from '@/core/host-hooks';
 
 export type IfFunction = () => boolean;
 
+// Marks this IfCondition as a glimmer-next-native block wrapper — identical to
+// the contract `list.ts`'s `rowBodyCtx` stamps on each per-row ctx. A host
+// renderer (e.g. ember.js' gxt-backend `$_tag`) that re-stamps a render ctx's
+// COMPONENT_ID with its shared root id MUST skip wrappers carrying this symbol:
+// the IfCondition is already a real, TREE-registered node with its own id and
+// CHILD bucket. Overwriting its id with the root id collapses A's CHILD bucket
+// into the root's AND aliases A's TREE entry, so when a branch tears down
+// (true→false toggle via destroyBranchSync) the cascade drops/over-cascades A's
+// live TREE entry — exactly the breakage the Ember host worked around by
+// re-registering the IfCondition. With the marker the host never re-stamps, so
+// a live IfCondition keeps its TREE entry across a sibling/branch destroy.
+// `Symbol.for` shares one identity with `list.ts` + the host across the package
+// boundary (no import → no cycle). Inert in standalone GXT (nothing reads it).
+const BLOCK_WRAPPER_SYMBOL = Symbol.for('gxt-block-wrapper');
+
 export class IfCondition {
   isDestructorRunning = false;
   prevComponent: GenericReturnType | null = null;
@@ -46,6 +61,9 @@ export class IfCondition {
   destroyPromise: Promise<any> | null = null;
   [RENDERED_NODES_PROPERTY]: Array<Node> = [];
   [COMPONENT_ID_PROPERTY] = cId();
+  // See BLOCK_WRAPPER_SYMBOL above: keeps a host renderer from re-stamping this
+  // IfCondition's COMPONENT_ID, so its TREE entry survives branch teardown.
+  [BLOCK_WRAPPER_SYMBOL] = true;
   // Snapshot of DOM nodes inserted by the most recent branch render. We track
   // these so we can clean them up even when the branch's `prevComponent` is
   // empty (e.g. when the true branch is just `{{yield}}` and the slot runtime
@@ -132,6 +150,15 @@ export class IfCondition {
     this._treeParent = treeParent;
     // @ts-expect-error typings error
     addToTree(treeParent, this, 'from if constructor');
+    // Announce this IfCondition (the branch render scope) to the host so it can
+    // attach pre-destroy work via `registerDestructor(this, …)`, mirroring the
+    // per-row `onRowContextCreated` seam in list.ts. Fired ONCE here at
+    // construction (before the first branch renders) rather than per branch
+    // swap, so a host destructor isn't accumulated on every toggle. No-op when
+    // no host hook is installed.
+    if (HOST_HOOKS.onRowContextCreated) {
+      HOST_HOOKS.onRowContextCreated(this as unknown as object);
+    }
     // @ts-expect-error
     this.api = initDOM(this);
     this.destructors.push(opcodeFor(this.condition, this.syncState.bind(this)));

--- a/src/core/control-flow/list.ts
+++ b/src/core/control-flow/list.ts
@@ -471,6 +471,12 @@ export class BasicListComponent<T extends { id: number }> {
     addToTree(this, rowCtx, 'from list rowBodyCtx');
     if (this.rowCtxMap === null) this.rowCtxMap = new Map();
     this.rowCtxMap.set(key, rowCtx);
+    // Announce the per-row destructor-owner ctx to the host so it can attach
+    // its own pre-destroy work via `registerDestructor(rowCtx, …)`. Those
+    // destructors fire from `destroyRowCtx` (per-row path) / `teardownAllRowCtxs`
+    // (bulk path) BEFORE the row DOM is removed. No-op when no host hook is
+    // installed (standalone GXT is unchanged).
+    if (HOST_HOOKS.onRowContextCreated) HOST_HOOKS.onRowContextCreated(rowCtx);
     return rowCtx as unknown as ComponentLike;
   }
   /**
@@ -519,10 +525,22 @@ export class BasicListComponent<T extends { id: number }> {
     let firstError: unknown = undefined;
     for (const rowCtx of rowCtxMap.values()) {
       const rowId = rowCtx[COMPONENT_ID_PROPERTY];
-      try {
-        destroyElementSync(rowCtx as unknown as ComponentLike, true, this.api);
-      } catch (e) {
-        if (firstError === undefined) firstError = e;
+      // Run ONLY the rowCtx's OWN destructors (its inline-element binding
+      // opcodes + any host `onRowContextCreated` pre-destroy hook) via the
+      // non-cascading `destroySync` — NOT `destroyElementSync`, which would
+      // cascade through rowCtx's CHILD tree into a `$_ucw`-wrapped row body. A
+      // wrapped body is ALSO tracked in `keyMap` and torn down by the bulk
+      // keyMap loop, so cascading here would double-destroy it (idempotent but
+      // it trips the dev double-destroy detector). The rowCtx's `addToTree`
+      // cleanup (run by destroySync) detaches its own tree maps + recycles its
+      // id; the manual deletes below are belt-and-braces. Mirrors the async
+      // standalone `fastCleanup` path.
+      if (!isDestroyed(rowCtx as object)) {
+        try {
+          destroySync(rowCtx as object);
+        } catch (e) {
+          if (firstError === undefined) firstError = e;
+        }
       }
       CHILD.delete(rowId);
       TREE.delete(rowId);
@@ -1629,10 +1647,28 @@ export class SyncListComponent<
     ) {
       // Detach CHILD so item destructors skip parent-sibling deletes.
       this.detachTreeChildren();
-      // O(n^2) FIX: bulk-clear the parent's DOM FIRST (innerHTML='' is O(1)),
-      // BEFORE running the per-row destructors. The guard above proves this
-      // list owns the entire parent (its markers are first/last child), so a
-      // bulk clear is safe and removes every row in one reflow. The per-row
+      // First-error-wins across the entire teardown: one throwing row
+      // destructor must not leak the remaining rows / rowCtxs / index formulas.
+      // Complete everything, clear the maps, re-throw the first error after.
+      let firstError: unknown = undefined;
+      // Tear down each row's per-row destructor-owner ctx BEFORE the bulk DOM
+      // clear, so the row body's `class`/attr/text/event/modifier opcodes — and
+      // any host `onRowContextCreated` pre-destroy hook — fire while the row DOM
+      // is still CONNECTED, matching the per-row `destroyItem`→`destroyRowCtx`
+      // ordering (the per-row path already fires rowCtx destructors before
+      // removing the row node). `teardownAllRowCtxs` uses non-cascading
+      // `destroySync` and never calls `.remove()` itself, so this reorder does
+      // NOT reintroduce the O(N^2) below; it leaves every row's DOM in place for
+      // the single bulk `clearChildren`. Without per-row ctxs this is a no-op.
+      try {
+        this.teardownAllRowCtxs();
+      } catch (e) {
+        if (firstError === undefined) firstError = e;
+      }
+      // O(n^2) FIX: bulk-clear the parent's DOM (innerHTML='' is O(1)) BEFORE
+      // running the per-row CONTENT destructors below. The guard above proves
+      // this list owns the entire parent (its markers are first/last child), so
+      // a bulk clear is safe and removes every row in one reflow. The per-row
       // `destroyElementSync(value, skipDom=true)` cascade below still runs the
       // reactive cleanup (registered destructors, cell/formula `.destroy()`),
       // but each row's top node is a raw <tr>/element passed to
@@ -1645,24 +1681,12 @@ export class SyncListComponent<
       this.api.clearChildren(parent);
       this.api.insert(parent, topMarker);
       this.api.insert(parent, bottomMarker);
-      // First-error-wins across the entire teardown: one throwing row
-      // destructor must not leak the remaining rows / rowCtxs / index formulas.
-      // Complete everything, clear the maps, re-throw the first error after.
-      let firstError: unknown = undefined;
       for (const value of keyMap.values()) {
         try {
           destroyElementSync(value as ComponentLike, true, this.api);
         } catch (e) {
           if (firstError === undefined) firstError = e;
         }
-      }
-      // Tear down each row's per-row destructor-owner ctx, so the row body's
-      // `class`/attr/text/event/modifier opcodes UNSUBSCRIBE from shared cells.
-      // Without this they would leak onto the surviving list instance.
-      try {
-        this.teardownAllRowCtxs();
-      } catch (e) {
-        if (firstError === undefined) firstError = e;
       }
       // Clean up all reactive index formulas
       if (indexFormulaMap) {
@@ -1957,42 +1981,24 @@ export class AsyncListComponent<
       // per-row DOM removal behind each modifier's pending promise — see PR
       // #212), and it still awaits so animated removals complete.
       if (!cascadeDestruction) {
-        // Bulk-remove the rendered rows between the markers FIRST.
-        this.api.clearChildren(parent);
-        this.api.insert(parent, topMarker);
-        this.api.insert(parent, bottomMarker);
-        // Snapshot the rows, then clear keyMap so the fire-and-forget
-        // destructors operate on a stable set independent of further syncs.
-        const rows: ComponentLike[] = [];
-        for (const value of keyMap.values()) {
-          rows.push(value as ComponentLike);
-        }
-        if (indexFormulaMap) {
-          for (const formula of indexFormulaMap.values()) {
-            formula.destroy();
-          }
-          indexFormulaMap.clear();
-        }
-        // Tear down the per-row destructor-owner ctxs so the row body's element
-        // binding opcodes unsubscribe instead of leaking onto the surviving
-        // list. This is a STANDALONE clear (the list itself survives —
-        // not a parent cascade), so there is no cascade-ordering hazard: the row
-        // CONTENT (the `<Row>` component / `$_ucw` wrapper) is independently
-        // tracked in `keyMap` and torn down by the `rows` fire-and-forget map
-        // below; the rowCtx's CHILD link to it is detached here first. So a rowCtx
-        // teardown only needs to run rowCtx's OWN destructors (the inline-element
-        // body's `class`/attr/text/event/modifier opcodes registered against it,
-        // if any) + reclaim its tree maps. `destroySync` does exactly that
-        // synchronously — for the common component-bodied row (no opcodes on
+        // Tear down the per-row destructor-owner ctxs FIRST — BEFORE the bulk DOM
+        // clear — so the row body's `class`/attr/text/event/modifier opcodes AND
+        // any host `onRowContextCreated` pre-destroy hook fire while the row DOM
+        // is still CONNECTED, matching the per-row `destroyItem`→`destroyRowCtx`
+        // ordering and the sync `fastCleanup`. This is a STANDALONE clear (the
+        // list itself survives — not a parent cascade), so there is no
+        // cascade-ordering hazard: the row CONTENT (the `<Row>` component /
+        // `$_ucw` wrapper) is independently tracked in `keyMap` and torn down by
+        // the `rows` fire-and-forget map below; the rowCtx's CHILD link to it is
+        // detached here first. So a rowCtx teardown only needs to run rowCtx's
+        // OWN destructors (the inline-element body's opcodes, if any) + reclaim
+        // its tree maps. `destroySync` does exactly that synchronously and
+        // touches NO DOM — for the common component-bodied row (no opcodes on
         // rowCtx) it runs only the `addToTree` cleanup closure, and for an
-        // inline-element body it runs the opcodes too. Replacing the prior
-        // per-row `destroyElement(rowCtx)` (async `runDestructors` walk + pending-
-        // array alloc + `.filter`/`.map`/Promise churn) with an inline
-        // `destroySync` removes that machinery from the high-N clear path — the
-        // DOM is already bulk-cleared (skipDom), so the teardown was fire-and-
-        // forget regardless; any async modifier on a row body fades nothing here
-        // (its node is already gone). `releaseId` reclaims the id (the closure
-        // can't — we pre-deleted its TREE entry below).
+        // inline-element body it runs the opcodes too. Because it touches no DOM,
+        // running it before `clearChildren` keeps the bulk clear O(1) and does
+        // not reintroduce per-row `.remove()` churn. `releaseId` reclaims the id
+        // (the closure can't — we pre-delete its TREE entry here).
         const rowCtxMap = this.rowCtxMap;
         if (rowCtxMap !== null && rowCtxMap.size > 0) {
           const childSet = CHILD.get(this[COMPONENT_ID_PROPERTY]);
@@ -2019,6 +2025,23 @@ export class AsyncListComponent<
           }
           rowCtxMap.clear();
           if (firstError !== undefined) reportDestructionError(firstError);
+        }
+        // Bulk-remove the rendered rows between the markers (the row DOM the
+        // destructors above just observed as connected) in ONE O(1) reflow.
+        this.api.clearChildren(parent);
+        this.api.insert(parent, topMarker);
+        this.api.insert(parent, bottomMarker);
+        // Snapshot the rows, then clear keyMap so the fire-and-forget
+        // destructors operate on a stable set independent of further syncs.
+        const rows: ComponentLike[] = [];
+        for (const value of keyMap.values()) {
+          rows.push(value as ComponentLike);
+        }
+        if (indexFormulaMap) {
+          for (const formula of indexFormulaMap.values()) {
+            formula.destroy();
+          }
+          indexFormulaMap.clear();
         }
         keyMap.clear();
         indexMap.clear();

--- a/src/core/hash-array-identity.test.ts
+++ b/src/core/hash-array-identity.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Spec for the `(hash)` / `(array)` identity-stability fix.
+ *
+ * Classic Glimmer memoizes `(hash)` / `(array)` so the produced object/array
+ * keeps a STABLE reference across reads/re-renders, only changing when an input
+ * changes (the `createComputeRef` contract). GXT previously rebuilt a fresh
+ * object/array on every read of the arg getter (`$_args` re-invokes the getter,
+ * which re-ran `$__hash` / `$__array`), so `childInstance.obj !== childInstance.obj`
+ * for two reads in the SAME render — causing reference-comparing consumers
+ * (Ember child components, modifiers) to over-invalidate.
+ *
+ * This suite proves:
+ *   - two reads of the same (hash)/(array) in ONE render are `===`;
+ *   - the reference is stable across an UNRELATED re-render;
+ *   - (hash) keeps its reference and updates the property in place when an input
+ *     changes; (array) produces a NEW reference when an input changes;
+ *   - value-correctness is preserved throughout.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { Component } from './component';
+import { RENDERED_NODES_PROPERTY, addToTree, $template, $args } from './shared';
+import { $_c, $_args, $_edp } from './dom';
+import { createDOMFixture, type DOMFixture } from './__test-utils__';
+import { cell, formula, cachedHelper, setTracker, type Cell } from './reactive';
+import { renderElement } from './render-core';
+import {
+  template,
+  compileTemplate,
+  setupGlobalScope,
+  GXT_RUNTIME_SYMBOLS,
+} from '../../plugins/runtime-compiler';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+describe('(hash)/(array) identity memoization — cachedHelper (runtime primitive)', () => {
+  test('zero-dep factory (the (hash) shape) returns a stable reference forever', () => {
+    let builds = 0;
+    const read = cachedHelper(() => ({ id: ++builds }));
+    const a = read();
+    const b = read();
+    expect(a).toBe(b); // same reference across reads
+    expect(builds).toBe(1); // factory ran exactly once
+  });
+
+  test('input-reading factory (the (array) shape) is stable until the input changes', () => {
+    const x = cell(1);
+    let builds = 0;
+    const read = cachedHelper(() => {
+      builds++;
+      return [x.value, 2];
+    });
+
+    // Read inside a consumer formula so deps are captured/replayed.
+    const consumer = formula(() => read());
+
+    const a1 = consumer.value as number[];
+    const a2 = consumer.value as number[];
+    expect(a1).toBe(a2); // stable while the input is unchanged
+    expect(a1).toEqual([1, 2]); // value-correct
+    expect(builds).toBe(1);
+
+    // An input change yields a NEW reference with the correct value.
+    x.update(9);
+    const a3 = consumer.value as number[];
+    expect(a3).not.toBe(a1);
+    expect(a3).toEqual([9, 2]);
+  });
+
+  test('captured deps are replayed into the ambient tracker on every read', () => {
+    const x = cell(1);
+    const read = cachedHelper(() => [x.value]);
+
+    // First (recompute) read inside an ambient tracker frame forwards the dep.
+    const frame1 = new Set<Cell>();
+    setTracker(frame1);
+    try {
+      read();
+    } finally {
+      setTracker(null);
+    }
+    expect(frame1.size).toBeGreaterThan(0);
+
+    // A subsequent CLEAN (memoized) read still replays the dep into a fresh
+    // frame, so a consumer that re-reads keeps depending on the input cell.
+    const frame2 = new Set<Cell>();
+    setTracker(frame2);
+    try {
+      read();
+    } finally {
+      setTracker(null);
+    }
+    expect(frame2.size).toBeGreaterThan(0);
+  });
+});
+
+describe('(hash)/(array) identity memoization — compiled output', () => {
+  test('a (hash) / (array) component arg is wrapped in $__cached', () => {
+    const result = compileTemplate(
+      '<Child @obj={{hash key=this.x}} @arr={{array this.x 2}} />',
+      { bindings: new Set(['Child']), flags: { IS_GLIMMER_COMPAT_MODE: true } }
+    );
+    expect(result.errors).toHaveLength(0);
+    expect(result.code).toContain('$__cached(() => $__hash(');
+    expect(result.code).toContain('$__cached(() => $__array(');
+  });
+});
+
+describe('(hash)/(array) identity memoization — render behavior', () => {
+  let fixture: DOMFixture;
+
+  function render(C: any, args: Record<string, unknown> = {}) {
+    const parent = new Component({});
+    parent[RENDERED_NODES_PROPERTY] = [];
+    addToTree(fixture.root, parent);
+    const a = $_args(args, false, $_edp as any);
+    const instance = $_c(C as any, a, parent);
+    renderElement(fixture.api, parent, fixture.container, instance);
+    return instance;
+  }
+
+  beforeEach(() => {
+    fixture = createDOMFixture();
+    setupGlobalScope();
+    const g = globalThis as any;
+    Object.entries(GXT_RUNTIME_SYMBOLS).forEach(([name, value]) => {
+      g[name] = value;
+    });
+  });
+
+  afterEach(() => fixture.cleanup());
+
+  test('(hash) keeps a stable reference; property updates in place; no over-invalidation', async () => {
+    let child: any = null;
+    class HashChild extends Component {
+      constructor(...rest: any[]) {
+        // @ts-expect-error component ctor args
+        super(...rest);
+        child = this;
+      }
+      [$template] = template('<span data-test-hash>{{@obj.name}}</span>');
+    }
+
+    class Parent extends Component {
+      nameCell = cell('a');
+      unrelatedCell = cell(0);
+      get nameVal() {
+        return this.nameCell.value;
+      }
+      get unrelatedVal() {
+        return this.unrelatedCell.value;
+      }
+      [$template] = template(
+        '<HashChild @obj={{hash name=this.nameVal}} /><i>{{this.unrelatedVal}}</i>',
+        { scope: { HashChild } }
+      );
+    }
+
+    const parent = render(Parent) as any;
+    expect(fixture.container.textContent).toContain('a');
+
+    const childArgs = child[$args];
+
+    // Two reads of the SAME (hash) in one render -> identical reference.
+    const r1 = childArgs.obj;
+    const r2 = childArgs.obj;
+    expect(r1).toBe(r2);
+    expect(r1.name).toBe('a'); // value-correct
+
+    // Unrelated re-render -> reference stays stable.
+    parent.unrelatedCell.update(1);
+    await flush();
+    expect(childArgs.obj).toBe(r1);
+
+    // Input change -> SAME reference, value updated in place (classic hash).
+    parent.nameCell.update('b');
+    await flush();
+    expect(fixture.container.textContent).toContain('b');
+    expect(childArgs.obj).toBe(r1);
+    expect(childArgs.obj.name).toBe('b');
+  });
+
+  test('(array) is stable across reads/unrelated re-render; new reference when an input changes', async () => {
+    let child: any = null;
+    class ArrChild extends Component {
+      constructor(...rest: any[]) {
+        // @ts-expect-error component ctor args
+        super(...rest);
+        child = this;
+      }
+      [$template] = template('<span data-test-arr>{{@arr.length}}</span>');
+    }
+
+    class Parent extends Component {
+      xCell = cell(1);
+      unrelatedCell = cell(0);
+      get xVal() {
+        return this.xCell.value;
+      }
+      get unrelatedVal() {
+        return this.unrelatedCell.value;
+      }
+      [$template] = template(
+        '<ArrChild @arr={{array this.xVal 2}} /><i>{{this.unrelatedVal}}</i>',
+        { scope: { ArrChild } }
+      );
+    }
+
+    const parent = render(Parent) as any;
+    const childArgs = child[$args];
+
+    // Two reads of the SAME (array) in one render -> identical reference.
+    const a1 = childArgs.arr;
+    const a2 = childArgs.arr;
+    expect(a1).toBe(a2);
+    expect([...a1]).toEqual([1, 2]); // value-correct
+
+    // Unrelated re-render -> reference stays stable.
+    parent.unrelatedCell.update(1);
+    await flush();
+    expect(childArgs.arr).toBe(a1);
+
+    // Input change -> NEW reference, value-correct.
+    parent.xCell.update(9);
+    await flush();
+    const a3 = childArgs.arr;
+    expect(a3).not.toBe(a1);
+    expect([...a3]).toEqual([9, 2]);
+  });
+});

--- a/src/core/helpers/cached.ts
+++ b/src/core/helpers/cached.ts
@@ -1,0 +1,18 @@
+import { cachedHelper } from '../reactive';
+
+/**
+ * `$__cached` — the compiler-emitted wrapper that memoizes the identity of a
+ * `(hash)` / `(array)` keyword-helper value so reference-comparing consumers
+ * (Ember child components, modifiers) don't see a perpetually-changed arg.
+ *
+ * The compiler replaces a bare arg getter `() => $__hash({...})` /
+ * `() => $__array(...)` with `$__cached(() => $__hash({...}))` /
+ * `$__cached(() => $__array(...))`. `$__cached` returns a getter (preserving the
+ * arg-getter calling convention) whose value is identity-stable across reads and
+ * re-renders while the inputs are unchanged.
+ *
+ * See `cachedHelper` in src/core/reactive.ts for the memoization semantics.
+ */
+export function $__cached<T>(factory: () => T): () => T {
+  return cachedHelper(factory);
+}

--- a/src/core/helpers/cell-for.test.ts
+++ b/src/core/helpers/cell-for.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest';
+import { $__cellFor } from './cell-for';
+import { formula, cellFor } from '../reactive';
+
+/**
+ * Behavior tests for the Ember-dialect {{#each}} row-item tap helper.
+ * `$__cellFor(item, key)` is what the compiler emits for `{{item.text}}` so
+ * the read stays reactive on item-property mutation without a runtime Proxy.
+ */
+describe('$__cellFor helper', () => {
+  test('reads the property value through the row item cell', () => {
+    const item = { text: 'a' };
+    expect($__cellFor(item, 'text')).toBe('a');
+  });
+
+  test('stays reactive: a formula recomputes when the item property mutates', () => {
+    const item = { text: 'a' };
+    const f = formula(() => $__cellFor(item, 'text'), 'tap');
+    expect(f.value).toBe('a');
+    // cellFor installed an accessor on item.text; assigning routes through the
+    // cell and bumps its revision, so the dependent formula recomputes.
+    item.text = 'b';
+    expect(f.value).toBe('b');
+  });
+
+  test('deep paths compose and stay reactive per segment', () => {
+    const item: { v: { x: number } } = { v: { x: 1 } };
+    const f = formula(
+      () => $__cellFor($__cellFor(item, 'v'), 'x'),
+      'deep'
+    );
+    expect(f.value).toBe(1);
+    item.v.x = 2;
+    expect(f.value).toBe(2);
+  });
+
+  test('shares the cell with cellFor(item, key): mutation via either is observed', () => {
+    const item = { text: 'a' };
+    const c = cellFor(item, 'text');
+    const f = formula(() => $__cellFor(item, 'text'), 'shared');
+    expect(f.value).toBe('a');
+    c.update('z');
+    expect(f.value).toBe('z');
+  });
+
+  test('primitive head falls back to a plain member read (no throw)', () => {
+    expect($__cellFor('hello', 'length')).toBe(5);
+    expect($__cellFor(42, 'toFixed')).toBe((42 as number).toFixed);
+  });
+
+  test('nullish head returns undefined (no throw)', () => {
+    expect($__cellFor(null, 'x')).toBeUndefined();
+    expect($__cellFor(undefined, 'x')).toBeUndefined();
+  });
+});

--- a/src/core/helpers/cell-for.ts
+++ b/src/core/helpers/cell-for.ts
@@ -1,0 +1,34 @@
+import { cellFor } from '../reactive';
+
+/**
+ * Compile-time `{{#each}}` row-item reactive tap.
+ *
+ * The Ember dialect (WITH_EMBER_INTEGRATION) rewrites a reactive member read
+ * whose head is a block param — `{{item.text}}` inside
+ * `{{#each items as |item|}}` — into `$__cellFor(item, 'text')`. This routes
+ * the read through the row item's GXT cell (`cellFor`), so the value stays
+ * reactive when the host mutates `item.text` (e.g. Ember's
+ * `set(item, 'text', …)`), WITHOUT wrapping every row item in a runtime
+ * tracking Proxy.
+ *
+ * Deep paths compose: `{{item.v.x}}` →
+ * `$__cellFor($__cellFor(item, 'v'), 'x')`. Each reactive segment is tapped.
+ *
+ * Primitive / nullish heads are not cell-trackable (a `cellFor` on a string or
+ * number would throw on the WeakMap key), so they fall back to a plain member
+ * read — matching the semantics of the bare `item.text` this replaced.
+ */
+export function $__cellFor(obj: unknown, key: string): unknown {
+  if (obj === null || obj === undefined) {
+    return undefined;
+  }
+  const t = typeof obj;
+  if (t !== 'object' && t !== 'function') {
+    // Primitive head (string/number/boolean/symbol/bigint) — not cell-
+    // trackable; mirror the bare property read the transform replaced.
+    return (obj as Record<string, unknown>)[key];
+  }
+  // `cellFor` installs a reactive accessor on obj[key] and returns its Cell;
+  // reading `.value` registers the dependency on the active tracker frame.
+  return cellFor(obj as object, key as never).value;
+}

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -9,3 +9,4 @@ export { $__fn } from './fn';
 export { $__or } from './or';
 export { $__not } from './not';
 export { $__and } from './and';
+export { $__cellFor } from './cell-for';

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -4,6 +4,7 @@ export { $__log } from './log';
 export { $__debugger } from './debugger';
 export { $__array } from './array';
 export { $__hash } from './hash';
+export { $__cached } from './cached';
 export { $__fn } from './fn';
 export { $__or } from './or';
 export { $__not } from './not';

--- a/src/core/host-hooks.ts
+++ b/src/core/host-hooks.ts
@@ -78,6 +78,41 @@ export interface HostHooks {
    * the `globalThis.$_eval` fallback read.
    */
   dynamicEval?: (value: unknown) => unknown;
+  /**
+   * Observe a freshly-created per-row / per-branch render context so the host
+   * can attach its own pre-destroy work to it via `registerDestructor(ctx, …)`.
+   *
+   * Fired:
+   *   - once per keyed-`{{#each}}` row, immediately after the row's destructor-
+   *     owner ctx is allocated + added to the tree (BEFORE the row body renders);
+   *   - once per `{{#if}}`/`{{#unless}}` `IfCondition`, at construction (the
+   *     branch render scope), BEFORE the first branch renders.
+   *
+   * Because the runtime fires the row ctx's destructors BEFORE the row DOM is
+   * removed (per-row `destroyItem`→`destroyRowCtx`, and the reordered bulk
+   * `fastCleanup`), a destructor the host registers here runs while the row DOM
+   * is still connected — letting the host run teardown/lifecycle hooks at the
+   * Ember-correct moment without re-implementing row ordering. No-op by default
+   * (standalone GXT never registers it, so behavior is unchanged).
+   */
+  onRowContextCreated?: (ctx: object) => void;
+  /**
+   * Notify the host that the runtime pushed `ctx` onto its render-scope
+   * (parent-context) stack — i.e. children rendered until the matching
+   * `onLeaveRenderScope` attach to `ctx` as their tree parent. Fired from every
+   * `setParentContext`/`pushParentContext` push (e.g. `{{#each}}` row render,
+   * `{{#if}}` branch render, the inverse block). Lets an Ember host ride GXT's
+   * scope stack for its own parentView hierarchy instead of re-pushing manually.
+   * No-op by default.
+   */
+  onEnterRenderScope?: (ctx: object) => void;
+  /**
+   * The converse of `onEnterRenderScope`: the runtime popped the top render
+   * scope (`setParentContext(null)`/`popParentContext`). Enter/leave are always
+   * balanced, so the host can mirror the stack with a simple push/pop. No-op by
+   * default.
+   */
+  onLeaveRenderScope?: () => void;
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,6 +14,7 @@ export {
   type MergedCell,
   formula,
   cached,
+  cachedHelper,
   type CachedCell,
 } from '@/core/reactive';
 

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -941,6 +941,99 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
   return self;
 }
 
+/**
+ * `cachedHelper(factory)` — identity-stable memoization for the `(hash)` and
+ * `(array)` keyword helpers.
+ *
+ * Classic Glimmer memoizes `(hash)`/`(array)` (a `createComputeRef`-style stable
+ * reference that only changes when an input changes). GXT compiles a `(hash)` /
+ * `(array)` value into a getter (`() => $__hash({...})` / `() => $__array(...)`)
+ * that the arg-access layer (`$_args`) RE-INVOKES on every read, so every read
+ * produced a FRESH object/array identity. Reference-comparing consumers (Ember
+ * child components, modifiers) then saw the arg as perpetually changed and
+ * over-fired `didUpdateAttrs` / `didReceiveAttrs` even on unrelated re-renders.
+ *
+ * This wraps the helper factory so the produced identity is memoized:
+ *   - the value is computed once, capturing the tracked cells read during the
+ *     computation;
+ *   - subsequent reads return the SAME reference while those cells are unchanged
+ *     — and FOREVER when the factory read no tracked cell (e.g. `(hash)`, whose
+ *     properties are live getters, or a constant `(array 1 2)`);
+ *   - the reference is recomputed (yielding a fresh identity) only when a
+ *     captured cell actually changes (e.g. `(array this.x)` when `this.x`
+ *     changes);
+ *   - the captured deps are replayed into the ambient tracker on every read, so
+ *     a consumer formula still depends on the underlying cells and re-runs when
+ *     they change — value-correctness is preserved.
+ *
+ * Unlike `cached()`, a zero-dep capture is treated as STABLE (not stale): the
+ * hash/array factories only read their own tracked-cell args, never raw mutable
+ * state, so there is nothing to miss. The memo deliberately does NOT subscribe a
+ * tag to the dep cells (no `bindAllCellsToTag`) — the consumer's own tracker
+ * does the subscribing — which keeps it allocation-light and leak-free (no tag
+ * lingers in a destroyed component's cell subscriber sets).
+ *
+ * Returns a getter so the existing arg-getter calling convention is preserved
+ * (`$_args` invokes the arg as `args[key]()`).
+ */
+export function cachedHelper<T>(factory: () => T): () => T {
+  let hasValue = false;
+  let lastValue: T;
+  let depRevisions: Map<Cell, number> | null = null;
+
+  function recompute(): T {
+    const priorTracker = currentTracker;
+    const localTracker: Set<Cell> = new Set();
+    setTracker(localTracker);
+    let value: T;
+    try {
+      value = factory();
+    } finally {
+      setTracker(priorTracker);
+      // Forward captured deps to whoever triggered the (re)compute so an outer
+      // formula whose only dep flows through this memo still re-runs.
+      if (priorTracker !== null) {
+        localTracker.forEach((cell) => priorTracker.add(cell));
+      }
+    }
+    const snapshot = new Map<Cell, number>();
+    localTracker.forEach((cell) => snapshot.set(cell, cell._revision));
+    depRevisions = snapshot;
+    lastValue = value;
+    hasValue = true;
+    return value;
+  }
+
+  function isClean(): boolean {
+    if (!hasValue || depRevisions === null) {
+      return false;
+    }
+    // Zero captured deps => stable for the lifetime of this call site.
+    for (const [cell, revision] of depRevisions) {
+      if (cell._revision !== revision) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return function cachedHelperRead(): T {
+    // Replay known deps into the ambient tracker so a consumer formula depends
+    // on the underlying cells even when we serve the memoized identity.
+    if (
+      currentTracker !== null &&
+      depRevisions !== null &&
+      depRevisions.size > 0
+    ) {
+      depRevisions.forEach((_revision, cell) => currentTracker!.add(cell));
+    }
+    if (isClean()) {
+      return lastValue;
+    }
+    return recompute();
+  };
+}
+
 export function deepFnValue(fn: Function | Fn) {
   const cell = fn();
   if (isFn(cell)) {

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -973,6 +973,23 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
  * does the subscribing — which keeps it allocation-light and leak-free (no tag
  * lingers in a destroyed component's cell subscriber sets).
  *
+ * WHY NOT reuse `createCache`/`getValue` (core/glimmer/caching-primitives.ts)?
+ * Empirically they cannot do this job: gxt's `createCache` is a PUSH/opcode-based,
+ * lifecycle-owned memo — it installs a persistent `formula`+`opcodeFor`
+ * subscription into each dep cell's `relatedTags` (released only by
+ * `cache.destroy()`), `getValue` reads a `calcVersion` counter WITHOUT entangling
+ * the caller, and recompute is driven ASYNCHRONOUSLY by the `scheduleRevalidate`
+ * microtask drain. For this fire-and-forget arg getter (no destroy hook) that
+ * would (1) LEAK — subscriptions pile up on long-lived parent cells across
+ * keyed-each churn (probed: 50 caches over one cell → relatedTags 0→100, none
+ * released); (2) fail to re-render `(array this.x)` consumers — `getValue`
+ * entangles nothing (probed: 0 cells); (3) flip identity only after a flush,
+ * breaking the synchronous-within-a-render-tick contract the identity tests
+ * assert. This helper is the PULL-based, entangling, synchronous, leak-free
+ * counterpart — faithful to the `@glimmer/tracking/primitives/cache` RFC for the
+ * arg-getter use. Do NOT collapse it into `createCache` without first making
+ * `createCache` itself RFC-faithful (a shared-primitive change, separate PR).
+ *
  * Returns a getter so the existing arg-getter calling convention is preserved
  * (`$_args` invokes the arg as `args[key]()`).
  */

--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -10,6 +10,7 @@ import {
   type ComponentLike,
 } from './types';
 import { TREE } from './tree';
+import { HOST_HOOKS } from './host-hooks';
 
 // `parentContextStack.length - 1` IS the active index — keeping a parallel
 // `parentContextIndex` doubled the bookkeeping (every push/pop incremented or
@@ -34,6 +35,9 @@ if (IS_DEV_MODE) {
  */
 export const pushParentContext = (value: ComponentLike): void => {
   parentContextStack.push(value[COMPONENT_ID_PROPERTY]!);
+  // Host render-scope mirror: every push of the scope stack is the host's cue
+  // to push its parentView. No-op when no host registered the hook.
+  if (HOST_HOOKS.onEnterRenderScope) HOST_HOOKS.onEnterRenderScope(value);
 };
 
 /**
@@ -41,6 +45,7 @@ export const pushParentContext = (value: ComponentLike): void => {
  */
 export const popParentContext = (): void => {
   parentContextStack.pop();
+  if (HOST_HOOKS.onLeaveRenderScope) HOST_HOOKS.onLeaveRenderScope();
 };
 
 /**
@@ -49,8 +54,10 @@ export const popParentContext = (): void => {
 export const setParentContext = (value: ComponentLike | null): void => {
   if (value === null) {
     parentContextStack.pop();
+    if (HOST_HOOKS.onLeaveRenderScope) HOST_HOOKS.onLeaveRenderScope();
   } else {
     parentContextStack.push(value[COMPONENT_ID_PROPERTY]!);
+    if (HOST_HOOKS.onEnterRenderScope) HOST_HOOKS.onEnterRenderScope(value);
   }
 };
 


### PR DESCRIPTION
## Summary

Three independent, verified fixes that let an embedding Ember host (the ember.js dual-backend) ride GXT's native machinery instead of re-implementing it. **Every behavior change is gated behind the Ember-integration build flags — gxt-standalone AND non-Ember glimmer-compat compilation/runtime are byte-identical to before.**

### 1. `fix(gxt)`: memoize `(hash)`/`(array)` helper identity (classic compute-ref contract)
GXT compiled a `(hash)`/`(array)` value into an arg getter that the arg-access layer (`$_args`) re-invokes on every read, so each read rebuilt a **fresh** object/array identity (`childInstance.obj !== childInstance.obj` in one render). Reference-comparing consumers (Ember child components, modifiers) saw the arg as perpetually changed and over-fired `didUpdateAttrs`/`didReceiveAttrs`, forcing no-op re-renders.

Fix: wrap `(hash)`/`(array)` arg getters in a new `$__cached` memo (`cachedHelper`) so the produced reference is identity-stable across reads/re-renders while inputs are unchanged, recomputing only when a tracked input changes — matching classic Glimmer's memoized compute-ref. `(hash)` stays stable forever (live getter props); `(array)` yields a new reference when an input changes. Value-correctness preserved; the memo is allocation-light and leak-free (no tag subscription).

**Gating:** `IS_GLIMMER_COMPAT_MODE && WITH_EMBER_INTEGRATION` (tightened from the original `IS_GLIMMER_COMPAT_MODE`-only guard so plain glimmer-compat is unaffected). An OFF-case compile test asserts no `$__cached` is emitted without the Ember flag.

### 2. `feat(compiler)`: Ember-dialect `{{#each}}` row-item cell tap
Moves per-row `{{#each}}` item-tracking from a runtime Proxy to compile time, mirroring the `$__hash`/`$__array` pattern. Under the Ember dialect, a reactive member read whose head is a block param — `{{item.text}}` inside `{{#each items as |item|}}`, or a component-yielded value — is rewritten to a host cell tap `$__cellFor(item, "text")`, so the read stays reactive on item-property mutation without wrapping every row item in a tracking Proxy. Deep paths compose: `{{item.v.x}}` → `$__cellFor($__cellFor(item, "v"), "x")`.

`$__cellFor(obj, key)` is a thin guarded wrapper over the existing `cellFor` primitive (falls back to a plain read for primitive/nullish heads); auto-imported like every `$__*` helper so the host registers nothing new.

**Gating:** `IS_GLIMMER_COMPAT_MODE && WITH_EMBER_INTEGRATION`. Excluded from the tap: the `{{#each}}` index param (a reactive Cell), recycled rows (`key="@recycle"`, a state-object forwarding channel), `{{#let}}` bindings (thunks), and non-identifier segments (numeric/bracket index — GXT's tracked-array machinery owns that reactivity).

**Caveats:** numeric/bracket deep-index access deliberately bails to the plain read; keyed-row rebind on recycled rows is intentionally excluded.

### 3. `feat(host-hooks)`: seams for Ember each/if teardown + render-scope delegation
Three host-integration seams, **all default no-op**:
- `onRowContextCreated(ctx)` — fired once per keyed-`{{#each}}` row (rowBodyCtx) and once per `IfCondition` (branch render scope). Lets the host `registerDestructor(ctx, …)` whose teardown runs **before** the row/branch DOM is removed. The bulk clear path now runs the row-ctx teardown **before** `clearChildren` in both `SyncListComponent.fastCleanup` and the standalone branch of `AsyncListComponent.fastCleanup` (non-cascading `destroySync`, touches no DOM, so the O(1) bulk clear + O(N²) guard are preserved — behavior-preserving for standalone).
- `onEnterRenderScope(ctx)` / `onLeaveRenderScope()` — fired from the single source of truth for the scope stack (`setParentContext`/`pushParentContext`/`popParentContext`), always balanced, so a host can mirror GXT's parent-context stack for its own parentView hierarchy.
- **TREE-entry fix:** a live `IfCondition` now carries the `Symbol.for('gxt-block-wrapper')` marker that `$_ucw`, `$_inElement` and per-row rowCtx already carry, so a host renderer that re-stamps a render ctx's `COMPONENT_ID` skips it and the IfCondition keeps its own id + TREE entry across a branch/sibling teardown cascade. Inert in standalone (nothing in GXT reads the marker — confirmed: it is only ever written, never branched on).

## Ember.js-side impact unlocked
- **Fix 1** removes `(hash)`/`(array)` over-invalidation of reference-comparing consumers.
- **Fix 2** lets ember.js delete its runtime per-row tracking Proxy (`wrapEachItemForTracking`, ~340 lines).
- **Fix 3** lets ember.js delete its row/branch teardown-ordering + parentView re-threading + IfCondition re-registration workarounds (~480 lines).

## Standalone byte-identity
With `WITH_EMBER_INTEGRATION` OFF: no `$__cached`, no `$__cellFor`, every host hook is no-op, and the block-wrapper marker is never read. The fastCleanup reorder is behavior-preserving (DOM-free `destroySync`). Dedicated OFF-case tests assert the compiled output is unchanged.

## Verification
- `tsc --noEmit`: clean.
- `vitest run`: **3936 passed, 7 skipped**. The single failing test file (`glint-environment-gxt/__tests__/transformation.test.ts`) is a **pre-existing** environmental failure — its `common-tags` devDependency is not installed in this clone; none of these changes touch that directory.
- New focused suites: `hash-array-identity.test.ts`, `each-item-cell-tap.test.ts`, `cell-for.test.ts`, `host-seams.test.ts` (incl. explicit OFF-case / standalone byte-identity tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
