### PR TITLE
fix(compat): emit AST write-path for mustache-form {{mut this.x}}

### DIFF
--- a/plugins/compiler/__tests__/compile.test.ts
+++ b/plugins/compiler/__tests__/compile.test.ts
@@ -4590,6 +4590,59 @@ describe('Compat mode AST transforms', () => {
       expect(result.code).not.toContain('"this.foo"');
     });
 
+    // The mustache form `@arg={{mut this.x}}` is the common two-way-binding
+    // shape; it parses as a MustacheStatement (not a SubExpression), so it must
+    // get the same compile-time write-path arg the subexpression form gets —
+    // otherwise the Ember bridge has to recover it by stringifying the getter at
+    // runtime (fragile for nested/guarded getter shapes).
+    test('mustache {{mut this.foo}} adds path string as second arg', () => {
+      const result = compile('<Btn @v={{mut this.foo}} />', {
+        flags: compatFlags,
+        bindings: new Set(['Btn']),
+      });
+      expect(result.code).toContain('"this.foo"');
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('mustache {{mut this.a.b}} emits the FULL dotted path (not just the head)', () => {
+      const result = compile('<Btn @v={{mut this.a.b}} />', {
+        flags: compatFlags,
+        bindings: new Set(['Btn']),
+      });
+      expect(result.code).toContain('"this.a.b"');
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('mustache {{mut @bar}} / {{mut @bar.baz}} add the @-path string', () => {
+      const bare = compile('<Btn @v={{mut @bar}} />', {
+        flags: compatFlags,
+        bindings: new Set(['Btn']),
+      });
+      expect(bare.code).toContain('"@bar"');
+      const nested = compile('<Btn @v={{mut @bar.baz}} />', {
+        flags: compatFlags,
+        bindings: new Set(['Btn']),
+      });
+      expect(nested.code).toContain('"@bar.baz"');
+    });
+
+    test('mustache {{mut this.foo}} does NOT add path string in non-compat mode', () => {
+      const result = compile('<Btn @v={{mut this.foo}} />', {
+        flags: defaultFlags,
+        bindings: new Set(['Btn']),
+      });
+      expect(result.code).not.toContain('"this.foo"');
+    });
+
+    test('mustache {{mut (get obj key)}} still lowers to __mutGet (not the path branch)', () => {
+      const result = compile('<Btn @v={{mut (get this.obj this.key)}} />', {
+        flags: compatFlags,
+        bindings: new Set(['Btn']),
+      });
+      expect(result.code).toContain('__mutGet');
+      expect(result.code).not.toContain('"this.obj"');
+    });
+
     test('(has-block) compiles to $_hasBlock.bind(this, $slots) in compat mode', () => {
       const result = compile('{{#if (has-block)}}has block{{/if}}', { flags: compatFlags });
       expect(result.code).toContain('$_hasBlock.bind(this, $slots)');

--- a/plugins/compiler/visitors/mustache.ts
+++ b/plugins/compiler/visitors/mustache.ts
@@ -82,6 +82,45 @@ export function visitMustache(
     }
   }
 
+  // In compat mode, transform mustache-form (mut this.prop) / (mut @arg) to pass
+  // the property path as a second string argument so the mut helper can build a
+  // proper setter — the exact mirror of the SubExpression handler in
+  // visitors/index.ts. The common two-way-binding form is in argument position
+  // (`@value={{mut this.a.b}}`), which parses as a MustacheStatement and so is
+  // handled here, NOT by the SubExpression visitor. Without this branch the
+  // mustache form emitted only `[getter]` (no path), forcing the Ember bridge to
+  // recover the write-path by stringifying the getter at runtime — fragile for
+  // nested/guarded getter shapes. The path is taken verbatim from the AST
+  // (getPathExpressionString = full dotted path), so it is correct by
+  // construction regardless of the compiled getter's shape.
+  if (ctx.flags.IS_GLIMMER_COMPAT_MODE && pathName === 'mut' && node.params.length === 1) {
+    const firstParam = node.params[0];
+    if (firstParam && firstParam.type === 'PathExpression') {
+      const paramPath = getPathExpressionString(firstParam);
+      if (paramPath.startsWith('this.') || paramPath.startsWith('@')) {
+        const paramResult = getVisit(ctx)(ctx, firstParam, false);
+        const firstArg =
+          paramResult && isSerializedValue(paramResult) ? paramResult : literal(null);
+        const mutPositional: SerializedValue[] = [firstArg, literal(paramPath)];
+        const mutNamed = new Map<string, SerializedValue>();
+        for (const pair of node.hash.pairs) {
+          const value = getVisit(ctx)(ctx, pair.value, false);
+          if (value !== null && isSerializedValue(value)) {
+            mutNamed.set(pair.key, value);
+          } else if (typeof value === 'string') {
+            mutNamed.set(pair.key, literal(value));
+          }
+        }
+        const pathRange = getNodeRange(node.path);
+        const mutResult = helper('mut', mutPositional, mutNamed, range, pathRange);
+        if (wrap) {
+          return getter(mutResult, range);
+        }
+        return mutResult;
+      }
+    }
+  }
+
   // In compat mode, transform bare {{this}} to {{this.__gxtSelfString__}}
   // Ember's {{this}} calls toString() on the component instance.
   if (ctx.flags.IS_GLIMMER_COMPAT_MODE && node.path.type === 'PathExpression') {


### PR DESCRIPTION
## What

The SubExpression visitor already lowers `(mut this.a.b)` / `(mut @x)` to `mut(getter, "this.a.b")` — passing the **full dotted write-path, taken verbatim from the AST** (`getPathExpressionString`) as a second arg, so the `mut` helper can build a proper setter.

The **MustacheStatement** visitor did not. It only had the `{{mut (get obj key)}}` → `__mutGet` case, so the common two-way-binding shape in argument position — `@value={{mut this.a.b}}`, which parses as a `MustacheStatement`, not a `SubExpression` — emitted just `[getter]` with **no path**.

Consumers then had to recover the write-path by **stringifying the getter at runtime** and scanning for the first `this.` — fragile for nested / guarded getter shapes (optional chaining, multi-`this` getters), and a string-heuristic where the AST already holds the exact answer.

## Proven gap

```
<Btn @v={{mut this.a.b}} />
  before:  $_maybeHelper("mut", [() => this.a?.b], this)            // no path
  after:   $_maybeHelper("mut", [() => this.a?.b, "this.a.b"], this) // matches (mut this.a.b)
```

## How

Mirror the SubExpression mut branch into the MustacheStatement visitor (`visitors/mustache.ts`): for `{{mut <path>}}` with a single `this.`/`@`-headed `PathExpression` param, emit `[getter, literal(getPathExpressionString(param))]` plus any hash pairs — correct by construction regardless of the compiled getter's shape. `{{mut (get obj key)}}` still lowers to `__mutGet`; non-compat mode unaffected.

## Results

- 5 new regression tests (mustache `this.`/`@`/nested/non-compat/`(get)`-still-`__mutGet`); the 4 existing subexpression tests still green.
- Full suite **3941**, `tsc` clean.
- Runtime `.` closure **byte-identical** (compiler-only change); compiler chunk **+2 br gz**.

One of three false-negative bugs from a bridge audit (siblings: #235 recycle, #236 node-thunk, #237 preamble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)