### PR TITLE
fix: 0.0.68 Ember-integration regressions — keyed {{#each}} stale-key + cachedHelper under-invalidation

### DIFF
--- a/src/core/control-flow/list.ts
+++ b/src/core/control-flow/list.ts
@@ -1755,6 +1755,34 @@ export class SyncListComponent<
     this._dupItemsRef = null;
     try {
       const { keyMap, keyForItem } = this;
+      // Stale-key eviction (explicit-key lists only). A row's keyed property can
+      // be mutated through its per-item cell (`$__cellFor`) WITHOUT re-syncing the
+      // list, leaving its keyMap entry under the now-stale key. A later full
+      // replace with a fresh object carrying the ORIGINAL key value would then hit
+      // the keyed reuse branch and serve the stale row (duplicate-key collapse /
+      // re-used-variable bleed). Evict any entry whose bound item's CURRENT key
+      // drifted so the diff below builds a fresh row for the new object. Simple
+      // keys only — nested `a.b` keys can't be re-derived cheaply here and don't
+      // exhibit the bug (their sources aren't `$__cellFor`-tapped block params).
+      if (
+        this.key !== '@identity' &&
+        !this.key.includes('.') &&
+        this.boundItemMap !== null &&
+        this.boundItemMap.size > 0
+      ) {
+        for (const [k, boundItem] of Array.from(this.boundItemMap)) {
+          if (boundItem !== null && typeof boundItem === 'object') {
+            const currentKey = String(
+              (boundItem as Record<string, unknown>)[this.key],
+            );
+            const baseKey = String(k).replace(/:\d+$/, '');
+            if (currentKey !== baseKey) {
+              const staleRow = keyMap.get(k);
+              if (staleRow !== undefined) this.destroyItem(staleRow, k);
+            }
+          }
+        }
+      }
 
       if (items.length > 0 && this.inverseContent !== null) {
         this.destroyInverseSync();

--- a/src/core/reactive.ts
+++ b/src/core/reactive.ts
@@ -966,12 +966,17 @@ export function cached<T>(fn: () => T, debugName?: string): CachedCell<T> {
  *     a consumer formula still depends on the underlying cells and re-runs when
  *     they change — value-correctness is preserved.
  *
- * Unlike `cached()`, a zero-dep capture is treated as STABLE (not stale): the
- * hash/array factories only read their own tracked-cell args, never raw mutable
- * state, so there is nothing to miss. The memo deliberately does NOT subscribe a
- * tag to the dep cells (no `bindAllCellsToTag`) — the consumer's own tracker
- * does the subscribing — which keeps it allocation-light and leak-free (no tag
- * lingers in a destroyed component's cell subscriber sets).
+ * Invalidation is gated on captured gxt-cell revisions AND a global-revision
+ * fallback: a zero-dep capture is NOT treated as stable-forever (that pinned
+ * stale values when the factory read classic/plain-object host props that don't
+ * entangle a gxt Cell). Instead, when the global revision moves the memo
+ * recomputes and a value-equality gate decides whether the served identity
+ * actually changes — identity stays stable while the value is unchanged (no
+ * over-invalidation) and turns over only on a real value change. The memo
+ * deliberately does NOT subscribe a tag to the dep cells (no `bindAllCellsToTag`)
+ * — the consumer's own tracker does the subscribing — which keeps it
+ * allocation-light and leak-free (no tag lingers in a destroyed component's cell
+ * subscriber sets).
  *
  * WHY NOT reuse `createCache`/`getValue` (core/glimmer/caching-primitives.ts)?
  * Empirically they cannot do this job: gxt's `createCache` is a PUSH/opcode-based,
@@ -997,8 +1002,41 @@ export function cachedHelper<T>(factory: () => T): () => T {
   let hasValue = false;
   let lastValue: T;
   let depRevisions: Map<Cell, number> | null = null;
+  // Global-revision fallback. The original memo invalidated ONLY on captured
+  // gxt-`Cell` deltas, treating a zero-dep capture as stable forever. That is
+  // wrong under the Ember integration: `(hash …)` / `(array …)` args frequently
+  // read CLASSIC / plain-object host properties, whose reads do NOT entangle a
+  // gxt Cell (their reactivity flows through the host's coarse re-render), so
+  // `depRevisions` is empty and the first value gets pinned permanently (stale
+  // `(array)`, stale `(hash)` consumers). Tracking the global revision lets us
+  // NOTICE that something moved even with zero captured cells; the value-equality
+  // gate below then decides whether the served IDENTITY actually changes — so an
+  // unrelated bump keeps the SAME reference (no `didUpdateAttrs` over-invalidation,
+  // preserving the #233 identity fix) while a real value change yields a fresh
+  // reference (so `(array)` / `{{#each}}` reconciles).
+  let lastGlobalRevisionAtCompute = -1;
 
-  function recompute(): T {
+  function shallowSame(a: T, b: T): boolean {
+    if (Object.is(a, b)) return true;
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        if (!Object.is(a[i], b[i])) return false;
+      }
+      return true;
+    }
+    if (a && b && typeof a === 'object' && typeof b === 'object') {
+      const ak = Object.keys(a as object);
+      if (ak.length !== Object.keys(b as object).length) return false;
+      for (const k of ak) {
+        if (!Object.is((a as any)[k], (b as any)[k])) return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function recompute(): void {
     const priorTracker = currentTracker;
     const localTracker: Set<Cell> = new Set();
     setTracker(localTracker);
@@ -1016,22 +1054,40 @@ export function cachedHelper<T>(factory: () => T): () => T {
     const snapshot = new Map<Cell, number>();
     localTracker.forEach((cell) => snapshot.set(cell, cell._revision));
     depRevisions = snapshot;
-    lastValue = value;
+    lastGlobalRevisionAtCompute = _globalRevision;
+    // Identity gate: only swap the served reference when the produced value
+    // actually differs. `(array)` -> fresh ref on a real change so `{{#each}}`
+    // reconciles; `(hash)` live getters compare equal -> stable ref, fresh value
+    // read in place; unrelated bump -> equal -> stable ref (no over-invalidation).
+    if (!hasValue || !shallowSame(value, lastValue)) {
+      lastValue = value;
+    }
     hasValue = true;
-    return value;
   }
 
   function isClean(): boolean {
     if (!hasValue || depRevisions === null) {
       return false;
     }
-    // Zero captured deps => stable for the lifetime of this call site.
-    for (const [cell, revision] of depRevisions) {
-      if (cell._revision !== revision) {
-        return false;
-      }
+    // Nothing in the whole system moved since our last compute.
+    if (_globalRevision === lastGlobalRevisionAtCompute) {
+      return true;
     }
-    return true;
+    // Something moved. If we captured gxt cells, trust their precise revisions
+    // (and suppress re-checks until the next global bump if they held).
+    if (depRevisions.size > 0) {
+      for (const [cell, revision] of depRevisions) {
+        if (cell._revision !== revision) {
+          return false;
+        }
+      }
+      lastGlobalRevisionAtCompute = _globalRevision;
+      return true;
+    }
+    // Zero captured cells + the global revision moved: recompute. The value-eq
+    // gate keeps identity stable when the produced value is unchanged, so this
+    // is a cheap re-evaluation, not identity churn.
+    return false;
   }
 
   return function cachedHelperRead(): T {
@@ -1044,10 +1100,10 @@ export function cachedHelper<T>(factory: () => T): () => T {
     ) {
       depRevisions.forEach((_revision, cell) => currentTracker!.add(cell));
     }
-    if (isClean()) {
-      return lastValue;
+    if (!isClean()) {
+      recompute();
     }
-    return recompute();
+    return lastValue;
   };
 }
 


### PR DESCRIPTION
Fixes regressions the **Ember integration** (`WITH_EMBER_INTEGRATION=true` / runtime-compiler build) hit on 0.0.68 that gxt's own vitest doesn't cover (the flag folds to `false` in the standalone test build, so these integration paths are effectively untested — Ember is the only integration test).

## Fixed (verified)
- **Keyed `{{#each}}` stale-key reuse** (`list.ts`) — `$__cellFor` installs a per-item cell on the *keyed* property, so mutating it (`set(item, key, …)`) updates the cell without re-syncing the list → the keyMap entry stays under the now-stale key → a later full replace with a fresh object carrying the original key value hits the keyed reuse branch and serves the stale row. Manifested as duplicate-key collapse + same-block-param-name bleed across sibling `{{#each}}` blocks. Fix: evict keyMap entries whose bound item's current key drifted, before the diff. (`String(k)` is required — keyMap keys are numbers at runtime for numeric ids.)
- **`cachedHelper` under-invalidation** (`reactive.ts`) — the `$__cached` memo invalidated only on captured gxt-Cell revisions, treating a zero-dep capture as stable-forever, which pinned `(array)` values when the factory read inputs that don't entangle a gxt Cell. Fix: `_globalRevision` fallback + value-equality identity gate (recompute-on-change while keeping #233's identity stability / no over-invalidation).

## Verification
- Full gxt vitest: **3945 passed, 0 failed** (2 pre-existing skips).
- Ember integration suite: **all 22 duplicate-key / same-variable `{{#each}}` regressions cleared**.

## Known remaining (NOT in this PR — need decisions/investigation)
- **`(hash)`/`(array)` with classic/plain-object props still stale** Ember-side: those reads capture no gxt Cell, so the `$__cached` arg gets an effectively const tag and the consuming component never re-pulls it on coarse re-render. `cachedHelper` can't fix this alone. Needs a design decision: (a) make `$__cached` pass-through for Ember (reverts #233's over-invalidation fix), (b) route Ember plain-object reads through `cellFor`, or (c) add a host-epoch signal the memo can entangle.
- **Nested `{{link-to}}` "Maximum call stack size exceeded"** — the each-teardown-reorder hypothesis was empirically disproven (gating it didn't fix link-to). Root cause unpinned; needs the actual recursion stack trace.
- A few Ember `[GXT]` tests document the old un-memoized `(hash)`/`(array)` behavior and need updating to assert the (now correct) memoized behavior.

## Testing gap this exposes
gxt's vitest can't reach the `WITH_EMBER_INTEGRATION=true` paths (flag folds false) AND the keyMap path needs `__gxtHostHooksInstalled`. Repro recipe for regression tests: `template(tpl, {flags:{WITH_EMBER_INTEGRATION:true}})` + `globalThis.__gxtHostHooksInstalled = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)